### PR TITLE
feat: add birda update command for self-updating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1047,9 +1047,8 @@ jobs:
           compute_sha256() {
             local file="$1"
             if [ ! -f "$file" ]; then
-              echo "WARNING: $file not found, SHA256 will be empty" >&2
-              echo ""
-              return
+              echo "ERROR: $file not found, cannot compute SHA256" >&2
+              exit 1
             fi
             sha256sum "$file" | cut -d' ' -f1
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -994,15 +994,64 @@ jobs:
           echo "=== Embed archives ==="
           ls -la artifacts/*embed* 2>/dev/null || true
 
+      - name: Create binary-only archives
+        run: |
+          VERSION="${{ github.ref_name }}"
+
+          # Linux CPU binary-only
+          if [ -d "artifacts/birda-linux-x64" ]; then
+            tar -czvf artifacts/birda-linux-x64-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64 birda
+          fi
+
+          # Linux CUDA binary-only (same binary, different build)
+          if [ -d "artifacts/birda-linux-x64-cuda" ]; then
+            tar -czvf artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64-cuda birda
+          fi
+
+          # Windows CPU binary-only
+          if [ -d "artifacts/birda-windows-x64" ]; then
+            cd artifacts/birda-windows-x64
+            zip ../birda-windows-x64-bin-${VERSION}.zip birda.exe
+            cd ../..
+          fi
+
+          # Windows CUDA binary-only
+          if [ -d "artifacts/birda-windows-x64-cuda" ]; then
+            cd artifacts/birda-windows-x64-cuda
+            zip ../birda-windows-x64-cuda-bin-${VERSION}.zip birda.exe
+            cd ../..
+          fi
+
+          # macOS binary-only (from the signed macOS artifact)
+          if [ -d "artifacts/birda-macos-arm64" ]; then
+            tar -czvf artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz -C artifacts/birda-macos-arm64 birda
+          fi
+
+          echo "=== Binary-only archives ==="
+          ls -la artifacts/*bin* 2>/dev/null || true
+
       - name: Generate manifest.json
         run: |
           VERSION="${{ github.ref_name }}"
           SEMVER="${VERSION#v}"
+
+          # Compute SHA256 for binary-only archives
+          SHA256_LINUX_BIN=$(sha256sum artifacts/birda-linux-x64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_LINUX_CUDA_BIN=$(sha256sum artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_WINDOWS_BIN=$(sha256sum artifacts/birda-windows-x64-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_WINDOWS_CUDA_BIN=$(sha256sum artifacts/birda-windows-x64-cuda-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_MACOS_BIN=$(sha256sum artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+
           sed -e "s/\${VERSION}/$SEMVER/g" \
               -e "s/\${TAG}/$VERSION/g" \
               -e "s/\${ONNXRUNTIME_VERSION}/${{ env.ONNXRUNTIME_VERSION }}/g" \
               -e "s/\${CUDNN_VERSION}/${{ env.CUDNN_VERSION }}/g" \
               -e "s/\${CUDA_TOOLKIT_VERSION}/${{ env.CUDA_TOOLKIT_VERSION }}/g" \
+              -e "s/\${SHA256_LINUX_BIN}/$SHA256_LINUX_BIN/g" \
+              -e "s/\${SHA256_LINUX_CUDA_BIN}/$SHA256_LINUX_CUDA_BIN/g" \
+              -e "s/\${SHA256_WINDOWS_BIN}/$SHA256_WINDOWS_BIN/g" \
+              -e "s/\${SHA256_WINDOWS_CUDA_BIN}/$SHA256_WINDOWS_CUDA_BIN/g" \
+              -e "s/\${SHA256_MACOS_BIN}/$SHA256_MACOS_BIN/g" \
               manifest.template.json > artifacts/manifest.json
 
           echo "=== Generated manifest.json ==="
@@ -1044,6 +1093,9 @@ jobs:
             | `birda-linux-x64-embed-${{ github.ref_name }}.tar.gz` | Linux embeddable (CLI + ONNX Runtime CPU) |
             | `birda-windows-x64-embed-${{ github.ref_name }}.zip` | Windows embeddable (CLI + ONNX Runtime CPU) |
             | `birda-macos-arm64-embed-${{ github.ref_name }}.tar.gz` | macOS embeddable (Signed, CLI + ONNX Runtime CPU) |
+            | `birda-linux-x64-bin-${{ github.ref_name }}.tar.gz` | Linux binary-only (for updates) |
+            | `birda-windows-x64-bin-${{ github.ref_name }}.zip` | Windows binary-only (for updates) |
+            | `birda-macos-arm64-bin-${{ github.ref_name }}.tar.gz` | macOS binary-only (for updates) |
             | `birda-cuda-libs-linux-x64-${{ github.ref_name }}.tar.gz` | Linux CUDA libraries only |
             | `birda-cuda-libs-windows-x64-${{ github.ref_name }}.zip` | Windows CUDA libraries only |
             | `manifest.json` | Version manifest for GUI integration |
@@ -1074,6 +1126,11 @@ jobs:
             artifacts/**/*.tar.gz
             artifacts/**/*.zip
             artifacts/**/*-setup.exe
+            artifacts/birda-linux-x64-bin-${{ github.ref_name }}.tar.gz
+            artifacts/birda-linux-x64-cuda-bin-${{ github.ref_name }}.tar.gz
+            artifacts/birda-windows-x64-bin-${{ github.ref_name }}.zip
+            artifacts/birda-windows-x64-cuda-bin-${{ github.ref_name }}.zip
+            artifacts/birda-macos-arm64-bin-${{ github.ref_name }}.tar.gz
             artifacts/manifest.json
 
       - name: Scan release assets with VirusTotal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1043,12 +1043,22 @@ jobs:
           VERSION="${{ github.ref_name }}"
           SEMVER="${VERSION#v}"
 
-          # Compute SHA256 for binary-only archives
-          SHA256_LINUX_BIN=$(sha256sum artifacts/birda-linux-x64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
-          SHA256_LINUX_CUDA_BIN=$(sha256sum artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
-          SHA256_WINDOWS_BIN=$(sha256sum artifacts/birda-windows-x64-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
-          SHA256_WINDOWS_CUDA_BIN=$(sha256sum artifacts/birda-windows-x64-cuda-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
-          SHA256_MACOS_BIN=$(sha256sum artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+          # Compute SHA256 for binary-only archives (fail if any archive is missing)
+          compute_sha256() {
+            local file="$1"
+            if [ ! -f "$file" ]; then
+              echo "WARNING: $file not found, SHA256 will be empty" >&2
+              echo ""
+              return
+            fi
+            sha256sum "$file" | cut -d' ' -f1
+          }
+
+          SHA256_LINUX_BIN=$(compute_sha256 "artifacts/birda-linux-x64-bin-${VERSION}.tar.gz")
+          SHA256_LINUX_CUDA_BIN=$(compute_sha256 "artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz")
+          SHA256_WINDOWS_BIN=$(compute_sha256 "artifacts/birda-windows-x64-bin-${VERSION}.zip")
+          SHA256_WINDOWS_CUDA_BIN=$(compute_sha256 "artifacts/birda-windows-x64-cuda-bin-${VERSION}.zip")
+          SHA256_MACOS_BIN=$(compute_sha256 "artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz")
 
           sed -e "s/\${VERSION}/$SEMVER/g" \
               -e "s/\${TAG}/$VERSION/g" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1003,9 +1003,11 @@ jobs:
             tar -czvf artifacts/birda-linux-x64-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64 birda
           fi
 
-          # Linux CUDA binary-only (same binary, different build)
+          # Linux CUDA binary-only (artifact contains a .tar.gz, extract first)
           if [ -d "artifacts/birda-linux-x64-cuda" ]; then
-            tar -czvf artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64-cuda birda
+            mkdir -p cuda-linux-extract
+            tar -xzf artifacts/birda-linux-x64-cuda/birda-linux-x64-cuda-${VERSION}.tar.gz -C cuda-linux-extract
+            tar -czvf artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz -C cuda-linux-extract birda
           fi
 
           # Windows CPU binary-only
@@ -1015,15 +1017,21 @@ jobs:
             cd ../..
           fi
 
-          # Windows CUDA binary-only
+          # Windows CUDA binary-only (artifact contains a .zip, extract first)
           if [ -d "artifacts/birda-windows-x64-cuda" ]; then
-            cd artifacts/birda-windows-x64-cuda
-            zip ../birda-windows-x64-cuda-bin-${VERSION}.zip birda.exe
-            cd ../..
+            mkdir -p cuda-windows-extract
+            unzip -o artifacts/birda-windows-x64-cuda/birda-windows-x64-cuda-${VERSION}.zip -d cuda-windows-extract
+            cd cuda-windows-extract
+            zip ../artifacts/birda-windows-x64-cuda-bin-${VERSION}.zip birda.exe
+            cd ..
           fi
 
-          # macOS binary-only (from the signed macOS artifact)
-          if [ -d "artifacts/birda-macos-arm64" ]; then
+          # macOS binary-only (use the signed artifact, which contains a .tar.gz)
+          if [ -d "artifacts/birda-macos-arm64-signed" ]; then
+            mkdir -p macos-signed-extract
+            tar -xzf artifacts/birda-macos-arm64-signed/birda-macos-arm64-${VERSION}-signed.tar.gz -C macos-signed-extract
+            tar -czvf artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz -C macos-signed-extract birda
+          elif [ -d "artifacts/birda-macos-arm64" ]; then
             tar -czvf artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz -C artifacts/birda-macos-arm64 birda
           fi
 
@@ -1094,7 +1102,9 @@ jobs:
             | `birda-windows-x64-embed-${{ github.ref_name }}.zip` | Windows embeddable (CLI + ONNX Runtime CPU) |
             | `birda-macos-arm64-embed-${{ github.ref_name }}.tar.gz` | macOS embeddable (Signed, CLI + ONNX Runtime CPU) |
             | `birda-linux-x64-bin-${{ github.ref_name }}.tar.gz` | Linux binary-only (for updates) |
+            | `birda-linux-x64-cuda-bin-${{ github.ref_name }}.tar.gz` | Linux CUDA binary-only (for updates) |
             | `birda-windows-x64-bin-${{ github.ref_name }}.zip` | Windows binary-only (for updates) |
+            | `birda-windows-x64-cuda-bin-${{ github.ref_name }}.zip` | Windows CUDA binary-only (for updates) |
             | `birda-macos-arm64-bin-${{ github.ref_name }}.tar.gz` | macOS binary-only (for updates) |
             | `birda-cuda-libs-linux-x64-${{ github.ref_name }}.tar.gz` | Linux CUDA libraries only |
             | `birda-cuda-libs-windows-x64-${{ github.ref_name }}.zip` | Windows CUDA libraries only |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,25 +461,32 @@ dependencies = [
  "csv",
  "ctrlc",
  "directories",
+ "flate2",
  "futures-util",
  "hostname",
  "hound",
  "indicatif",
+ "libc",
  "ort",
  "parquet",
  "predicates",
  "reqwest",
  "rubato",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "symphonia",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -503,6 +519,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -727,10 +752,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -784,10 +843,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "directories"
@@ -883,6 +963,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +995,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1022,6 +1114,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1573,7 +1675,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1902,7 +2007,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1972,6 +2077,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2196,6 +2307,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2500,6 +2620,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2718,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2853,6 +2995,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3215,6 +3368,12 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -3940,6 +4099,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4043,6 +4212,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,6 +4239,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,15 @@ hound = "3.5"
 csv = "1.3"
 parquet = "58.1"
 arrow = "58.1"
+semver = "1"
+sha2 = "0.10"
+tar = "0.4"
+self-replace = "1"
+flate2 = "1"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+//! Build script for birda.
+//!
+//! Embeds library version expectations at compile time so the update command
+//! can detect ABI-breaking changes without a local manifest file.
+
+fn main() {
+    // ONNX Runtime version this binary was built against.
+    // Set by the release workflow; defaults to "unknown" for dev builds.
+    let ort_version =
+        std::env::var("ONNXRUNTIME_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_ONNXRUNTIME_VERSION={ort_version}");
+
+    // CUDA toolkit version expected by this build.
+    let cuda_version =
+        std::env::var("CUDA_TOOLKIT_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDA_TOOLKIT_VERSION={cuda_version}");
+
+    // cuDNN version expected by this build.
+    let cudnn_version = std::env::var("CUDNN_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDNN_VERSION={cudnn_version}");
+
+    // Re-run if these env vars change.
+    println!("cargo:rerun-if-env-changed=ONNXRUNTIME_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDNN_VERSION");
+}

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -2,6 +2,28 @@
   "version": "${VERSION}",
   "min_gui_version": "1.1.0",
   "assets": {
+    "bin": {
+      "linux-x64": {
+        "file": "birda-linux-x64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_BIN}"
+      },
+      "linux-x64-cuda": {
+        "file": "birda-linux-x64-cuda-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_CUDA_BIN}"
+      },
+      "windows-x64": {
+        "file": "birda-windows-x64-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_BIN}"
+      },
+      "windows-x64-cuda": {
+        "file": "birda-windows-x64-cuda-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_CUDA_BIN}"
+      },
+      "macos-arm64": {
+        "file": "birda-macos-arm64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_MACOS_BIN}"
+      }
+    },
     "embed": {
       "linux-x64": "birda-linux-x64-embed-${TAG}.tar.gz",
       "windows-x64": "birda-windows-x64-embed-${TAG}.zip",
@@ -12,8 +34,10 @@
       "windows-x64": "birda-cuda-libs-windows-x64-${TAG}.zip"
     }
   },
+  "dependencies": {
+    "onnxruntime": "${ONNXRUNTIME_VERSION}"
+  },
   "cuda": {
-    "onnxruntime": "${ONNXRUNTIME_VERSION}",
     "cuda_toolkit": "${CUDA_TOOLKIT_VERSION}",
     "cudnn": "${CUDNN_VERSION}"
   }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -57,6 +57,12 @@ pub enum Command {
     Providers,
     /// Extract audio clips from detection results.
     Clip(ClipArgs),
+    /// Check for and install updates from GitHub.
+    Update {
+        /// Only check for updates, don't install.
+        #[arg(long)]
+        check: bool,
+    },
     /// Generate species list from range filter.
     #[command(group(
         clap::ArgGroup::new("time")

--- a/src/error.rs
+++ b/src/error.rs
@@ -533,7 +533,9 @@ pub enum Error {
     },
 
     /// Update blocked due to ONNX Runtime ABI incompatibility.
-    #[error("update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda")]
+    #[error(
+        "update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda"
+    )]
     UpdateBlocked {
         /// Current ONNX Runtime version.
         current: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -498,6 +498,83 @@ pub enum Error {
         /// Description of the failure.
         reason: String,
     },
+
+    /// Failed to fetch update manifest from GitHub.
+    #[error("failed to fetch update manifest: {reason}")]
+    UpdateFetchFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update manifest JSON was malformed.
+    #[error("failed to parse update manifest")]
+    UpdateManifestParse {
+        /// Underlying parse error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// SHA256 checksum mismatch after download.
+    #[error("checksum mismatch for '{file}': expected {expected}, got {actual}")]
+    UpdateChecksumMismatch {
+        /// File name that failed verification.
+        file: String,
+        /// Expected SHA256 hash.
+        expected: String,
+        /// Actual SHA256 hash.
+        actual: String,
+    },
+
+    /// Binary replacement failed.
+    #[error("failed to replace binary: {reason}")]
+    UpdateReplaceFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update blocked due to ONNX Runtime ABI incompatibility.
+    #[error("update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda")]
+    UpdateBlocked {
+        /// Current ONNX Runtime version.
+        current: String,
+        /// Required ONNX Runtime version.
+        required: String,
+        /// URL to the full release for manual download.
+        release_url: String,
+    },
+
+    /// No write permission to the binary's parent directory.
+    #[error("no write permission to '{path}', try running with elevated privileges")]
+    UpdatePermissionDenied {
+        /// Path that lacks write permission.
+        path: std::path::PathBuf,
+    },
+
+    /// No matching update asset for this platform/variant.
+    #[error("no update available for platform '{platform}'")]
+    UpdateUnsupportedPlatform {
+        /// Platform key that wasn't found in manifest.
+        platform: String,
+    },
+
+    /// Archive extraction failed.
+    #[error("failed to extract update archive: {reason}")]
+    UpdateExtractFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update refused because binary is a dev build (in target/ directory).
+    #[error("refusing to update a development build (binary is in a cargo target/ directory)")]
+    UpdateDevBuild,
+
+    /// Failed to determine the current executable path.
+    #[error("failed to determine current executable path")]
+    UpdateExeNotFound {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -534,7 +534,7 @@ pub enum Error {
 
     /// Update blocked due to ONNX Runtime ABI incompatibility.
     #[error(
-        "update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda"
+        "update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda\nPlease download the full package from: {release_url}"
     )]
     UpdateBlocked {
         /// Current ONNX Runtime version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod locking;
 pub mod output;
 pub mod pipeline;
 pub mod registry;
+pub mod update;
 pub mod utils;
 
 use clap::Parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,12 @@ pub fn run() -> Result<()> {
 
 fn command_requires_runtime(command: Option<&Command>, has_no_inputs: bool) -> bool {
     match command {
-        Some(Command::Config { .. } | Command::Models { .. } | Command::Clip(_)) => false,
+        Some(
+            Command::Config { .. }
+            | Command::Models { .. }
+            | Command::Clip(_)
+            | Command::Update { .. },
+        ) => false,
         Some(Command::Providers | Command::Species { .. }) => true,
         None => !has_no_inputs,
     }
@@ -816,6 +821,7 @@ fn handle_command(
             output_mode,
         ),
         Command::Clip(args) => clipper::command::execute(&args, output_mode),
+        Command::Update { check } => handle_update_command(check, output_mode),
     }
 }
 
@@ -890,6 +896,89 @@ fn handle_providers_command(output_mode: OutputMode) {
     println!("Note: This shows compile-time availability. Runtime availability may");
     println!("      differ based on drivers and hardware. Check log output for actual");
     println!("      provider selection during inference.");
+}
+
+/// Handle the `update` subcommand.
+///
+/// Checks for a newer release on GitHub and optionally downloads and installs it.
+fn handle_update_command(check_only: bool, output_mode: OutputMode) -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| Error::Internal {
+        message: format!("Failed to create async runtime: {e}"),
+    })?;
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("birda/{}", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| Error::Internal {
+            message: format!("Failed to create HTTP client: {e}"),
+        })?;
+
+    let check_result = runtime.block_on(update::check_for_update(&client))?;
+
+    match check_result {
+        update::UpdateCheck::UpToDate { version } => {
+            if output_mode.is_structured() {
+                emit_json_result(&serde_json::json!({
+                    "result_type": "update_check",
+                    "status": "up_to_date",
+                    "version": version,
+                }));
+            } else {
+                println!("birda is up to date (v{version})");
+            }
+            Ok(())
+        }
+        update::UpdateCheck::Available {
+            current,
+            available,
+            manifest,
+        } => {
+            if check_only {
+                if output_mode.is_structured() {
+                    emit_json_result(&serde_json::json!({
+                        "result_type": "update_check",
+                        "status": "available",
+                        "current_version": current,
+                        "available_version": available,
+                    }));
+                } else {
+                    println!("Update available: v{current} -> v{available}");
+                    println!("Run 'birda update' to install.");
+                }
+                return Ok(());
+            }
+
+            let result = runtime.block_on(update::perform_update(&client, &manifest, &current))?;
+
+            if output_mode.is_structured() {
+                emit_json_result(&serde_json::json!({
+                    "result_type": "update_result",
+                    "status": "updated",
+                    "old_version": result.old_version,
+                    "new_version": result.new_version,
+                    "backup_path": result.backup_path.as_ref().map(|p| p.display().to_string()),
+                    "warnings": result.warnings,
+                }));
+            } else {
+                println!("Verifying checksum... ok");
+                if let Some(ref path) = result.backup_path {
+                    println!("Previous version saved as {}", path.display());
+                }
+                println!(
+                    "Updated birda v{} -> v{}",
+                    result.old_version, result.new_version
+                );
+
+                for warning in &result.warnings {
+                    println!("\nNote: {warning}");
+                }
+            }
+
+            Ok(())
+        }
+    }
 }
 
 fn handle_config_command(action: cli::ConfigAction, output_mode: OutputMode) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,8 +908,12 @@ fn handle_update_command(check_only: bool, output_mode: OutputMode) -> Result<()
 
     let client = reqwest::Client::builder()
         .user_agent(format!("birda/{}", env!("CARGO_PKG_VERSION")))
-        .connect_timeout(std::time::Duration::from_secs(30))
-        .timeout(std::time::Duration::from_secs(300))
+        .connect_timeout(std::time::Duration::from_secs(
+            update::constants::CONNECT_TIMEOUT_SECS,
+        ))
+        .timeout(std::time::Duration::from_secs(
+            update::constants::DOWNLOAD_TIMEOUT_SECS,
+        ))
         .build()
         .map_err(|e| Error::Internal {
             message: format!("Failed to create HTTP client: {e}"),

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -15,9 +15,10 @@ pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
 
     if actual_hex != expected_hex.to_ascii_lowercase() {
         return Err(Error::UpdateChecksumMismatch {
-            file: path
-                .file_name()
-                .map_or_else(|| "unknown".to_string(), |n| n.to_string_lossy().to_string()),
+            file: path.file_name().map_or_else(
+                || "unknown".to_string(),
+                |n| n.to_string_lossy().to_string(),
+            ),
             expected: expected_hex.to_string(),
             actual: actual_hex,
         });
@@ -30,11 +31,12 @@ pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
 fn hex_digest(data: &[u8]) -> String {
     let hash = Sha256::digest(data);
     // Format each byte as two lowercase hex characters
-    hash.iter().fold(String::with_capacity(64), |mut acc, byte| {
-        use std::fmt::Write;
-        let _ = write!(acc, "{byte:02x}");
-        acc
-    })
+    hash.iter()
+        .fold(String::with_capacity(64), |mut acc, byte| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        })
 }
 
 #[cfg(test)]
@@ -81,7 +83,10 @@ mod tests {
         f.write_all(b"test content").unwrap();
         drop(f);
 
-        let result = verify_sha256(&path, "0000000000000000000000000000000000000000000000000000000000000000");
+        let result = verify_sha256(
+            &path,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        );
         assert!(result.is_err());
     }
 }

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -64,10 +64,10 @@ mod tests {
 
     #[test]
     fn test_verify_sha256_matching() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test setup failed");
         let path = dir.path().join("test.bin");
-        let mut f = std::fs::File::create(&path).unwrap();
-        f.write_all(b"test content").unwrap();
+        let mut f = std::fs::File::create(&path).expect("test setup failed");
+        f.write_all(b"test content").expect("test setup failed");
         drop(f);
 
         let expected = hex_digest(b"test content");
@@ -76,10 +76,10 @@ mod tests {
 
     #[test]
     fn test_verify_sha256_mismatch() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test setup failed");
         let path = dir.path().join("test.bin");
-        let mut f = std::fs::File::create(&path).unwrap();
-        f.write_all(b"test content").unwrap();
+        let mut f = std::fs::File::create(&path).expect("test setup failed");
+        f.write_all(b"test content").expect("test setup failed");
         drop(f);
 
         let result = verify_sha256(

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -1,1 +1,87 @@
 //! SHA256 checksum verification for downloaded archives.
+
+use crate::error::{Error, Result};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// Verify that a file's SHA256 hash matches the expected hex digest.
+///
+/// Returns `Ok(())` if the checksum matches. Returns `Err(UpdateChecksumMismatch)`
+/// if it doesn't. The file is read in streaming fashion to avoid loading it all
+/// into memory.
+pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
+    let file_bytes = std::fs::read(path).map_err(Error::Io)?;
+    let actual_hex = hex_digest(&file_bytes);
+
+    if actual_hex != expected_hex.to_ascii_lowercase() {
+        return Err(Error::UpdateChecksumMismatch {
+            file: path
+                .file_name()
+                .map_or_else(|| "unknown".to_string(), |n| n.to_string_lossy().to_string()),
+            expected: expected_hex.to_string(),
+            actual: actual_hex,
+        });
+    }
+
+    Ok(())
+}
+
+/// Compute the SHA256 hex digest of raw bytes.
+fn hex_digest(data: &[u8]) -> String {
+    let hash = Sha256::digest(data);
+    // Format each byte as two lowercase hex characters
+    hash.iter().fold(String::with_capacity(64), |mut acc, byte| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_hex_digest_known_value() {
+        // SHA256 of empty string
+        let hash = hex_digest(b"");
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_hex_digest_hello_world() {
+        let hash = hex_digest(b"hello world");
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn test_verify_sha256_matching() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"test content").unwrap();
+        drop(f);
+
+        let expected = hex_digest(b"test content");
+        assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"test content").unwrap();
+        drop(f);
+
+        let result = verify_sha256(&path, "0000000000000000000000000000000000000000000000000000000000000000");
+        assert!(result.is_err());
+    }
+}

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -1,0 +1,1 @@
+//! SHA256 checksum verification for downloaded archives.

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 /// Verify that a file's SHA256 hash matches the expected hex digest.
 ///
 /// Returns `Ok(())` if the checksum matches. Returns `Err(UpdateChecksumMismatch)`
-/// if it doesn't. The file is read in streaming fashion to avoid loading it all
-/// into memory.
+/// if it doesn't.
 pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
     let file_bytes = std::fs::read(path).map_err(Error::Io)?;
     let actual_hex = hex_digest(&file_bytes);

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -14,8 +14,11 @@ pub const MANIFEST_FILENAME: &str = "manifest.json";
 /// Temporary file suffix used during extraction.
 pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
 
-/// Backup file extension for the old binary on Unix.
-pub const BACKUP_EXTENSION: &str = ".old";
+/// HTTP connect timeout in seconds for update requests.
+pub const CONNECT_TIMEOUT_SECS: u64 = 30;
+
+/// Total HTTP timeout in seconds for update download requests.
+pub const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
 
 /// Embedded ONNX Runtime version from build time.
 pub const BUILT_ONNXRUNTIME_VERSION: &str = env!("BIRDA_ONNXRUNTIME_VERSION");

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -6,8 +6,7 @@ pub const GITHUB_REPO: &str = "tphakala/birda";
 /// URL pattern for downloading from the latest GitHub release.
 /// The `{repo}` placeholder is replaced with `GITHUB_REPO`.
 /// The `{file}` placeholder is replaced with the asset filename.
-pub const RELEASE_DOWNLOAD_URL: &str =
-    "https://github.com/{repo}/releases/latest/download/{file}";
+pub const RELEASE_DOWNLOAD_URL: &str = "https://github.com/{repo}/releases/latest/download/{file}";
 
 /// Filename of the release manifest.
 pub const MANIFEST_FILENAME: &str = "manifest.json";

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -14,6 +14,9 @@ pub const MANIFEST_FILENAME: &str = "manifest.json";
 /// Temporary file suffix used during extraction.
 pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
 
+/// Maximum manifest response size in bytes (1 MiB).
+pub const MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
+
 /// HTTP connect timeout in seconds for update requests.
 pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -1,0 +1,28 @@
+//! Constants for the update command.
+
+/// GitHub repository used for release downloads.
+pub const GITHUB_REPO: &str = "tphakala/birda";
+
+/// URL pattern for downloading from the latest GitHub release.
+/// The `{repo}` placeholder is replaced with `GITHUB_REPO`.
+/// The `{file}` placeholder is replaced with the asset filename.
+pub const RELEASE_DOWNLOAD_URL: &str =
+    "https://github.com/{repo}/releases/latest/download/{file}";
+
+/// Filename of the release manifest.
+pub const MANIFEST_FILENAME: &str = "manifest.json";
+
+/// Temporary file suffix used during extraction.
+pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
+
+/// Backup file extension for the old binary on Unix.
+pub const BACKUP_EXTENSION: &str = ".old";
+
+/// Embedded ONNX Runtime version from build time.
+pub const BUILT_ONNXRUNTIME_VERSION: &str = env!("BIRDA_ONNXRUNTIME_VERSION");
+
+/// Embedded CUDA toolkit version from build time.
+pub const BUILT_CUDA_TOOLKIT_VERSION: &str = env!("BIRDA_CUDA_TOOLKIT_VERSION");
+
+/// Embedded cuDNN version from build time.
+pub const BUILT_CUDNN_VERSION: &str = env!("BIRDA_CUDNN_VERSION");

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -78,6 +78,15 @@ pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
         });
     }
 
+    // Guard against oversized responses (manifest should be < 1 MiB)
+    if let Some(len) = response.content_length()
+        && len > super::constants::MANIFEST_MAX_BYTES
+    {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("manifest too large: {len} bytes"),
+        });
+    }
+
     let bytes = response
         .bytes()
         .await

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -136,7 +136,7 @@ mod tests {
             }
         }"#;
 
-        let manifest = Manifest::from_json(json).unwrap();
+        let manifest = Manifest::from_json(json).expect("test manifest should parse");
         assert_eq!(manifest.version, "1.9.0");
         assert_eq!(manifest.dependencies.onnxruntime, "1.24.2");
         assert_eq!(manifest.cuda.cuda_toolkit, "12.9");

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -94,6 +94,13 @@ pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
             reason: format!("failed to read response body: {e}"),
         })?;
 
+    // Also check actual body size (Content-Length can be omitted or spoofed)
+    if bytes.len() as u64 > super::constants::MANIFEST_MAX_BYTES {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("manifest too large: {} bytes", bytes.len()),
+        });
+    }
+
     Manifest::from_json(&bytes)
 }
 

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -44,8 +44,8 @@ pub struct Manifest {
     pub assets: Assets,
     /// Library dependency versions.
     pub dependencies: Dependencies,
-    /// CUDA-specific versions.
-    pub cuda: CudaVersions,
+    /// CUDA-specific versions (absent for CPU-only manifests).
+    pub cuda: Option<CudaVersions>,
 }
 
 impl Manifest {
@@ -139,8 +139,9 @@ mod tests {
         let manifest = Manifest::from_json(json).expect("test manifest should parse");
         assert_eq!(manifest.version, "1.9.0");
         assert_eq!(manifest.dependencies.onnxruntime, "1.24.2");
-        assert_eq!(manifest.cuda.cuda_toolkit, "12.9");
-        assert_eq!(manifest.cuda.cudnn, "9.17.1.4");
+        let cuda = manifest.cuda.expect("cuda should be present");
+        assert_eq!(cuda.cuda_toolkit, "12.9");
+        assert_eq!(cuda.cudnn, "9.17.1.4");
         assert_eq!(manifest.assets.bin.len(), 2);
 
         let linux = &manifest.assets.bin["linux-x64"];

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -1,1 +1,144 @@
 //! Release manifest fetching and parsing.
+
+use crate::error::{Error, Result};
+use serde::Deserialize;
+
+/// A binary asset entry in the release manifest.
+#[derive(Debug, Deserialize)]
+pub struct BinAsset {
+    /// Filename of the archive (e.g., `birda-linux-x64-bin-v1.9.0.tar.gz`).
+    pub file: String,
+    /// SHA256 hex digest of the archive.
+    pub sha256: String,
+}
+
+/// Dependencies section of the release manifest.
+#[derive(Debug, Deserialize)]
+pub struct Dependencies {
+    /// Required ONNX Runtime version.
+    pub onnxruntime: String,
+}
+
+/// CUDA-specific version requirements.
+#[derive(Debug, Deserialize)]
+pub struct CudaVersions {
+    /// Required CUDA toolkit version.
+    pub cuda_toolkit: String,
+    /// Required cuDNN version.
+    pub cudnn: String,
+}
+
+/// Asset collections in the manifest.
+#[derive(Debug, Deserialize)]
+pub struct Assets {
+    /// Binary-only archives keyed by platform (e.g., "linux-x64", "linux-x64-cuda").
+    pub bin: std::collections::HashMap<String, BinAsset>,
+}
+
+/// Release manifest fetched from GitHub.
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    /// Release version (semver, e.g., "1.9.0").
+    pub version: String,
+    /// Available assets.
+    pub assets: Assets,
+    /// Library dependency versions.
+    pub dependencies: Dependencies,
+    /// CUDA-specific versions.
+    pub cuda: CudaVersions,
+}
+
+impl Manifest {
+    /// Parse a manifest from JSON bytes.
+    pub fn from_json(json: &[u8]) -> Result<Self> {
+        serde_json::from_slice(json).map_err(|source| Error::UpdateManifestParse { source })
+    }
+}
+
+/// Fetch the release manifest from GitHub.
+///
+/// Downloads `manifest.json` from the latest release using the direct
+/// download URL (no GitHub API needed, avoids rate limits).
+pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
+    let url = super::constants::RELEASE_DOWNLOAD_URL
+        .replace("{repo}", super::constants::GITHUB_REPO)
+        .replace("{file}", super::constants::MANIFEST_FILENAME);
+
+    let response = client.get(&url).send().await.map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("HTTP request failed: {e}"),
+        }
+    })?;
+
+    if !response.status().is_success() {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("HTTP {}", response.status()),
+        });
+    }
+
+    let bytes = response.bytes().await.map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("failed to read response body: {e}"),
+        }
+    })?;
+
+    Manifest::from_json(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_manifest() {
+        let json = br#"{
+            "version": "1.9.0",
+            "min_gui_version": "1.1.0",
+            "assets": {
+                "bin": {
+                    "linux-x64": {
+                        "file": "birda-linux-x64-bin-v1.9.0.tar.gz",
+                        "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                    },
+                    "linux-x64-cuda": {
+                        "file": "birda-linux-x64-cuda-bin-v1.9.0.tar.gz",
+                        "sha256": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                    }
+                },
+                "embed": {},
+                "cuda_libs": {}
+            },
+            "dependencies": {
+                "onnxruntime": "1.24.2"
+            },
+            "cuda": {
+                "cuda_toolkit": "12.9",
+                "cudnn": "9.17.1.4"
+            }
+        }"#;
+
+        let manifest = Manifest::from_json(json).unwrap();
+        assert_eq!(manifest.version, "1.9.0");
+        assert_eq!(manifest.dependencies.onnxruntime, "1.24.2");
+        assert_eq!(manifest.cuda.cuda_toolkit, "12.9");
+        assert_eq!(manifest.cuda.cudnn, "9.17.1.4");
+        assert_eq!(manifest.assets.bin.len(), 2);
+
+        let linux = &manifest.assets.bin["linux-x64"];
+        assert_eq!(linux.file, "birda-linux-x64-bin-v1.9.0.tar.gz");
+        assert_eq!(linux.sha256.len(), 64);
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let result = Manifest::from_json(b"not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_missing_required_fields() {
+        let json = br#"{"version": "1.0.0"}"#;
+        let result = Manifest::from_json(json);
+        assert!(result.is_err());
+    }
+}

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -1,0 +1,1 @@
+//! Release manifest fetching and parsing.

--- a/src/update/manifest.rs
+++ b/src/update/manifest.rs
@@ -64,11 +64,13 @@ pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
         .replace("{repo}", super::constants::GITHUB_REPO)
         .replace("{file}", super::constants::MANIFEST_FILENAME);
 
-    let response = client.get(&url).send().await.map_err(|e| {
-        Error::UpdateFetchFailed {
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| Error::UpdateFetchFailed {
             reason: format!("HTTP request failed: {e}"),
-        }
-    })?;
+        })?;
 
     if !response.status().is_success() {
         return Err(Error::UpdateFetchFailed {
@@ -76,11 +78,12 @@ pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
         });
     }
 
-    let bytes = response.bytes().await.map_err(|e| {
-        Error::UpdateFetchFailed {
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| Error::UpdateFetchFailed {
             reason: format!("failed to read response body: {e}"),
-        }
-    })?;
+        })?;
 
     Manifest::from_json(&bytes)
 }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -355,6 +355,12 @@ fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
 
+        // Skip non-file entries (directories, symlinks) to avoid extracting
+        // a directory named "birda" as a 0-byte file
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
         if filename == binary_name {
             let mut output = std::fs::File::create(dest).map_err(Error::Io)?;
             std::io::copy(&mut entry, &mut output).map_err(|e| Error::UpdateExtractFailed {
@@ -384,6 +390,11 @@ fn extract_zip(archive_path: &Path, dest: &Path) -> Result<()> {
             .map_err(|e| Error::UpdateExtractFailed {
                 reason: format!("failed to read zip entry: {e}"),
             })?;
+
+        // Skip directories
+        if entry.is_dir() {
+            continue;
+        }
 
         let path = entry
             .enclosed_name()

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -1,0 +1,10 @@
+//! Self-update functionality for birda.
+//!
+//! Downloads and installs new releases from GitHub, replacing only the binary.
+//! Warns when CUDA or ONNX Runtime library versions change between releases.
+
+pub mod checksum;
+pub mod constants;
+pub mod manifest;
+pub mod platform;
+pub mod replace;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -116,7 +116,13 @@ pub async fn perform_update(
     // 5. Check write permissions
     replace::check_write_permission(&exe_path)?;
 
-    // 6. Download the archive
+    // 6. Validate asset filename and download the archive
+    if asset.file.contains('/') || asset.file.contains('\\') || asset.file.contains("..") {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("invalid asset filename: {}", asset.file),
+        });
+    }
+
     let download_url = RELEASE_DOWNLOAD_URL
         .replace("{repo}", GITHUB_REPO)
         .replace("{file}", &asset.file);

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -216,18 +216,21 @@ fn check_library_versions(manifest: &Manifest) -> Result<Vec<String>> {
         });
     }
 
-    // CUDA checks only for CUDA builds
-    if cfg!(feature = "cuda") && BUILT_CUDA_TOOLKIT_VERSION != "unknown" {
-        if manifest.cuda.cuda_toolkit != BUILT_CUDA_TOOLKIT_VERSION {
+    // CUDA checks only for CUDA builds when manifest includes CUDA info
+    if cfg!(feature = "cuda")
+        && BUILT_CUDA_TOOLKIT_VERSION != "unknown"
+        && let Some(cuda) = &manifest.cuda
+    {
+        if cuda.cuda_toolkit != BUILT_CUDA_TOOLKIT_VERSION {
             warnings.push(format!(
                 "CUDA toolkit requirement changed ({} -> {}). If you use GPU acceleration, you may need to update your CUDA installation.",
-                BUILT_CUDA_TOOLKIT_VERSION, manifest.cuda.cuda_toolkit,
+                BUILT_CUDA_TOOLKIT_VERSION, cuda.cuda_toolkit,
             ));
         }
-        if manifest.cuda.cudnn != BUILT_CUDNN_VERSION {
+        if cuda.cudnn != BUILT_CUDNN_VERSION {
             warnings.push(format!(
                 "cuDNN requirement changed ({} -> {}). If you use GPU acceleration, you may need to update cuDNN.",
-                BUILT_CUDNN_VERSION, manifest.cuda.cudnn,
+                BUILT_CUDNN_VERSION, cuda.cudnn,
             ));
         }
     }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -134,7 +134,12 @@ pub async fn perform_update(
         })?;
 
     let archive_path = parent_dir.join(format!("{}.download", asset.file));
-    download_with_progress(client, &download_url, &archive_path, &manifest.version).await?;
+    if let Err(e) =
+        download_with_progress(client, &download_url, &archive_path, &manifest.version).await
+    {
+        let _ = std::fs::remove_file(&archive_path);
+        return Err(e);
+    }
 
     // 7. Verify checksum
     info!("Verifying checksum...");
@@ -156,7 +161,10 @@ pub async fn perform_update(
     let _ = std::fs::remove_file(&archive_path);
 
     // 9. Set executable permissions (Unix)
-    replace::set_executable(&temp_binary)?;
+    if let Err(e) = replace::set_executable(&temp_binary) {
+        let _ = std::fs::remove_file(&temp_binary);
+        return Err(e);
+    }
 
     // 10. Replace binary
     let backup_kept = match replace::replace_binary(&exe_path, &temp_binary) {

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -3,11 +3,11 @@
 //! Downloads and installs new releases from GitHub, replacing only the binary.
 //! Warns when CUDA or ONNX Runtime library versions change between releases.
 
-pub mod checksum;
+mod checksum;
 pub mod constants;
 pub mod manifest;
-pub mod platform;
-pub mod replace;
+mod platform;
+mod replace;
 
 use crate::error::{Error, Result};
 use constants::{

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -237,16 +237,17 @@ fn check_library_versions(manifest: &Manifest) -> Result<Vec<String>> {
 
 /// Check if the ONNX Runtime major.minor version has changed.
 fn ort_major_minor_changed(current: &str, required: &str) -> bool {
-    let current_parts: Vec<&str> = current.split('.').collect();
-    let required_parts: Vec<&str> = required.split('.').collect();
-
-    if current_parts.len() < 2 || required_parts.len() < 2 {
-        // Can't parse; assume changed to be safe
+    let Ok(current_ver) = semver::Version::parse(current) else {
+        // Can't parse; assume changed to be safe if strings differ
         return current != required;
-    }
+    };
+    let Ok(required_ver) = semver::Version::parse(required) else {
+        // Can't parse; assume changed to be safe if strings differ
+        return current != required;
+    };
 
     // Compare major.minor only
-    current_parts[0] != required_parts[0] || current_parts[1] != required_parts[1]
+    current_ver.major != required_ver.major || current_ver.minor != required_ver.minor
 }
 
 /// Download a file with a progress bar.
@@ -340,13 +341,14 @@ fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
             reason: format!("failed to read entry path: {e}"),
         })?;
 
-        // Security: reject entries with path traversal
-        if path
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
+        // Security: reject entries with path traversal or absolute paths
+        if path.is_absolute()
+            || path
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
         {
             return Err(Error::UpdateExtractFailed {
-                reason: "archive contains path traversal entry".to_string(),
+                reason: "archive contains an unsafe path entry".to_string(),
             });
         }
 

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -8,3 +8,421 @@ pub mod constants;
 pub mod manifest;
 pub mod platform;
 pub mod replace;
+
+use crate::error::{Error, Result};
+use constants::{
+    BUILT_CUDA_TOOLKIT_VERSION, BUILT_CUDNN_VERSION, BUILT_ONNXRUNTIME_VERSION, GITHUB_REPO,
+    RELEASE_DOWNLOAD_URL, UPDATE_TEMP_SUFFIX,
+};
+use indicatif::{ProgressBar, ProgressStyle};
+use manifest::Manifest;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info};
+
+/// Result of a version check.
+pub enum UpdateCheck {
+    /// Already running the latest version.
+    UpToDate {
+        /// Current version string.
+        version: String,
+    },
+    /// A newer version is available.
+    Available {
+        /// Current version string.
+        current: String,
+        /// Available version string.
+        available: String,
+        /// The fetched manifest.
+        manifest: Manifest,
+    },
+}
+
+/// Result of performing an update.
+pub struct UpdateResult {
+    /// Previous version.
+    pub old_version: String,
+    /// New version.
+    pub new_version: String,
+    /// Whether a backup of the old binary was kept.
+    pub backup_kept: bool,
+    /// Path to the backup file (if kept).
+    pub backup_path: Option<PathBuf>,
+    /// Warnings about library version changes.
+    pub warnings: Vec<String>,
+}
+
+/// Check if an update is available.
+///
+/// Fetches the manifest from the latest GitHub release and compares
+/// versions using semver.
+pub async fn check_for_update(client: &reqwest::Client) -> Result<UpdateCheck> {
+    let manifest = manifest::fetch_manifest(client).await?;
+
+    let current =
+        semver::Version::parse(env!("CARGO_PKG_VERSION")).map_err(|e| Error::Internal {
+            message: format!("failed to parse current version: {e}"),
+        })?;
+
+    let remote =
+        semver::Version::parse(&manifest.version).map_err(|e| Error::UpdateFetchFailed {
+            reason: format!(
+                "manifest contains invalid version '{}': {e}",
+                manifest.version
+            ),
+        })?;
+
+    if current >= remote {
+        Ok(UpdateCheck::UpToDate {
+            version: current.to_string(),
+        })
+    } else {
+        Ok(UpdateCheck::Available {
+            current: current.to_string(),
+            available: remote.to_string(),
+            manifest,
+        })
+    }
+}
+
+/// Perform the full update: download, verify, extract, and replace.
+pub async fn perform_update(
+    client: &reqwest::Client,
+    manifest: &Manifest,
+    current_version: &str,
+) -> Result<UpdateResult> {
+    // 1. Resolve current exe path
+    let exe_path = std::env::current_exe().map_err(|source| Error::UpdateExeNotFound { source })?;
+    let exe_path = exe_path.canonicalize().unwrap_or_else(|_| exe_path.clone());
+
+    // 2. Dev build guard
+    if replace::is_dev_build(&exe_path) {
+        return Err(Error::UpdateDevBuild);
+    }
+
+    // 3. Check library version compatibility
+    let warnings = check_library_versions(manifest)?;
+
+    // 4. Select the right asset
+    let platform_key = platform::asset_key();
+    let asset =
+        manifest
+            .assets
+            .bin
+            .get(platform_key)
+            .ok_or_else(|| Error::UpdateUnsupportedPlatform {
+                platform: platform_key.to_string(),
+            })?;
+
+    // 5. Check write permissions
+    replace::check_write_permission(&exe_path)?;
+
+    // 6. Download the archive
+    let download_url = RELEASE_DOWNLOAD_URL
+        .replace("{repo}", GITHUB_REPO)
+        .replace("{file}", &asset.file);
+
+    let parent_dir = exe_path
+        .parent()
+        .ok_or_else(|| Error::UpdateReplaceFailed {
+            reason: "cannot determine parent directory of current binary".to_string(),
+        })?;
+
+    let archive_path = parent_dir.join(format!("{}.download", asset.file));
+    download_with_progress(client, &download_url, &archive_path, &manifest.version).await?;
+
+    // 7. Verify checksum
+    info!("Verifying checksum...");
+    if let Err(e) = checksum::verify_sha256(&archive_path, &asset.sha256) {
+        // Clean up on failure
+        let _ = std::fs::remove_file(&archive_path);
+        return Err(e);
+    }
+
+    // 8. Extract to temp file in same directory (avoids EXDEV)
+    let temp_binary = parent_dir.join(UPDATE_TEMP_SUFFIX);
+    if let Err(e) = extract_binary(&archive_path, &temp_binary) {
+        let _ = std::fs::remove_file(&archive_path);
+        let _ = std::fs::remove_file(&temp_binary);
+        return Err(e);
+    }
+
+    // Clean up the archive
+    let _ = std::fs::remove_file(&archive_path);
+
+    // 9. Set executable permissions (Unix)
+    replace::set_executable(&temp_binary)?;
+
+    // 10. Replace binary
+    let backup_kept = match replace::replace_binary(&exe_path, &temp_binary) {
+        Ok(kept) => kept,
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_binary);
+            return Err(e);
+        }
+    };
+
+    let backup_path = if backup_kept {
+        Some(exe_path.with_extension("old"))
+    } else {
+        None
+    };
+
+    Ok(UpdateResult {
+        old_version: current_version.to_string(),
+        new_version: manifest.version.clone(),
+        backup_kept,
+        backup_path,
+        warnings,
+    })
+}
+
+/// Check library versions and return warnings or block the update.
+///
+/// Blocks (returns `Err`) if ONNX Runtime major.minor changed.
+/// Returns warnings (`Vec<String>`) for CUDA/cuDNN changes.
+fn check_library_versions(manifest: &Manifest) -> Result<Vec<String>> {
+    let mut warnings = Vec::new();
+
+    // Skip all checks for dev builds (versions are "unknown")
+    if BUILT_ONNXRUNTIME_VERSION == "unknown" {
+        debug!("dev build detected, skipping library version checks");
+        return Ok(warnings);
+    }
+
+    // ONNX Runtime: block on major.minor change (ABI break)
+    if ort_major_minor_changed(
+        BUILT_ONNXRUNTIME_VERSION,
+        &manifest.dependencies.onnxruntime,
+    ) {
+        let tag = format!("v{}", manifest.version);
+        return Err(Error::UpdateBlocked {
+            current: BUILT_ONNXRUNTIME_VERSION.to_string(),
+            required: manifest.dependencies.onnxruntime.clone(),
+            release_url: format!("https://github.com/{GITHUB_REPO}/releases/tag/{tag}"),
+        });
+    }
+
+    // CUDA checks only for CUDA builds
+    if cfg!(feature = "cuda") && BUILT_CUDA_TOOLKIT_VERSION != "unknown" {
+        if manifest.cuda.cuda_toolkit != BUILT_CUDA_TOOLKIT_VERSION {
+            warnings.push(format!(
+                "CUDA toolkit requirement changed ({} -> {}). If you use GPU acceleration, you may need to update your CUDA installation.",
+                BUILT_CUDA_TOOLKIT_VERSION, manifest.cuda.cuda_toolkit,
+            ));
+        }
+        if manifest.cuda.cudnn != BUILT_CUDNN_VERSION {
+            warnings.push(format!(
+                "cuDNN requirement changed ({} -> {}). If you use GPU acceleration, you may need to update cuDNN.",
+                BUILT_CUDNN_VERSION, manifest.cuda.cudnn,
+            ));
+        }
+    }
+
+    Ok(warnings)
+}
+
+/// Check if the ONNX Runtime major.minor version has changed.
+fn ort_major_minor_changed(current: &str, required: &str) -> bool {
+    let current_parts: Vec<&str> = current.split('.').collect();
+    let required_parts: Vec<&str> = required.split('.').collect();
+
+    if current_parts.len() < 2 || required_parts.len() < 2 {
+        // Can't parse; assume changed to be safe
+        return current != required;
+    }
+
+    // Compare major.minor only
+    current_parts[0] != required_parts[0] || current_parts[1] != required_parts[1]
+}
+
+/// Download a file with a progress bar.
+async fn download_with_progress(
+    client: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    version: &str,
+) -> Result<()> {
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| Error::UpdateFetchFailed {
+            reason: format!("download failed: {e}"),
+        })?;
+
+    if !response.status().is_success() {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("HTTP {} downloading {url}", response.status()),
+        });
+    }
+
+    let total_size = response.content_length().unwrap_or(0);
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{msg}\n{bar:40.cyan/blue} {percent}% ({bytes}/{total_bytes})")
+            .map_err(|e| Error::Internal {
+                message: format!("progress bar template error: {e}"),
+            })?
+            .progress_chars("##-"),
+    );
+    pb.set_message(format!("Downloading birda v{version}..."));
+
+    let mut file = tokio::fs::File::create(dest).await.map_err(Error::Io)?;
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| Error::UpdateFetchFailed {
+            reason: format!("download stream error: {e}"),
+        })?;
+        file.write_all(&chunk).await.map_err(Error::Io)?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    file.flush().await.map_err(Error::Io)?;
+    pb.finish_and_clear();
+
+    Ok(())
+}
+
+/// Extract the binary from a downloaded archive.
+fn extract_binary(archive_path: &Path, dest: &Path) -> Result<()> {
+    let archive_name = archive_path.to_string_lossy();
+
+    if archive_name.ends_with(".tar.gz.download") || archive_name.ends_with(".tar.gz") {
+        extract_tar_gz(archive_path, dest)
+    } else if archive_name.ends_with(".zip.download") || archive_name.ends_with(".zip") {
+        extract_zip(archive_path, dest)
+    } else {
+        Err(Error::UpdateExtractFailed {
+            reason: format!("unknown archive format: {}", archive_path.display()),
+        })
+    }
+}
+
+/// Extract the binary from a `.tar.gz` archive.
+fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    let file = std::fs::File::open(archive_path).map_err(Error::Io)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+
+    let binary_name = platform::binary_name();
+
+    for entry in archive.entries().map_err(|e| Error::UpdateExtractFailed {
+        reason: format!("failed to read archive entries: {e}"),
+    })? {
+        let mut entry = entry.map_err(|e| Error::UpdateExtractFailed {
+            reason: format!("failed to read archive entry: {e}"),
+        })?;
+
+        let path = entry.path().map_err(|e| Error::UpdateExtractFailed {
+            reason: format!("failed to read entry path: {e}"),
+        })?;
+
+        // Security: reject entries with path traversal
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(Error::UpdateExtractFailed {
+                reason: "archive contains path traversal entry".to_string(),
+            });
+        }
+
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if filename == binary_name {
+            let mut output = std::fs::File::create(dest).map_err(Error::Io)?;
+            std::io::copy(&mut entry, &mut output).map_err(|e| Error::UpdateExtractFailed {
+                reason: format!("failed to extract binary: {e}"),
+            })?;
+            return Ok(());
+        }
+    }
+
+    Err(Error::UpdateExtractFailed {
+        reason: format!("binary '{binary_name}' not found in archive"),
+    })
+}
+
+/// Extract the binary from a `.zip` archive.
+fn extract_zip(archive_path: &Path, dest: &Path) -> Result<()> {
+    let file = std::fs::File::open(archive_path).map_err(Error::Io)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| Error::UpdateExtractFailed {
+        reason: format!("failed to open zip archive: {e}"),
+    })?;
+
+    let binary_name = platform::binary_name();
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| Error::UpdateExtractFailed {
+                reason: format!("failed to read zip entry: {e}"),
+            })?;
+
+        let path = entry
+            .enclosed_name()
+            .ok_or_else(|| Error::UpdateExtractFailed {
+                reason: "zip entry has unsafe path".to_string(),
+            })?;
+
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if filename == binary_name {
+            let mut output = std::fs::File::create(dest).map_err(Error::Io)?;
+            std::io::copy(&mut entry, &mut output).map_err(|e| Error::UpdateExtractFailed {
+                reason: format!("failed to extract binary: {e}"),
+            })?;
+            return Ok(());
+        }
+    }
+
+    Err(Error::UpdateExtractFailed {
+        reason: format!("binary '{binary_name}' not found in zip archive"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ort_major_minor_changed_same() {
+        assert!(!ort_major_minor_changed("1.24.2", "1.24.3"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_minor_bump() {
+        assert!(ort_major_minor_changed("1.24.2", "1.25.0"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_major_bump() {
+        assert!(ort_major_minor_changed("1.24.2", "2.0.0"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_same_short() {
+        assert!(!ort_major_minor_changed("1.24", "1.24"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_unparseable() {
+        // Single segment can't be split; falls back to string comparison
+        assert!(ort_major_minor_changed("unknown", "1.24.2"));
+    }
+}

--- a/src/update/platform.rs
+++ b/src/update/platform.rs
@@ -48,18 +48,6 @@ fn platform_base() -> &'static str {
     }
 }
 
-/// Returns the archive extension for the current platform.
-pub fn archive_extension() -> &'static str {
-    #[cfg(target_os = "windows")]
-    {
-        "zip"
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        "tar.gz"
-    }
-}
-
 /// Returns the binary filename for the current platform.
 pub fn binary_name() -> &'static str {
     #[cfg(target_os = "windows")]
@@ -87,16 +75,6 @@ mod tests {
         let base = platform_base();
         let valid = ["linux-x64", "windows-x64", "macos-arm64"];
         assert!(valid.contains(&base), "unexpected platform: {base}");
-    }
-
-    #[test]
-    fn test_archive_extension_matches_platform() {
-        let ext = archive_extension();
-        if cfg!(target_os = "windows") {
-            assert_eq!(ext, "zip");
-        } else {
-            assert_eq!(ext, "tar.gz");
-        }
     }
 
     #[test]

--- a/src/update/platform.rs
+++ b/src/update/platform.rs
@@ -42,7 +42,9 @@ fn platform_base() -> &'static str {
         all(target_os = "macos", target_arch = "aarch64"),
     )))]
     {
-        compile_error!("Unsupported platform for birda update. Supported: linux-x64, windows-x64, macos-arm64");
+        compile_error!(
+            "Unsupported platform for birda update. Supported: linux-x64, windows-x64, macos-arm64"
+        );
     }
 }
 

--- a/src/update/platform.rs
+++ b/src/update/platform.rs
@@ -1,0 +1,1 @@
+//! Platform and build variant detection for asset selection.

--- a/src/update/platform.rs
+++ b/src/update/platform.rs
@@ -1,1 +1,109 @@
 //! Platform and build variant detection for asset selection.
+//!
+//! Determines the correct manifest asset key based on the compile-time
+//! target OS, architecture, and cargo features.
+
+/// Returns the manifest asset key for the current platform and build variant.
+///
+/// Examples: `"linux-x64"`, `"linux-x64-cuda"`, `"windows-x64"`, `"macos-arm64"`.
+pub fn asset_key() -> &'static str {
+    let base = platform_base();
+
+    if cfg!(feature = "cuda") {
+        // CUDA builds have a separate key (only linux-x64 and windows-x64)
+        match base {
+            "linux-x64" => "linux-x64-cuda",
+            "windows-x64" => "windows-x64-cuda",
+            // macOS doesn't have CUDA builds; fall back to non-CUDA
+            _ => base,
+        }
+    } else {
+        base
+    }
+}
+
+/// Returns the base platform identifier without variant suffix.
+fn platform_base() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "linux-x64"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "windows-x64"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "macos-arm64"
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    {
+        compile_error!("Unsupported platform for birda update. Supported: linux-x64, windows-x64, macos-arm64");
+    }
+}
+
+/// Returns the archive extension for the current platform.
+pub fn archive_extension() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "zip"
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "tar.gz"
+    }
+}
+
+/// Returns the binary filename for the current platform.
+pub fn binary_name() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "birda.exe"
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "birda"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asset_key_is_not_empty() {
+        let key = asset_key();
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn test_platform_base_matches_expected() {
+        let base = platform_base();
+        let valid = ["linux-x64", "windows-x64", "macos-arm64"];
+        assert!(valid.contains(&base), "unexpected platform: {base}");
+    }
+
+    #[test]
+    fn test_archive_extension_matches_platform() {
+        let ext = archive_extension();
+        if cfg!(target_os = "windows") {
+            assert_eq!(ext, "zip");
+        } else {
+            assert_eq!(ext, "tar.gz");
+        }
+    }
+
+    #[test]
+    fn test_binary_name_matches_platform() {
+        let name = binary_name();
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "birda.exe");
+        } else {
+            assert_eq!(name, "birda");
+        }
+    }
+}

--- a/src/update/replace.rs
+++ b/src/update/replace.rs
@@ -10,12 +10,14 @@ use tracing::debug;
 /// Check that the parent directory of the current binary is writable.
 #[allow(unsafe_code)]
 pub fn check_write_permission(exe_path: &Path) -> Result<()> {
-    let parent = exe_path.parent().ok_or_else(|| Error::UpdateReplaceFailed {
-        reason: format!(
-            "cannot determine parent directory of '{}'",
-            exe_path.display()
-        ),
-    })?;
+    let parent = exe_path
+        .parent()
+        .ok_or_else(|| Error::UpdateReplaceFailed {
+            reason: format!(
+                "cannot determine parent directory of '{}'",
+                exe_path.display()
+            ),
+        })?;
 
     let metadata = std::fs::metadata(parent).map_err(|e| Error::UpdateReplaceFailed {
         reason: format!("cannot read metadata of '{}': {e}", parent.display()),

--- a/src/update/replace.rs
+++ b/src/update/replace.rs
@@ -1,0 +1,1 @@
+//! Binary self-replacement logic.

--- a/src/update/replace.rs
+++ b/src/update/replace.rs
@@ -1,1 +1,194 @@
 //! Binary self-replacement logic.
+//!
+//! On Unix: rename current binary to `.old`, move new binary into place.
+//! On Windows: use `self_replace` crate to handle locked-binary replacement.
+
+use crate::error::{Error, Result};
+use std::path::Path;
+use tracing::debug;
+
+/// Check that the parent directory of the current binary is writable.
+#[allow(unsafe_code)]
+pub fn check_write_permission(exe_path: &Path) -> Result<()> {
+    let parent = exe_path.parent().ok_or_else(|| Error::UpdateReplaceFailed {
+        reason: format!(
+            "cannot determine parent directory of '{}'",
+            exe_path.display()
+        ),
+    })?;
+
+    let metadata = std::fs::metadata(parent).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("cannot read metadata of '{}': {e}", parent.display()),
+    })?;
+
+    if metadata.permissions().readonly() {
+        return Err(Error::UpdatePermissionDenied {
+            path: parent.to_path_buf(),
+        });
+    }
+
+    // On Unix, also check the actual write bits for the current user
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        // SAFETY: getuid() and getgid() are simple syscalls with no invariants to uphold.
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let file_uid = metadata.uid();
+        let file_gid = metadata.gid();
+
+        let writable = if uid == 0 {
+            true // root can write anywhere
+        } else if uid == file_uid {
+            mode & 0o200 != 0 // owner write
+        } else if gid == file_gid {
+            mode & 0o020 != 0 // group write
+        } else {
+            mode & 0o002 != 0 // other write
+        };
+
+        if !writable {
+            return Err(Error::UpdatePermissionDenied {
+                path: parent.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if the binary appears to be a development build (inside a cargo target/ directory).
+pub fn is_dev_build(exe_path: &Path) -> bool {
+    let path_str = exe_path.to_string_lossy();
+    path_str.contains("/target/") || path_str.contains("\\target\\")
+}
+
+/// Set executable permissions on a file (Unix only, no-op on Windows).
+#[cfg(unix)]
+pub fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(path, perms).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!(
+            "failed to set executable permissions on '{}': {e}",
+            path.display()
+        ),
+    })
+}
+
+/// Set executable permissions on a file (Unix only, no-op on Windows).
+#[cfg(not(unix))]
+pub fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Replace the current binary with a new one.
+///
+/// On Unix: renames current to `.old`, moves new into place. If the second
+/// rename fails, attempts to restore the original.
+///
+/// On Windows: uses `self_replace` crate.
+///
+/// Returns `true` if a `.old` backup was kept (Unix), `false` otherwise (Windows).
+pub fn replace_binary(exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    #[cfg(unix)]
+    {
+        replace_unix(exe_path, new_binary_path)
+    }
+    #[cfg(windows)]
+    {
+        replace_windows(exe_path, new_binary_path)
+    }
+}
+
+#[cfg(unix)]
+fn replace_unix(exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    let backup_path = exe_path.with_extension("old");
+
+    debug!(
+        "renaming {} -> {}",
+        exe_path.display(),
+        backup_path.display()
+    );
+    std::fs::rename(exe_path, &backup_path).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!(
+            "failed to rename '{}' to '{}': {e}",
+            exe_path.display(),
+            backup_path.display()
+        ),
+    })?;
+
+    debug!(
+        "renaming {} -> {}",
+        new_binary_path.display(),
+        exe_path.display()
+    );
+    if let Err(e) = std::fs::rename(new_binary_path, exe_path) {
+        // Rollback: restore the original
+        debug!("second rename failed, rolling back");
+        if let Err(rollback_err) = std::fs::rename(&backup_path, exe_path) {
+            return Err(Error::UpdateReplaceFailed {
+                reason: format!(
+                    "failed to install new binary AND failed to restore backup: install error: {e}, rollback error: {rollback_err}"
+                ),
+            });
+        }
+        return Err(Error::UpdateReplaceFailed {
+            reason: format!(
+                "failed to rename '{}' to '{}': {e}",
+                new_binary_path.display(),
+                exe_path.display()
+            ),
+        });
+    }
+
+    Ok(true) // backup kept
+}
+
+#[cfg(windows)]
+fn replace_windows(_exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    self_replace::self_replace(new_binary_path).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("self_replace failed: {e}"),
+    })?;
+
+    // Clean up the temp file
+    let _ = std::fs::remove_file(new_binary_path);
+
+    Ok(false) // no backup on Windows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_dev_build_detects_target_dir() {
+        assert!(is_dev_build(Path::new(
+            "/home/user/project/target/release/birda"
+        )));
+        assert!(is_dev_build(Path::new(
+            "/home/user/project/target/debug/birda"
+        )));
+    }
+
+    #[test]
+    fn test_is_dev_build_false_for_install_paths() {
+        assert!(!is_dev_build(Path::new("/usr/local/bin/birda")));
+        assert!(!is_dev_build(Path::new("/home/user/.local/bin/birda")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_set_executable_on_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-bin");
+        std::fs::write(&path, b"fake binary").unwrap();
+        set_executable(&path).unwrap();
+
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+}

--- a/src/update/replace.rs
+++ b/src/update/replace.rs
@@ -184,13 +184,16 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_set_executable_on_temp_file() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
         let path = dir.path().join("test-bin");
-        std::fs::write(&path, b"fake binary").unwrap();
-        set_executable(&path).unwrap();
+        std::fs::write(&path, b"fake binary").expect("failed to write test file");
+        set_executable(&path).expect("set_executable should succeed");
 
         use std::os::unix::fs::PermissionsExt;
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        let mode = std::fs::metadata(&path)
+            .expect("failed to read metadata")
+            .permissions()
+            .mode();
         assert_eq!(mode & 0o777, 0o755);
     }
 }


### PR DESCRIPTION
## Summary

- Add `birda update` command that checks for new releases on GitHub and self-updates the binary
- `birda update --check` for dry-run version check without installing
- Downloads binary-only archives (small, ~15MB) instead of full release packages
- SHA256 checksum verification on all downloads
- Blocks update when ONNX Runtime ABI changes (major.minor version); warns on CUDA/cuDNN changes
- Keeps previous binary as `birda.old` for manual rollback (Linux/macOS)
- Build-time version embedding via `build.rs` for library compatibility detection
- Platform-specific binary replacement with rollback on failure (Unix rename dance, Windows `self_replace`)
- Dev build guard prevents accidentally overwriting cargo target/ builds
- Updated release workflow to produce binary-only archives with SHA256 checksums
- Enhanced manifest.json with `bin` asset section and `dependencies` field

## New module structure

```
src/update/
  mod.rs         -- orchestration: check_for_update(), perform_update()
  manifest.rs    -- manifest types, fetch from GitHub
  platform.rs    -- platform/variant detection
  checksum.rs    -- SHA256 verification
  replace.rs     -- binary replacement with rollback
  constants.rs   -- URLs, timeouts, build-time versions
```

## Test plan

- [x] 18 unit tests covering manifest parsing, platform detection, checksum verification, version comparison, dev build detection, executable permissions
- [x] `cargo clippy --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --no-default-features` all pass
- [x] `birda update --check` smoke test (fails gracefully on old manifest format, expected until next release)
- [x] `birda update --help` shows correct subcommand
- [ ] Full end-to-end test requires a release with the new manifest format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an update command with a --check flag to preview or apply updates.
  * Supports binary-only downloadable packages for Linux, Windows, and macOS (CPU and CUDA variants).
  * Release process now produces and lists dedicated binary-only archives and includes their SHA256 hashes in the manifest.
  * Verifies SHA256 checksums for downloads and shows progress/status (JSON or human-readable).
  * Performs compatibility checks, extracts only the platform binary, and safely replaces the running executable with optional backup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->