### PR TITLE
refactor: DRY improvements for provider metadata and test helpers

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -166,7 +166,12 @@ pub enum ModelsAction {
 }
 
 /// Arguments for the analyze command.
-#[derive(Debug, Args)]
+///
+/// # Default Implementation
+///
+/// All fields default to `None`/`false`/`0`, representing "no user input".
+/// This allows configuration file values to take precedence over defaults.
+#[derive(Debug, Clone, Args, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct AnalyzeArgs {
     /// Model name from configuration.

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -71,57 +71,12 @@ pub fn build_range_filter_config(
 mod tests {
     use super::*;
 
-    // Helper function to create minimal AnalyzeArgs for testing
-    fn create_analyze_args() -> crate::cli::AnalyzeArgs {
-        crate::cli::AnalyzeArgs {
-            model: None,
-            model_path: None,
-            labels_path: None,
-            model_type: None,
-            meta_model_path: None,
-            format: None,
-            output_dir: None,
-            min_confidence: None,
-            overlap: None,
-            batch_size: None,
-            combine: false,
-            force: false,
-            fail_fast: false,
-            quiet: false,
-            verbose: 0,
-            no_progress: false,
-            no_csv_bom: false,
-            gpu: false,
-            cpu: false,
-            cuda: false,
-            tensorrt: false,
-            directml: false,
-            coreml: false,
-            rocm: false,
-            openvino: false,
-            onednn: false,
-            qnn: false,
-            acl: false,
-            armnn: false,
-            xnnpack: false,
-            lat: None,
-            lon: None,
-            week: None,
-            month: None,
-            day: None,
-            range_threshold: None,
-            rerank: false,
-            slist: None,
-            stale_lock_timeout: None,
-        }
-    }
-
     #[test]
     fn test_build_range_filter_with_week() {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.lat = Some(60.1699);
         args.lon = Some(24.9384);
         args.week = Some(24);
@@ -152,7 +107,7 @@ mod tests {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.lat = Some(60.1699);
         args.lon = Some(24.9384);
         args.month = Some(6);
@@ -183,7 +138,7 @@ mod tests {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.week = Some(24);
 
         let mut config = Config::default();
@@ -211,7 +166,7 @@ mod tests {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.week = Some(24);
 
         let config = Config::default();
@@ -234,7 +189,7 @@ mod tests {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.lat = Some(60.1699);
         args.lon = Some(24.9384);
 
@@ -258,7 +213,7 @@ mod tests {
         use crate::config::types::{Config, ModelConfig, ModelType};
         use std::path::PathBuf;
 
-        let mut args = create_analyze_args();
+        let mut args = crate::cli::AnalyzeArgs::default();
         args.lat = Some(60.1699);
         args.lon = Some(24.9384);
         args.week = Some(24);

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -464,41 +464,6 @@ mod tests {
         assert!(filtered.iter().any(|p| p.species.contains("Cyanistes")));
         assert!(!filtered.iter().any(|p| p.species.contains("Turdus")));
     }
-
-    #[test]
-    fn test_provider_display_name_returns_expected_strings() {
-        // Test all known providers return expected display names
-        assert_eq!(provider_display_name(ExecutionProviderInfo::Cpu), "CPU");
-        assert_eq!(provider_display_name(ExecutionProviderInfo::Cuda), "CUDA");
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::TensorRt),
-            "TensorRT"
-        );
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::DirectMl),
-            "DirectML"
-        );
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::CoreMl),
-            "CoreML"
-        );
-        assert_eq!(provider_display_name(ExecutionProviderInfo::Rocm), "ROCm");
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::OpenVino),
-            "OpenVINO"
-        );
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::OneDnn),
-            "oneDNN"
-        );
-        assert_eq!(provider_display_name(ExecutionProviderInfo::Qnn), "QNN");
-        assert_eq!(provider_display_name(ExecutionProviderInfo::Acl), "ACL");
-        assert_eq!(provider_display_name(ExecutionProviderInfo::ArmNn), "ArmNN");
-        assert_eq!(
-            provider_display_name(ExecutionProviderInfo::Xnnpack),
-            "XNNPACK"
-        );
-    }
 }
 
 /// Configure an explicit execution provider (fail if unavailable).
@@ -517,27 +482,6 @@ fn configure_explicit_provider(
     info!("Requested device: {provider_name}");
     let builder = add_execution_provider(builder, provider_info);
     Ok((builder, provider_name))
-}
-
-/// Get human-readable display name for an execution provider.
-///
-/// Returns a consistent string representation used for logging and error messages.
-pub fn provider_display_name(provider: ExecutionProviderInfo) -> &'static str {
-    match provider {
-        ExecutionProviderInfo::Cpu => "CPU",
-        ExecutionProviderInfo::Cuda => "CUDA",
-        ExecutionProviderInfo::TensorRt => "TensorRT",
-        ExecutionProviderInfo::DirectMl => "DirectML",
-        ExecutionProviderInfo::CoreMl => "CoreML",
-        ExecutionProviderInfo::Rocm => "ROCm",
-        ExecutionProviderInfo::OpenVino => "OpenVINO",
-        ExecutionProviderInfo::OneDnn => "oneDNN",
-        ExecutionProviderInfo::Qnn => "QNN",
-        ExecutionProviderInfo::Acl => "ACL",
-        ExecutionProviderInfo::ArmNn => "ArmNN",
-        ExecutionProviderInfo::Xnnpack => "XNNPACK",
-        _ => "Unknown",
-    }
 }
 
 /// Setup `TensorRT` cache directory, returning the path if successful.
@@ -649,7 +593,7 @@ fn provider_unavailable_error(provider_name: &str, available: &[ExecutionProvide
     message.push_str("Available providers:\n");
 
     for provider in available {
-        let _ = writeln!(message, "  ✓ {}", provider_display_name(*provider));
+        let _ = writeln!(message, "  ✓ {}", super::provider_metadata(*provider).name);
     }
 
     message.push_str("\nTry one of:\n");

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -1,10 +1,12 @@
 //! Inference module for bird species detection.
 
 mod classifier;
+mod provider;
 pub mod range_filter;
 
 pub use birdnet_onnx::{BatchInferenceContext, InferenceOptions};
-pub use classifier::{BirdClassifier, provider_display_name};
+pub use classifier::BirdClassifier;
+pub use provider::{ProviderMetadata, provider_metadata};
 
 use std::path::PathBuf;
 

--- a/src/inference/provider.rs
+++ b/src/inference/provider.rs
@@ -1,0 +1,134 @@
+//! Execution provider metadata.
+
+use birdnet_onnx::ExecutionProviderInfo;
+
+/// Metadata for an execution provider.
+pub struct ProviderMetadata {
+    /// CLI flag identifier (e.g., "cuda", "tensorrt").
+    pub id: &'static str,
+    /// Display name (e.g., "CUDA", "`TensorRT`").
+    pub name: &'static str,
+    /// Full description for human output (e.g., "CUDA (NVIDIA GPU acceleration)").
+    pub description: &'static str,
+}
+
+/// Get metadata for an execution provider.
+#[must_use]
+pub fn provider_metadata(provider: ExecutionProviderInfo) -> ProviderMetadata {
+    match provider {
+        ExecutionProviderInfo::Cpu => ProviderMetadata {
+            id: "cpu",
+            name: "CPU",
+            description: "CPU (always available)",
+        },
+        ExecutionProviderInfo::Cuda => ProviderMetadata {
+            id: "cuda",
+            name: "CUDA",
+            description: "CUDA (NVIDIA GPU acceleration)",
+        },
+        ExecutionProviderInfo::TensorRt => ProviderMetadata {
+            id: "tensorrt",
+            name: "TensorRT",
+            description: "TensorRT (NVIDIA optimized inference)",
+        },
+        ExecutionProviderInfo::DirectMl => ProviderMetadata {
+            id: "directml",
+            name: "DirectML",
+            description: "DirectML (Windows GPU acceleration)",
+        },
+        ExecutionProviderInfo::CoreMl => ProviderMetadata {
+            id: "coreml",
+            name: "CoreML",
+            description: "CoreML (Apple GPU/Neural Engine)",
+        },
+        ExecutionProviderInfo::Rocm => ProviderMetadata {
+            id: "rocm",
+            name: "ROCm",
+            description: "ROCm (AMD GPU acceleration)",
+        },
+        ExecutionProviderInfo::OpenVino => ProviderMetadata {
+            id: "openvino",
+            name: "OpenVINO",
+            description: "OpenVINO (Intel optimization)",
+        },
+        ExecutionProviderInfo::OneDnn => ProviderMetadata {
+            id: "onednn",
+            name: "oneDNN",
+            description: "oneDNN (Intel CPU optimization)",
+        },
+        ExecutionProviderInfo::Qnn => ProviderMetadata {
+            id: "qnn",
+            name: "QNN",
+            description: "QNN (Qualcomm Neural Network)",
+        },
+        ExecutionProviderInfo::Acl => ProviderMetadata {
+            id: "acl",
+            name: "ACL",
+            description: "ACL (Arm Compute Library)",
+        },
+        ExecutionProviderInfo::ArmNn => ProviderMetadata {
+            id: "armnn",
+            name: "ArmNN",
+            description: "ArmNN (Arm Neural Network)",
+        },
+        ExecutionProviderInfo::Xnnpack => ProviderMetadata {
+            id: "xnnpack",
+            name: "XNNPACK",
+            description: "XNNPACK (optimized CPU for ARM/x86)",
+        },
+        _ => ProviderMetadata {
+            id: "unknown",
+            name: "Unknown",
+            description: "Unknown provider",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata_returns_expected_values() {
+        // Data-driven test: (provider, expected_id, expected_name, description_keyword)
+        let test_cases = [
+            (ExecutionProviderInfo::Cpu, "cpu", "CPU", "CPU"),
+            (ExecutionProviderInfo::Cuda, "cuda", "CUDA", "NVIDIA"),
+            (
+                ExecutionProviderInfo::TensorRt,
+                "tensorrt",
+                "TensorRT",
+                "NVIDIA",
+            ),
+            (
+                ExecutionProviderInfo::DirectMl,
+                "directml",
+                "DirectML",
+                "Windows",
+            ),
+            (ExecutionProviderInfo::CoreMl, "coreml", "CoreML", "Apple"),
+            (ExecutionProviderInfo::Rocm, "rocm", "ROCm", "AMD"),
+            (
+                ExecutionProviderInfo::OpenVino,
+                "openvino",
+                "OpenVINO",
+                "Intel",
+            ),
+            (ExecutionProviderInfo::OneDnn, "onednn", "oneDNN", "Intel"),
+            (ExecutionProviderInfo::Qnn, "qnn", "QNN", "Qualcomm"),
+            (ExecutionProviderInfo::Acl, "acl", "ACL", "Arm"),
+            (ExecutionProviderInfo::ArmNn, "armnn", "ArmNN", "Arm"),
+            (ExecutionProviderInfo::Xnnpack, "xnnpack", "XNNPACK", "CPU"),
+        ];
+
+        for (provider, expected_id, expected_name, desc_keyword) in test_cases {
+            let meta = provider_metadata(provider);
+            assert_eq!(meta.id, expected_id, "ID mismatch for {provider:?}");
+            assert_eq!(meta.name, expected_name, "Name mismatch for {provider:?}");
+            assert!(
+                meta.description.contains(desc_keyword),
+                "Description for {provider:?} should contain '{desc_keyword}'"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,7 @@ fn handle_command(
 }
 
 fn handle_providers_command(output_mode: OutputMode) {
+    use crate::inference::provider_metadata;
     use birdnet_onnx::available_execution_providers;
 
     let providers = available_execution_providers();
@@ -596,53 +597,11 @@ fn handle_providers_command(output_mode: OutputMode) {
     let provider_infos: Vec<ProviderInfo> = providers
         .iter()
         .map(|provider| {
-            let (id, name, description) = match provider {
-                birdnet_onnx::ExecutionProviderInfo::Cpu => {
-                    ("cpu", "CPU", "CPU (always available)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::Cuda => {
-                    ("cuda", "CUDA", "CUDA (NVIDIA GPU acceleration)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::TensorRt => (
-                    "tensorrt",
-                    "TensorRT",
-                    "TensorRT (NVIDIA optimized inference)",
-                ),
-                birdnet_onnx::ExecutionProviderInfo::DirectMl => (
-                    "directml",
-                    "DirectML",
-                    "DirectML (Windows GPU acceleration)",
-                ),
-                birdnet_onnx::ExecutionProviderInfo::CoreMl => {
-                    ("coreml", "CoreML", "CoreML (Apple GPU/Neural Engine)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::Rocm => {
-                    ("rocm", "ROCm", "ROCm (AMD GPU acceleration)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::OpenVino => {
-                    ("openvino", "OpenVINO", "OpenVINO (Intel optimization)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::OneDnn => {
-                    ("onednn", "oneDNN", "oneDNN (Intel CPU optimization)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::Qnn => {
-                    ("qnn", "QNN", "QNN (Qualcomm Neural Network)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::Acl => {
-                    ("acl", "ACL", "ACL (Arm Compute Library)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::ArmNn => {
-                    ("armnn", "ArmNN", "ArmNN (Arm Neural Network)")
-                }
-                birdnet_onnx::ExecutionProviderInfo::Xnnpack => {
-                    ("xnnpack", "XNNPACK", "XNNPACK (optimized CPU for ARM/x86)")
-                }
-                _ => ("unknown", "Unknown", "Unknown provider"),
-            };
+            let meta = provider_metadata(*provider);
             ProviderInfo {
-                id: id.to_string(),
-                name: name.to_string(),
-                description: description.to_string(),
+                id: meta.id.to_string(),
+                name: meta.name.to_string(),
+                description: meta.description.to_string(),
             }
         })
         .collect();
@@ -1047,47 +1006,7 @@ mod tests {
 
     /// Create default AnalyzeArgs (all None/false).
     fn default_args() -> AnalyzeArgs {
-        AnalyzeArgs {
-            model: None,
-            model_path: None,
-            labels_path: None,
-            model_type: None,
-            meta_model_path: None,
-            format: None,
-            output_dir: None,
-            min_confidence: None,
-            overlap: None,
-            batch_size: None,
-            combine: false,
-            force: false,
-            fail_fast: false,
-            quiet: false,
-            verbose: 0,
-            no_progress: false,
-            no_csv_bom: false,
-            gpu: false,
-            cpu: false,
-            cuda: false,
-            tensorrt: false,
-            directml: false,
-            coreml: false,
-            rocm: false,
-            openvino: false,
-            onednn: false,
-            qnn: false,
-            acl: false,
-            armnn: false,
-            xnnpack: false,
-            lat: None,
-            lon: None,
-            week: None,
-            month: None,
-            day: None,
-            range_threshold: None,
-            rerank: false,
-            slist: None,
-            stale_lock_timeout: None,
-        }
+        AnalyzeArgs::default()
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Consolidate duplicate code for provider metadata and test helper structs.

Fixes #86, #89

### Changes

- **New `ProviderMetadata` struct** - Single source of truth for provider id, name, and description
- **`provider_metadata()` function** - Consolidates `provider_display_name()` and `provider_info()` into one
- **`Default` for `AnalyzeArgs`** - Eliminates duplicate test helper functions
- **Comprehensive tests** - Added tests for `provider_metadata()` covering all 12 providers

### Code Reduction

- Net reduction: ~35 lines (162 added, 197 removed)
- Eliminated 2 duplicate test helpers (~80 lines of duplicate code)
- Consolidated 2 provider matching functions into 1

## Test Plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 159 unit tests pass
- [x] Integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Provider metadata reorganized and unified for clearer provider names and descriptions.
* **Bug Fixes / Behavior**
  * Error messages now display provider names from the centralized metadata.
  * Analysis command defaults updated so runtime configuration values can take precedence when unspecified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->