### PR TITLE
fix: emit progress events in stdout mode

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -5,5 +5,7 @@ mod decode;
 mod resample;
 
 pub use chunker::{AudioChunk, chunk_audio};
-pub use decode::{DecodedAudio, RawSegment, StreamingDecoder, decode_audio_file};
+pub use decode::{
+    DecodedAudio, RawSegment, StreamingDecoder, decode_audio_file, get_audio_duration,
+};
 pub use resample::{resample, resample_chunk};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,15 +434,18 @@ fn process_all_files(
             ProcessCheck::Process => {}
         }
 
+        // Get audio duration for progress estimation
+        let audio_duration = crate::audio::get_audio_duration(file).ok().flatten();
+
         // Estimate segments for reporter
         let segment_duration = classifier.segment_duration();
         #[allow(clippy::cast_possible_truncation)]
         let estimated_segments =
-            progress::estimate_segment_count(None, segment_duration, params.overlap).unwrap_or(0)
-                as usize;
+            progress::estimate_segment_count(audio_duration, segment_duration, params.overlap)
+                .unwrap_or(0) as usize;
 
         // Report file start
-        reporter.file_started(file, index, estimated_segments, None);
+        reporter.file_started(file, index, estimated_segments, audio_duration);
 
         // Process the file
         let file_start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

Fixes missing progress events in stdout mode, enabling GUI applications to show real-time analysis progress.

## Problem

When using `--stdout` mode, the GUI received:
1. `file_started` event with `estimated_segments: 0`
2. No `progress` events during analysis  
3. `detections` event only at completion

This resulted in the GUI showing no progress for long-running analyses.

## Root Causes

**Issue 1: estimated_segments was always 0**
- `process_all_files()` was calling `estimate_segment_count(None, ...)` without audio duration
- Without duration, segment estimation returned `None`, unwrapped to 0
- This made progress tracking impossible

**Issue 2: Progress events never emitted**
- `process_batch()` only called `inc_progress()` for CLI progress bars
- Never called `reporter.progress()` to emit NDJSON progress events
- The reporter was only used at completion to emit detections

## Solution

### 1. Add efficient audio duration extraction
Added `get_audio_duration()` function to `src/audio/decode.rs`:
- Reads only file metadata, doesn't decode audio samples
- Lightweight operation suitable for progress estimation
- Returns `Option<f64>` from `n_frames` metadata

### 2. Get duration before file_started
Updated `src/lib.rs`:
- Call `get_audio_duration()` before `file_started()`
- Pass duration to `estimate_segment_count()` for accurate estimation
- Pass duration to `file_started()` event

### 3. Emit progress during processing
Modified `src/pipeline/processor.rs`:
- Added reporter and estimated_segments parameters to `process_batch()` and `run_streaming_inference()`
- Track `segments_done` counter
- Call `reporter.progress()` after each segment with `FileProgress`:
  - `path`: Current file
  - `segments_done`: Segments processed so far
  - `segments_total`: Estimated total segments
  - `percent`: Completion percentage (0-100)

## Testing

```bash
# Run with stdout mode (3-hour audio file)
birda --stdout --force -m birdnet-v24 -c 0.1 -q test.wav

# Expected output:
# {"event":"pipeline_started","data":{"total_files":1,"model":"birdnet-v24","min_confidence":0.1}}
# {"event":"file_started","data":{"file":"test.wav","index":0,"estimated_segments":3600}}
# {"event":"progress","data":{"file":{"path":"test.wav","segments_done":1,"segments_total":3600,"percent":0.03}}}
# {"event":"progress","data":{"file":{"path":"test.wav","segments_done":2,"segments_total":3600,"percent":0.06}}}
# ... (progress events every ~1% or 500ms)
# {"event":"detections","data":{"file":"test.wav","detections":[...]}}
# {"event":"file_completed","data":{"file":"test.wav","status":"success",...}}
# {"event":"pipeline_completed","data":{"status":"success",...}}
```

## Impact

- ✅ GUIs can now show real-time progress bars during analysis
- ✅ Progress events throttled (max every 500ms or 1% change) to avoid spam
- ✅ No performance impact (duration read from metadata, not audio decoding)
- ✅ Works for both stdout mode and regular mode
- ✅ All 186 tests passing

## Files Changed

- `src/audio/decode.rs` - Added `get_audio_duration()` helper
- `src/audio/mod.rs` - Export new function
- `src/lib.rs` - Get duration before file_started
- `src/pipeline/processor.rs` - Emit progress events during processing

## Breaking Changes

None - purely additive functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio duration detection that reads metadata directly without requiring full file decoding, enabling faster processing.
  * Introduced real-time progress reporting with per-file segment tracking and percentage completion updates during processing.

* **Improvements**
  * Progress estimation now uses actual audio duration for more accurate segment count predictions instead of fallback estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->