### PR TITLE
feat: add RF64/WAV64 support for large audio files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,8 +1678,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "symphonia"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -1698,8 +1697,7 @@ dependencies = [
 [[package]]
 name = "symphonia-bundle-flac"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1710,8 +1708,7 @@ dependencies = [
 [[package]]
 name = "symphonia-bundle-mp3"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "lazy_static",
  "log",
@@ -1722,8 +1719,7 @@ dependencies = [
 [[package]]
 name = "symphonia-codec-aac"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "lazy_static",
  "log",
@@ -1733,8 +1729,7 @@ dependencies = [
 [[package]]
 name = "symphonia-codec-adpcm"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1743,8 +1738,7 @@ dependencies = [
 [[package]]
 name = "symphonia-codec-pcm"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1753,8 +1747,7 @@ dependencies = [
 [[package]]
 name = "symphonia-codec-vorbis"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1764,8 +1757,7 @@ dependencies = [
 [[package]]
 name = "symphonia-core"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "arrayvec",
  "bitflags 1.3.2",
@@ -1777,8 +1769,7 @@ dependencies = [
 [[package]]
 name = "symphonia-format-mkv"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "lazy_static",
  "log",
@@ -1790,8 +1781,7 @@ dependencies = [
 [[package]]
 name = "symphonia-format-ogg"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1802,8 +1792,7 @@ dependencies = [
 [[package]]
 name = "symphonia-format-riff"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "extended",
  "log",
@@ -1814,8 +1803,7 @@ dependencies = [
 [[package]]
 name = "symphonia-metadata"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "encoding_rs",
  "lazy_static",
@@ -1826,8 +1814,7 @@ dependencies = [
 [[package]]
 name = "symphonia-utils-xiph"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+source = "git+https://github.com/tphakala/Symphonia?branch=feature%2Frf64-support#bc8731928e13ce117f7d973ec8c367c92e19a8f5"
 dependencies = [
  "symphonia-core",
  "symphonia-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cuda = ["birdnet-onnx/cuda"]
 
 [dependencies]
 birdnet-onnx = "2.0.0-rc.1"
-symphonia = { version = "0.5", features = ["aac", "mp3", "flac", "wav", "pcm"] }
+symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "1.0"
 audioadapter-buffers = "2.0"
 clap = { version = "4", features = ["derive", "env"] }


### PR DESCRIPTION
## Summary
- Switch Symphonia dependency from crates.io to custom fork with RF64 support
- Enables processing of WAV files larger than 4GB (RF64/MBWF format)
- Common for long field recordings from wildlife audio recorders like AudioMoth

## Details
Standard WAV format has a 4GB file size limit due to 32-bit size fields. RF64 (also known as MBWF/BW64) extends WAV with 64-bit size fields for larger files.

Fork: https://github.com/tphakala/Symphonia

## Test plan
- [ ] Test with standard WAV files (regression)
- [ ] Test with RF64 files >4GB
- [ ] Verify FLAC, MP3, AAC formats still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the audio processing library dependency to an alternate source while preserving supported formats: AAC, MP3, FLAC, WAV, PCM.
  * No changes to exported or public APIs were introduced; existing integrations should remain compatible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->