### PR TITLE
[codex] Add AGENTS.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## What changed
- add `AGENTS.md` as a symlink to `CLAUDE.md`

## Why
- add `AGENTS.md` for Codex and OpenCode support
- keep both agent-instruction entry points available without duplicating content

## Impact
- Codex and OpenCode can use `AGENTS.md`
- there is a single source of truth in `CLAUDE.md`

## Validation
- verified `AGENTS.md` is a symlink to `CLAUDE.md`
- verified in a fresh Codex session that the symlinked `AGENTS.md` is picked up: asking "when to use LEAN" produced the correct answer without explicit file reads or tool use
- no automated checks were run for this filesystem-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation file to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->