### PR TITLE
refactor: improve code quality with proper error types and DRY utilities

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -332,57 +332,13 @@ pub struct AnalyzeArgs {
     pub stale_lock_timeout: Option<String>,
 }
 
-/// Parse and validate latitude value.
-fn parse_latitude(s: &str) -> Result<f64, String> {
-    let value: f64 = s
-        .parse()
-        .map_err(|_| format!("'{s}' is not a valid number"))?;
-
-    if !(-90.0..=90.0).contains(&value) {
-        return Err(format!(
-            "latitude must be between -90.0 and 90.0, got {value}"
-        ));
-    }
-
-    Ok(value)
-}
-
-/// Parse and validate longitude value.
-fn parse_longitude(s: &str) -> Result<f64, String> {
-    let value: f64 = s
-        .parse()
-        .map_err(|_| format!("'{s}' is not a valid number"))?;
-
-    if !(-180.0..=180.0).contains(&value) {
-        return Err(format!(
-            "longitude must be between -180.0 and 180.0, got {value}"
-        ));
-    }
-
-    Ok(value)
-}
-
-// Re-use shared confidence validator
-use super::validators::parse_confidence;
+// Re-use shared validators
+use super::validators::{parse_confidence, parse_latitude, parse_longitude};
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_confidence_valid() {
-        assert_eq!(parse_confidence("0.5").ok(), Some(0.5));
-        assert_eq!(parse_confidence("0.0").ok(), Some(0.0));
-        assert_eq!(parse_confidence("1.0").ok(), Some(1.0));
-    }
-
-    #[test]
-    fn test_parse_confidence_invalid() {
-        assert!(parse_confidence("1.5").is_err());
-        assert!(parse_confidence("-0.1").is_err());
-        assert!(parse_confidence("abc").is_err());
-    }
 
     #[test]
     fn test_cli_parse_simple() {

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -17,6 +17,38 @@ pub fn parse_confidence(s: &str) -> Result<f32, String> {
     Ok(value)
 }
 
+/// Parse and validate a bounded float value.
+///
+/// # Arguments
+///
+/// * `s` - The string to parse
+/// * `min` - Minimum allowed value (inclusive)
+/// * `max` - Maximum allowed value (inclusive)
+/// * `name` - Name of the parameter for error messages
+pub fn parse_bounded_float(s: &str, min: f64, max: f64, name: &str) -> Result<f64, String> {
+    let value: f64 = s
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+
+    if !(min..=max).contains(&value) {
+        return Err(format!(
+            "{name} must be between {min} and {max}, got {value}"
+        ));
+    }
+
+    Ok(value)
+}
+
+/// Parse and validate latitude value (-90.0 to 90.0).
+pub fn parse_latitude(s: &str) -> Result<f64, String> {
+    parse_bounded_float(s, -90.0, 90.0, "latitude")
+}
+
+/// Parse and validate longitude value (-180.0 to 180.0).
+pub fn parse_longitude(s: &str) -> Result<f64, String> {
+    parse_bounded_float(s, -180.0, 180.0, "longitude")
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
@@ -34,5 +66,35 @@ mod tests {
         assert!(parse_confidence("1.1").is_err());
         assert!(parse_confidence("-0.1").is_err());
         assert!(parse_confidence("abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_bounded_float_valid() {
+        assert_eq!(
+            parse_bounded_float("50.0", -100.0, 100.0, "test").ok(),
+            Some(50.0)
+        );
+        assert_eq!(
+            parse_bounded_float("-100.0", -100.0, 100.0, "test").ok(),
+            Some(-100.0)
+        );
+        assert_eq!(
+            parse_bounded_float("100.0", -100.0, 100.0, "test").ok(),
+            Some(100.0)
+        );
+    }
+
+    #[test]
+    fn test_parse_bounded_float_invalid_range() {
+        let err = parse_bounded_float("101.0", -100.0, 100.0, "test");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("test must be between"));
+    }
+
+    #[test]
+    fn test_parse_bounded_float_invalid_number() {
+        let err = parse_bounded_float("abc", -100.0, 100.0, "test");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("not a valid number"));
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -252,7 +252,7 @@ impl std::fmt::Display for OutputFormat {
 }
 
 impl std::str::FromStr for OutputFormat {
-    type Err = String;
+    type Err = crate::error::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
@@ -261,7 +261,9 @@ impl std::str::FromStr for OutputFormat {
             "audacity" => Ok(Self::Audacity),
             "kaleidoscope" => Ok(Self::Kaleidoscope),
             "json" => Ok(Self::Json),
-            other => Err(format!("unknown output format: {other}")),
+            other => Err(crate::error::Error::InvalidOutputFormat {
+                value: other.to_string(),
+            }),
         }
     }
 }
@@ -292,14 +294,16 @@ impl std::fmt::Display for ModelType {
 }
 
 impl std::str::FromStr for ModelType {
-    type Err = String;
+    type Err = crate::error::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "birdnet-v24" => Ok(Self::BirdnetV24),
             "birdnet-v30" => Ok(Self::BirdnetV30),
             "perch-v2" => Ok(Self::PerchV2),
-            other => Err(format!("unknown model type: {other}")),
+            other => Err(crate::error::Error::InvalidModelType {
+                value: other.to_string(),
+            }),
         }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -75,6 +75,9 @@ pub mod range_filter {
     /// Days per `BirdNET` week (365.25 / 48).
     pub const DAYS_PER_WEEK: f32 = 7.6;
 
+    /// First day of the year (January 1st) for week-to-day offset calculation.
+    pub const YEAR_START_DAY: f32 = 1.0;
+
     /// Default range filter threshold.
     pub const DEFAULT_THRESHOLD: f32 = 0.01;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -378,4 +378,24 @@ pub enum Error {
         #[source]
         source: serde_json::Error,
     },
+
+    /// Invalid output format string.
+    #[error("invalid output format: {value}")]
+    InvalidOutputFormat {
+        /// The invalid value.
+        value: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_output_format_error_display() {
+        let err = Error::InvalidOutputFormat {
+            value: "foobar".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid output format: foobar");
+    }
 }


### PR DESCRIPTION
## Summary

- Replace stringly-typed errors in `FromStr` implementations with proper `Error` variants
- Add `InvalidOutputFormat` error variant for `OutputFormat::FromStr`
- Use existing `InvalidModelType` error variant for `ModelType::FromStr`
- Extract week-to-day calculation to `utils/date.rs` with `YEAR_START_DAY` constant
- Add generic `parse_bounded_float` validator to eliminate duplicate coordinate parsers
- Consolidate `parse_latitude` and `parse_longitude` using the generic helper

## Issues Addressed

Closes #78 - Extract generic coordinate validation helper
Closes #79 - Extract week-to-day calculation to utils with named constant  
Closes #84 - Replace stringly-typed errors in FromStr implementations

## Test Plan

- [x] All existing tests pass (183 tests)
- [x] New unit tests added for `week_to_start_day` function
- [x] New unit tests added for `parse_bounded_float` validator
- [x] New unit test for `InvalidOutputFormat` error display
- [x] Clippy passes with `-D warnings`
- [x] Code formatted with `cargo fmt`

## Changes

| File | Change |
|------|--------|
| `src/error.rs` | Added `InvalidOutputFormat` error variant |
| `src/config/types.rs` | Updated `FromStr` impls to use proper error types |
| `src/constants.rs` | Added `YEAR_START_DAY` constant |
| `src/utils/date.rs` | Added `week_to_start_day` function |
| `src/config/range_filter.rs` | Use `week_to_start_day` instead of inline calc |
| `src/cli/species.rs` | Use `week_to_start_day` instead of inline calc |
| `src/cli/validators.rs` | Added `parse_bounded_float`, `parse_latitude`, `parse_longitude` |
| `src/cli/args.rs` | Removed duplicate coordinate parsers, use validators module |