### PR TITLE
fix: migrate to rubato 1.0 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "birda"
 version = "0.9.1"
 dependencies = [
+ "audioadapter-buffers",
  "birdnet-onnx",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cuda = ["birdnet-onnx/cuda"]
 birdnet-onnx = "1.0.2"
 symphonia = { version = "0.5", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "1.0"
+audioadapter-buffers = "2.0"
 clap = { version = "4", features = ["derive", "env"] }
 toml = "0.9"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Migrate from deprecated `FftFixedInOut` to `Fft` with `FixedSync` enum
- Add `audioadapter-buffers` dependency for new buffer adapter API
- Use `SequentialSlice` adapter for wrapping input audio data
- Use `take_data()` to extract samples from `InterleavedOwned` output

Fixes build failure caused by dependabot rubato 1.0 update.

## Test plan
- [x] All 42 tests pass locally
- [x] cargo clippy passes with no warnings
- [x] cargo fmt --check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned audio resampling pipeline with enhanced data handling and processing efficiency.

* **Chores**
  * Added audioadapter-buffers v2.0 dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->