### PR TITLE
feat: update birdnet-onnx to 2.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,13 +176,14 @@ dependencies = [
 
 [[package]]
 name = "birdnet-onnx"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8531987d098b58160514a23ea448b6716875a8cf140c8131fbe14cc2828de9f3"
+checksum = "6f99f1e45ab5e4fb3318dbd938f2f6538811b61a9ea5fd5204462d6542626d62"
 dependencies = [
  "chrono",
  "clap",
  "csv",
+ "ctrlc",
  "hound",
  "ndarray",
  "ort",
@@ -408,7 +409,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1037,7 +1038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,7 +1292,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["cuda"]
 cuda = ["birdnet-onnx/cuda"]
 
 [dependencies]
-birdnet-onnx = "2.0.0-rc.1"
+birdnet-onnx = "2.0.0-rc.4"
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "1.0"
 audioadapter-buffers = "2.0"

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -3,6 +3,7 @@
 mod classifier;
 pub mod range_filter;
 
+pub use birdnet_onnx::InferenceOptions;
 pub use classifier::BirdClassifier;
 
 use std::path::PathBuf;

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -3,7 +3,7 @@
 use crate::audio::AudioChunk;
 use crate::config::OutputFormat;
 use crate::error::Result;
-use crate::inference::BirdClassifier;
+use crate::inference::{BirdClassifier, InferenceOptions};
 use crate::locking::FileLock;
 use crate::output::{
     AudacityWriter, CsvWriter, Detection, KaleidoscopeWriter, OutputWriter, RavenWriter,
@@ -209,10 +209,11 @@ fn process_batch(
         batch_size,
     );
 
+    let options = InferenceOptions::default();
     let results = if batch_size == 1 {
-        vec![classifier.predict(segments[0])?]
+        vec![classifier.predict(segments[0], &options)?]
     } else {
-        classifier.predict_batch(&segments)?
+        classifier.predict_batch(&segments, &options)?
     };
 
     // Watchdog is automatically cancelled when _watchdog drops here


### PR DESCRIPTION
## Summary

- Update birdnet-onnx dependency from 2.0.0-rc.1 to 2.0.0-rc.4
- Use `with_cuda()` for safe CUDA memory defaults (SameAsRequested arena strategy prevents memory growth issues)
- Add `InferenceOptions` parameter to `predict`/`predict_batch` methods (API change from rc.2)
- Re-export `InferenceOptions` from inference module

## New APIs available in rc.4

- `CUDAConfig` / `with_cuda_config()` - Fine-grained CUDA memory control
- `BatchInferenceContext` - Memory-efficient GPU batch processing  
- `ArenaExtendStrategy` - Control memory growth strategy

## Test plan

- [x] All 108 unit tests pass
- [x] Clippy passes with zero warnings
- [ ] Manual test with CUDA inference