### PR TITLE
fix: pad partial batches for TensorRT batch size alignment

### DIFF
--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -228,9 +228,10 @@ fn process_batch(
             target_batch_size,
             padding_needed
         );
-        for _ in 0..padding_needed {
-            segments.push(padding_buffer.as_slice());
-        }
+        segments.extend(std::iter::repeat_n(
+            padding_buffer.as_slice(),
+            padding_needed,
+        ));
     }
 
     let batch_size = segments.len();


### PR DESCRIPTION
## Summary

Fixes #63 - TensorRT inference stalls on final partial batch when batch size doesn't align with total segments.

**Root Cause:** TensorRT compiles optimized engines for specific batch sizes. Warmup with `batch_size=N` means only N-segment batches use the cached engine. Partial batches trigger on-the-fly engine compilation which times out.

**Solution:** Pad partial batches with silence (zeros) at the segment reference level to match the target batch size, then discard results from padded segments.

## Changes

- Move padding logic inside `process_batch` for better encapsulation
- Pad `segments: Vec<&[f32]>` with references to a single zero buffer (avoids deep cloning `AudioChunk` structs - 50MB+ memory savings)
- Add debug logging when padding occurs
- Rename `valid_count` param to `target_batch_size` for clarity

## Memory Optimization

**Before (initial fix):** Padding cloned entire `AudioChunk` structs including their `Vec<f32>` samples
- For batch_size=200, valid_count=113: 87 clones × 576KB = ~50MB temporary allocations

**After (optimized):** Single zero buffer allocation, multiple references
- For batch_size=200, valid_count=113: 1 allocation × 576KB = ~576KB

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo test` passes (138 tests)
- [ ] Manual test with TensorRT on file producing partial batch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch processing alignment to ensure only valid data contributes to detections and results, preventing padding artifacts from affecting output accuracy.

* **Chores**
  * Enhanced internal batch processing logic with better padding handling and diagnostic logging for improved traceability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->