### PR TITLE
feat: add XNNPACK execution provider support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "birdnet-onnx"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d8b7ad2ad7ec96c7c837354c2a7723cbcdfed919408117709e12a41a8c2cc1"
+checksum = "342f425d71bf3b0d14592b728ee026e83ed71019a9b5af197314b679d1fcd2ae"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cuda = ["birdnet-onnx/cuda"]
 load-dynamic = ["birdnet-onnx/load-dynamic"]
 
 [dependencies]
-birdnet-onnx = { version = "2.0.0-rc.5", features = ["load-dynamic"] }
+birdnet-onnx = { version = "2.0.0-rc.6", features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "1.0"
 audioadapter-buffers = "2.0"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -286,6 +286,10 @@ pub struct AnalyzeArgs {
     #[arg(long, group = "provider")]
     pub armnn: bool,
 
+    /// Use `XNNPACK` provider explicitly (optimized CPU for ARM/x86).
+    #[arg(long, group = "provider")]
+    pub xnnpack: bool,
+
     /// Latitude for range filtering (-90.0 to 90.0).
     #[arg(long, value_parser = parse_latitude, env = "BIRDA_LATITUDE")]
     pub lat: Option<f64>,

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -109,6 +109,7 @@ mod tests {
             qnn: false,
             acl: false,
             armnn: false,
+            xnnpack: false,
             lat: None,
             lon: None,
             week: None,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -158,6 +158,10 @@ pub enum InferenceDevice {
     /// Explicit `ArmNN` provider (fail if unavailable).
     #[serde(rename = "armnn")]
     ArmNn,
+    /// Explicit `XNNPACK` provider (fail if unavailable).
+    /// Optimized CPU inference for ARM/x86 platforms.
+    #[serde(rename = "xnnpack")]
+    Xnnpack,
 }
 
 /// Inference settings.

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -162,6 +162,12 @@ impl BirdClassifier {
                 ExecutionProviderInfo::ArmNn,
                 "ArmNN",
             )?,
+            InferenceDevice::Xnnpack => configure_explicit_provider(
+                builder,
+                &available_providers,
+                ExecutionProviderInfo::Xnnpack,
+                "XNNPACK",
+            )?,
         };
 
         let inner = builder.build().map_err(|e| Error::ClassifierBuild {
@@ -549,7 +555,13 @@ fn add_execution_provider(
         ExecutionProviderInfo::ArmNn => {
             builder.execution_provider(ArmNNExecutionProvider::default())
         }
+        ExecutionProviderInfo::Xnnpack => builder.with_xnnpack(),
         ExecutionProviderInfo::Cpu => builder, // CPU doesn't need explicit provider
+        _ => {
+            // Future-proof: unknown providers fall back to CPU
+            warn!("Unknown execution provider, using CPU fallback");
+            builder
+        }
     }
 }
 
@@ -573,6 +585,8 @@ fn provider_unavailable_error(provider_name: &str, available: &[ExecutionProvide
             ExecutionProviderInfo::Qnn => "QNN",
             ExecutionProviderInfo::Acl => "ACL",
             ExecutionProviderInfo::ArmNn => "ArmNN",
+            ExecutionProviderInfo::Xnnpack => "XNNPACK",
+            _ => "Unknown",
         };
         let _ = writeln!(message, "  ✓ {name}");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ fn resolve_model_config(args: &AnalyzeArgs, config: &Config) -> Result<(ModelCon
         // Warn if --model-type is also provided (will be ignored)
         if args.model_type.is_some() {
             warn!(
-                "--model-type is ignored when using default model '{}' (use --model-path to trigger ad-hoc mode)",
+                "--model-type is ignored when using default model '{}' (provide both --model-path and --model-type to use ad-hoc mode)",
                 name
             );
         }
@@ -245,6 +245,7 @@ fn analyze_files(
         (args.qnn, InferenceDevice::Qnn),
         (args.acl, InferenceDevice::Acl),
         (args.armnn, InferenceDevice::ArmNn),
+        (args.xnnpack, InferenceDevice::Xnnpack),
     ]
     .into_iter()
     .find(|(flag, _)| *flag)
@@ -632,6 +633,10 @@ fn handle_providers_command(output_mode: OutputMode) {
                 birdnet_onnx::ExecutionProviderInfo::ArmNn => {
                     ("armnn", "ArmNN", "ArmNN (Arm Neural Network)")
                 }
+                birdnet_onnx::ExecutionProviderInfo::Xnnpack => {
+                    ("xnnpack", "XNNPACK", "XNNPACK (optimized CPU for ARM/x86)")
+                }
+                _ => ("unknown", "Unknown", "Unknown provider"),
             };
             ProviderInfo {
                 id: id.to_string(),
@@ -677,6 +682,7 @@ fn handle_providers_command(output_mode: OutputMode) {
         ("qnn", "Use QNN"),
         ("acl", "Use ACL"),
         ("armnn", "Use ArmNN"),
+        ("xnnpack", "Use XNNPACK"),
     ];
     for (flag, description) in explicit_providers {
         println!("  --{flag:<13} {description}");
@@ -1070,6 +1076,7 @@ mod tests {
             qnn: false,
             acl: false,
             armnn: false,
+            xnnpack: false,
             lat: None,
             lon: None,
             week: None,


### PR DESCRIPTION
## Summary

- Add XNNPACK as an optimized CPU inference option for ARM and x86 platforms
- Update birdnet-onnx to 2.0.0-rc.6 (includes XNNPACK support)
- Fix misleading warning message in ad-hoc model mode

## Changes

- Add `--xnnpack` CLI flag for explicit provider selection
- Add `Xnnpack` variant to `InferenceDevice` enum
- Wire XNNPACK through classifier and provider handling
- Clarify warning message: "provide both --model-path and --model-type to use ad-hoc mode"

## Usage

```bash
# Use XNNPACK for optimized CPU inference
birda --xnnpack recording.wav

# View available providers
birda providers
```

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (156 tests)
- [ ] Manual test with `--xnnpack` flag on ARM/x86 hardware