### PR TITLE
feat: Add macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,17 +337,6 @@ jobs:
 
           echo "=== Notarization successful ==="
 
-      - name: Staple notarization to binary
-        run: |
-          echo "=== Stapling notarization ticket ==="
-          xcrun stapler staple unsigned/birda
-
-          echo "=== Verifying staple ==="
-          xcrun stapler validate unsigned/birda
-
-          echo "=== Final Gatekeeper check ==="
-          spctl --assess --verbose=4 --type execute unsigned/birda
-
       - name: Create signed tar.gz
         run: |
           VERSION="${{ github.ref_name }}"

--- a/installer/macos/entitlements.plist
+++ b/installer/macos/entitlements.plist
@@ -3,26 +3,6 @@
 <plist version="1.0">
 <dict>
 	<!-- Hardened Runtime Entitlements -->
-
-	<!-- Allow execution of JIT-compiled code (not needed for Birda, but keeping minimal set) -->
-	<!-- <key>com.apple.security.cs.allow-jit</key>
-	<true/> -->
-
-	<!-- Allow loading of unsigned executable memory (not needed for Birda) -->
-	<!-- <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/> -->
-
-	<!-- Allow DYLD environment variables (not needed for Birda) -->
-	<!-- <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/> -->
-
-	<!-- Disable library validation - allows loading of any dynamic library -->
-	<!-- Required because we bundle ONNX Runtime dynamic library -->
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-
-	<!-- Allow debugging (only needed during development, disabled for production) -->
-	<!-- <key>com.apple.security.cs.debugger</key>
-	<true/> -->
+	<!-- No entitlements needed - all libraries are signed with the same Team ID -->
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds code signing and notarization for macOS releases
- Creates both signed DMG and tar.gz artifacts
- Eliminates Gatekeeper warnings on macOS

## Implementation Details

### New Workflow Job: `sign-and-notarize-macos`
- Runs after `build-cpu` completes for macOS
- Imports Developer ID certificate from GitHub secrets
- Signs binary and ONNX Runtime libraries with hardened runtime
- Submits to Apple for notarization using `notarytool`
- Staples notarization tickets for offline verification
- Creates both DMG and tar.gz distributions

### Security Features
- **Hardened runtime** enabled with minimal entitlements
- **Timestamp signing** ensures signatures remain valid after cert expiration
- **Deep signing** of all embedded libraries (ONNX Runtime dylibs)
- **Notarization** by Apple verifies no malware

### Distribution Formats
- **DMG**: Drag-and-drop installer with clean user experience
- **tar.gz**: Command-line friendly for Homebrew and CLI users
- Both formats are fully signed and notarized

### Required GitHub Secrets
The following secrets must be configured in the repository (already done):
- `APPLE_CERTIFICATE_BASE64` - Developer ID Application certificate (P12 base64-encoded)
- `APPLE_CERTIFICATE_PASSWORD` - Certificate password
- `APPLE_ID` - Apple ID for notarization
- `APPLE_APP_SPECIFIC_PASSWORD` - App-specific password
- `APPLE_TEAM_ID` - 10-character Apple Developer Team ID

## Files Changed
- `.github/workflows/release.yml` - Added signing job and updated release job
- `installer/macos/entitlements.plist` - Hardened runtime entitlements

## Testing
- Workflow syntax validated with Python YAML parser
- Workflow structure validated with `act -l`
- Pre-commit hooks passed

## User Impact
macOS users will now get:
- ✅ No "unidentified developer" warnings
- ✅ Professional DMG installer with drag-to-Applications
- ✅ Signed tar.gz for package managers
- ✅ Full Apple notarization for maximum trust

## Release Notes Updated
Updated the release body template to highlight the signed/notarized macOS builds.