### PR TITLE
refactor: improve provider handling and fail-fast behavior

### DIFF
--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -4,7 +4,7 @@ mod classifier;
 pub mod range_filter;
 
 pub use birdnet_onnx::{BatchInferenceContext, InferenceOptions};
-pub use classifier::BirdClassifier;
+pub use classifier::{BirdClassifier, provider_display_name};
 
 use std::path::PathBuf;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,14 +186,7 @@ fn analyze_files(
 
     let total_start = Instant::now();
 
-    // Collect all input files
-    let files = collect_input_files(inputs)?;
-    if files.is_empty() {
-        return Err(Error::NoValidAudioFiles);
-    }
-
-    info!("Found {} audio file(s) to process", files.len());
-
+    // Fail fast on configuration errors before scanning filesystem
     // Resolve model configuration using priority-based resolution
     let (model_config, model_name) = resolve_model_config(args, config)?;
 
@@ -213,6 +206,14 @@ fn analyze_files(
     {
         return Err(Error::MetaModelNotFound { path: meta.clone() });
     }
+
+    // Collect input files only after config is validated
+    let files = collect_input_files(inputs)?;
+    if files.is_empty() {
+        return Err(Error::NoValidAudioFiles);
+    }
+
+    info!("Found {} audio file(s) to process", files.len());
 
     // Resolve other settings
     let min_confidence = args


### PR DESCRIPTION
## Summary

This PR addresses several code quality issues in the classifier module and improves error handling in the analyze pipeline.

- Remove unreachable `Cpu` arm in `add_execution_provider()` and improve unknown provider warning
- Extract TensorRT cache setup into dedicated `setup_tensorrt_cache()` function
- Add `provider_display_name()` helper for consistent provider name strings
- Reorder `analyze_files()` to fail fast on config errors before scanning files

## Issues Addressed

- Closes #80 - Remove unreachable code in `add_execution_provider`
- Closes #82 - Move TensorRT cache directory setup out of builder configuration
- Closes #83 - Consolidate provider name strings into helper function
- Closes #85 - Resolve model config before scanning input files

## Changes

| File | Changes |
|------|---------|
| `src/inference/classifier.rs` | Add `provider_display_name()`, `setup_tensorrt_cache()`, remove unreachable `Cpu` arm |
| `src/inference/mod.rs` | Export `provider_display_name` |
| `src/lib.rs` | Reorder operations in `analyze_files()` for fail-fast behavior |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - all 158 unit tests + 21 integration tests pass
- [ ] Manual test: invalid model config fails immediately (not after file scan)
- [ ] Manual test: provider error messages display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Execution provider names are now standardized and exposed for consistent display.
  * TensorRT cache handling improved to be more reliable.
  * Configuration validation runs before processing input files, enabling faster error detection.
  * Unavailable providers now fall back to CPU automatically with clearer warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->