### PR TITLE
feat: add TensorRT warmup to prevent watchdog timeout during engine build

### DIFF
--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -258,7 +258,7 @@ impl BirdClassifier {
                 })?;
         } else {
             // Batch inference warmup - TensorRT needs to build engine for this batch size
-            let segments: Vec<&[f32]> = (0..batch_size).map(|_| dummy_segment.as_slice()).collect();
+            let segments = vec![dummy_segment.as_slice(); batch_size];
             self.inner
                 .predict_batch(&segments, &options)
                 .map_err(|e| Error::Inference {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,10 @@ fn analyze_files(inputs: &[PathBuf], args: &AnalyzeArgs, config: &Config) -> Res
         use indicatif::{ProgressBar, ProgressStyle};
         use std::time::{Duration, Instant};
 
+        /// Threshold in seconds to distinguish engine build from cache load.
+        /// Warmup taking >= this long indicates `TensorRT` compiled a new engine.
+        const WARMUP_BUILD_THRESHOLD_SECS: u64 = 2;
+
         // Create a spinner to show activity during warmup
         let spinner = ProgressBar::new_spinner();
         spinner.set_style(
@@ -222,7 +226,7 @@ fn analyze_files(inputs: &[PathBuf], args: &AnalyzeArgs, config: &Config) -> Res
         // Propagate any warmup error
         result?;
 
-        if warmup_duration.as_secs() >= 2 {
+        if warmup_duration.as_secs() >= WARMUP_BUILD_THRESHOLD_SECS {
             // Engine was built - this was a slow initialization
             info!(
                 "TensorRT: Engine built in {:.1}s (cached for future runs)",


### PR DESCRIPTION
## Summary

- Add warmup inference before processing to trigger TensorRT engine compilation
- TensorRT compiles optimized GPU engines on first run, which can take several minutes
- Previously the inference watchdog would kill the process during this initialization

## Changes

- Add `warmup(batch_size)` method to `BirdClassifier` that runs inference before the main loop
- Use actual batch size for warmup (TensorRT builds separate engines per batch size)
- Show spinner with informative message during warmup
- Display appropriate message based on warmup duration:
  - Fast (<2s): "Engine loaded from cache (XXms)"
  - Slow (≥2s): "Engine built in X.Xs (cached for future runs)"

## Test plan

- [x] Verify warmup triggers engine build on first run with new batch size
- [x] Verify cached engine loads quickly on subsequent runs
- [x] Verify watchdog no longer kills process during engine build
- [x] Verify spinner displays correctly during warmup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automatic GPU acceleration warm-up that prepares and optimizes resources before processing begins.
  * Shows a spinner progress UI during warm-up with timing info.
  * Distinguishes and logs whether the acceleration engine was newly built or loaded from cache.
* **Bug Fixes**
  * Ensures acceleration initialization completes before file processing and progress updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->