### PR TITLE
Add direct clip extraction mode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -385,6 +385,15 @@ pub enum Error {
         /// The invalid value.
         value: String,
     },
+
+    /// Invalid time range for clip extraction.
+    #[error("invalid time range: end ({end}s) must be greater than start ({start}s)")]
+    InvalidTimeRange {
+        /// Start time in seconds.
+        start: f64,
+        /// End time in seconds.
+        end: f64,
+    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds support for extracting a single audio clip directly from source file and time range, without requiring CSV detection files. This enables the GUI detail view to extract clips on demand.

## Usage

```bash
birda clip --audio source.wav --start 639 --end 642 --pre 2 --post 2 -o clips/
```

When `--start` and `--end` are provided, the command skips CSV parsing and extracts a single segment directly from the audio file. Output clip path is printed to stdout (human mode) or emitted as JSON.

## Changes

- **CLI Args** (`src/cli/clip.rs`): Added optional `--start` and `--end` fields with validation
- **Command** (`src/clipper/command.rs`): 
  - Refactored `execute()` to dispatch between CSV and direct extraction modes
  - Implemented `execute_direct_extraction()` for time-based extraction
  - Maintained backward compatibility with existing CSV mode
- **Error Handling** (`src/error.rs`): Added `InvalidTimeRange` error variant

## Key Features

✅ **Dual Mode Support**: Auto-detects mode based on `--start`/`--end` presence  
✅ **Padding Applied**: `--pre` and `--post` flags work as expected  
✅ **Multiple Output Formats**: Supports human-readable, JSON, and NDJSON modes  
✅ **Generic Naming**: Uses timestamp-based names (e.g., `detection_639-642`)  
✅ **Validation**: Validates time ranges and file existence  
✅ **Backward Compatible**: CSV mode unchanged and fully functional  

## Testing

All existing tests pass:
- ✅ `cargo test` - 184 tests passing
- ✅ `cargo clippy` - No warnings
- ✅ `cargo fmt --check` - Properly formatted

Manual testing completed:
- ✅ Direct extraction (human mode) - prints clip path to stdout
- ✅ Direct extraction (JSON mode) - emits structured JSON
- ✅ Direct extraction (NDJSON mode) - emits newline-delimited JSON
- ✅ Invalid time range - proper error handling
- ✅ Missing required args - clap validation works
- ✅ CSV mode - still works unchanged
- ✅ Clip duration verification - padding applied correctly

## Example Output

**Human mode (for GUI consumption):**
```
$ birda clip --audio test.wav --start 10.0 --end 13.0 --pre 2 --post 2
clips/detection_10-13/detection_10-13_100p_8.0-15.0.wav
```

**JSON mode:**
```json
{
  "result_type": "clip_extraction",
  "output_dir": "clips",
  "total_clips": 1,
  "clips": [{
    "source_audio": "test.wav",
    "scientific_name": "detection_10-13",
    "start_time": 8.0,
    "end_time": 15.0,
    "output_file": "clips/detection_10-13/detection_10-13_100p_8.0-15.0.wav"
  }]
}
```

## Implementation Notes

- Reuses existing `ClipExtractor`, `WavWriter`, and output infrastructure
- Creates synthetic `DetectionGroup` for extraction
- No code duplication or architectural changes
- Follows project coding standards (no magic numbers, proper error handling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct time-based clip extraction with `--start` and `--end` options, enabling users to extract audio clips by specifying exact time ranges without requiring detection files.
  * Improved error handling with clearer validation messages for invalid time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->