### PR TITLE
feat: reimplement CLI output enhancements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ fn analyze_files(inputs: &[PathBuf], args: &AnalyzeArgs, config: &Config) -> Res
                 processed += 1;
                 total_detections += result.detections;
                 total_segments += result.segments;
-                total_audio_duration += f64::from(result.audio_duration_secs);
+                total_audio_duration += result.audio_duration_secs;
             }
             Err(e) => {
                 error!("Failed to process {}: {}", file.display(), e);
@@ -273,13 +273,11 @@ fn analyze_files(inputs: &[PathBuf], args: &AnalyzeArgs, config: &Config) -> Res
         } else {
             0.0
         };
-        #[allow(clippy::cast_possible_truncation)]
-        let total_audio_duration_f32 = total_audio_duration as f32;
         info!(
             "Performance: {:.1} segments/sec overall, {:.1}x realtime ({} total audio)",
             avg_segments_per_sec,
             overall_realtime_factor,
-            progress::format_duration(total_audio_duration_f32)
+            progress::format_duration(total_audio_duration)
         );
     }
 

--- a/src/output/progress.rs
+++ b/src/output/progress.rs
@@ -60,14 +60,14 @@ pub fn inc_progress(pb: Option<&ProgressBar>) {
 }
 
 /// Format seconds as HH:MM:SS.
-pub fn format_duration(secs: f32) -> String {
-    const SECONDS_PER_HOUR: u32 = 3600;
-    const SECONDS_PER_MINUTE: u32 = 60;
+pub fn format_duration(secs: f64) -> String {
+    const SECONDS_PER_HOUR: u64 = 3600;
+    const SECONDS_PER_MINUTE: u64 = 60;
 
     debug_assert!(secs >= 0.0, "Audio duration should not be negative: {secs}");
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let total_secs = secs.abs() as u32;
+    let total_secs = secs.abs() as u64;
     let hours = total_secs / SECONDS_PER_HOUR;
     let mins = (total_secs % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
     let secs_remainder = total_secs % SECONDS_PER_MINUTE;
@@ -111,11 +111,14 @@ mod tests {
     fn test_format_duration() {
         assert_eq!(format_duration(0.0), "00:00:00");
         assert_eq!(format_duration(59.0), "00:00:59");
+        assert_eq!(format_duration(59.9), "00:00:59"); // Documents truncation behavior
         assert_eq!(format_duration(60.0), "00:01:00");
         assert_eq!(format_duration(3661.0), "01:01:01");
         assert_eq!(format_duration(44589.0), "12:23:09");
         assert_eq!(format_duration(86399.0), "23:59:59");
         assert_eq!(format_duration(86400.0), "24:00:00");
+        // Note: Negative values trigger debug_assert in debug builds, but are
+        // handled via .abs() in release builds as a safety fallback.
     }
 
     #[test]

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -52,7 +52,7 @@ pub fn process_file(
     // Decode audio
     info!("Decoding audio...");
     let decoded = decode_audio_file(input_path)?;
-    let audio_duration_secs = decoded.duration_secs;
+    let audio_duration_secs = f64::from(decoded.duration_secs);
     info!(
         "Decoded {} of audio ({:.1}s)",
         progress::format_duration(audio_duration_secs),
@@ -142,7 +142,7 @@ pub fn process_file(
         0.0
     };
     let realtime_factor = if duration_secs > 0.0 {
-        f64::from(audio_duration_secs) / duration_secs
+        audio_duration_secs / duration_secs
     } else {
         0.0
     };
@@ -262,5 +262,5 @@ pub struct ProcessResult {
     /// Processing duration in seconds.
     pub duration_secs: f64,
     /// Audio duration in seconds.
-    pub audio_duration_secs: f32,
+    pub audio_duration_secs: f64,
 }


### PR DESCRIPTION
## Summary

Restores CLI output features that were accidentally lost when PR #35's `MultiProgress` changes were reverted. This implementation does NOT touch the progress bar code - it only adds the informational output enhancements.

## What Was Lost in PR #35

The revert commit `a9c0456` removed the `MultiProgress` approach that didn't work, but also accidentally removed CLI enhancements that weren't related to the progress bar issue:
- "Decoding audio..." log message
- "Decoded HH:MM:SS of audio" log message  
- Realtime factor in processing stats
- Total audio duration in summary

## Changes

### 1. Audio Decoding Feedback
- Changed "Decoding audio..." from DEBUG to INFO level
- Added "Decoded HH:MM:SS of audio (Xs)" INFO log after decode completes
- Provides immediate feedback during long decode operations

### 2. Realtime Performance Metrics
- Shows realtime factor per file (e.g., `122.5x realtime` = processing 122.5s of audio per 1s of real time)
- Shows overall realtime factor in final summary
- Displays total audio duration in final summary (e.g., `(12:23:09 total audio)`)

### 3. Code Changes
- Added `format_duration()` helper function with comprehensive unit tests
- Added `audio_duration_secs` field to `ProcessResult` struct
- Used named constants for time calculations (SECONDS_PER_HOUR, SECONDS_PER_MINUTE)
- Used f64 for total_audio_duration accumulation to prevent precision loss

## Example Output

**Before (current):**
```
2026-01-05T07:57:05.785527Z  INFO birda::pipeline::processor: Processing: D:\src\20250220_030341.wav
  [00:00:04] ████████████████████████████████████████ 14913/14913 segments - 20250220_030341.wav
2026-01-05T07:57:17.468420Z  INFO birda::pipeline::processor: Found 4542 detections above 10.0% confidence
2026-01-05T07:57:17.471490Z  INFO birda::pipeline::processor: Processed 14913 segments in 11.69s (1276.1 segments/sec)
[00:00:12] ████████████████████████████████████████ 1/1 files (0s)
2026-01-05T07:57:18.173219Z  INFO birda: Complete: 1 processed, 0 skipped, 0 errors, 4542 total detections in 13.02s
2026-01-05T07:57:18.173290Z  INFO birda: Performance: 1145.6 segments/sec overall
```

**After (this PR):**
```
2026-01-05T07:57:05.785527Z  INFO birda::pipeline::processor: Processing: D:\src\20250220_030341.wav
2026-01-05T07:57:05.785600Z  INFO birda::pipeline::processor: Decoding audio...
2026-01-05T07:57:06.123456Z  INFO birda::pipeline::processor: Decoded 12:23:09 of audio (44589.0s)
  [00:00:04] ████████████████████████████████████████ 14913/14913 segments - 20250220_030341.wav
2026-01-05T07:57:17.468420Z  INFO birda::pipeline::processor: Found 4542 detections above 10.0% confidence
2026-01-05T07:57:17.471490Z  INFO birda::pipeline::processor: Processed 14913 segments in 11.69s (1276.1 segments/sec, 122.5x realtime)
[00:00:12] ████████████████████████████████████████ 1/1 files (0s)
2026-01-05T07:57:18.173219Z  INFO birda: Complete: 1 processed, 0 skipped, 0 errors, 4542 total detections in 13.02s
2026-01-05T07:57:18.173290Z  INFO birda: Performance: 1145.6 segments/sec overall, 115.4x realtime (12:23:09 total audio)
```

## Testing

- ✅ All 104 tests passing (including new `test_format_duration`)
- ✅ Zero clippy warnings
- ✅ Code formatted with rustfmt
- ✅ Pre-commit hooks passing

## Files Changed

- `src/lib.rs` - Track and display total audio duration with realtime factor
- `src/output/progress.rs` - Add `format_duration()` helper with tests
- `src/pipeline/processor.rs` - Add decode logs and per-file realtime factor

## Breaking Changes

None - all changes are additive to output formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio processing now tracks and reports total audio duration and exposes per-run audio duration in results
  * Performance summaries include a realtime factor (ratio of audio duration to processing time)
  * Progress updates and completion messages display durations in human-readable HH:MM:SS format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->