### PR TITLE
fix: correct registry label file references

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -85,12 +85,6 @@
               "filename": "birdnet-v24-es.txt"
             },
             {
-              "code": "et",
-              "name": "Estonian",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_et.txt",
-              "filename": "birdnet-v24-et.txt"
-            },
-            {
               "code": "fi",
               "name": "Finnish",
               "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_fi.txt",
@@ -109,12 +103,6 @@
               "filename": "birdnet-v24-he.txt"
             },
             {
-              "code": "hi",
-              "name": "Hindi",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_hi.txt",
-              "filename": "birdnet-v24-hi.txt"
-            },
-            {
               "code": "hr",
               "name": "Croatian",
               "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_hr.txt",
@@ -129,7 +117,7 @@
             {
               "code": "id",
               "name": "Indonesian",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_id.txt",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_in.txt",
               "filename": "birdnet-v24-id.txt"
             },
             {
@@ -163,16 +151,10 @@
               "filename": "birdnet-v24-lt.txt"
             },
             {
-              "code": "lv",
-              "name": "Latvian",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_lv.txt",
-              "filename": "birdnet-v24-lv.txt"
-            },
-            {
-              "code": "mk",
-              "name": "Macedonian",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_mk.txt",
-              "filename": "birdnet-v24-mk.txt"
+              "code": "ml",
+              "name": "Malayalam",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_ml.txt",
+              "filename": "birdnet-v24-ml.txt"
             },
             {
               "code": "nl",
@@ -193,10 +175,16 @@
               "filename": "birdnet-v24-pl.txt"
             },
             {
-              "code": "pt",
-              "name": "Portuguese",
-              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_pt.txt",
-              "filename": "birdnet-v24-pt.txt"
+              "code": "pt-BR",
+              "name": "Portuguese (Brazil)",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_pt_BR.txt",
+              "filename": "birdnet-v24-pt-BR.txt"
+            },
+            {
+              "code": "pt-PT",
+              "name": "Portuguese (Portugal)",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_pt_PT.txt",
+              "filename": "birdnet-v24-pt-PT.txt"
             },
             {
               "code": "ro",
@@ -223,6 +211,12 @@
               "filename": "birdnet-v24-sl.txt"
             },
             {
+              "code": "sr",
+              "name": "Serbian",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_sr.txt",
+              "filename": "birdnet-v24-sr.txt"
+            },
+            {
               "code": "sv",
               "name": "Swedish",
               "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_sv.txt",
@@ -233,6 +227,12 @@
               "name": "Thai",
               "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_th.txt",
               "filename": "birdnet-v24-th.txt"
+            },
+            {
+              "code": "tr",
+              "name": "Turkish",
+              "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_tr.txt",
+              "filename": "birdnet-v24-tr.txt"
             },
             {
               "code": "uk",


### PR DESCRIPTION
## Summary

Fixes model installation failure caused by incorrect label file references in registry.json. The registry referenced files that don't exist in the repository, causing downloads to fail.

## Problem

After merging #106 (download all language labels), model installation now fails because the registry.json contains references to label files that don't exist:

```
error: failed to download from 'https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_et.txt'
```

## Changes

**Removed non-existent files:**
- ❌ et (Estonian)
- ❌ hi (Hindi)  
- ❌ lv (Latvian)
- ❌ mk (Macedonian)

**Fixed file references:**
- ✅ id (Indonesian): Changed from `_id.txt` to `_in.txt`

**Updated Portuguese variants:**
- ✅ pt → pt-BR (Portuguese Brazil)
- ✅ Added pt-PT (Portuguese Portugal)

**Added missing languages:**
- ✅ ml (Malayalam)
- ✅ sr (Serbian)
- ✅ tr (Turkish)

## Verification

All 37 language entries have been verified to exist in the repository:

```bash
# All files now return HTTP 200
✓ af, ar, bg, ca, cs, da, de, el, en, es, fi, fr, he, hr, hu
✓ id, is, it, ja, ko, lt, ml, nl, no, pl, pt-BR, pt-PT, ro, ru
✓ sk, sl, sr, sv, th, tr, uk, zh
```

## Impact

- ✅ Model installation will now complete successfully
- ✅ All 37 available languages can be downloaded
- ✅ Fixes regression introduced in #106

## Test Plan

- [x] Verified all language file URLs return HTTP 200
- [x] Compared registry against actual repository files
- [ ] Manual test: `birda models install birdnet-v24` completes without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Malayalam, Serbian, and Turkish languages.
  * Portuguese now available in Brazil and Portugal variants.

* **Chores**
  * Removed support for Estonian, Hindi, Latvian, and Macedonian languages.
  * Updated Indonesian language resource reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->