### PR TITLE
feat: add bat detection support with BattyBirdNET classifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,8 +483,6 @@ dependencies = [
 [[package]]
 name = "birdnet-onnx"
 version = "2.0.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268149d2cb6ae88937c89385d6759fe6e06ebaf668622b49770f0353e9896d1c"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "birdnet-onnx"
 version = "2.0.0-rc.13"
-source = "git+https://github.com/tphakala/rust-birdnet-onnx.git?branch=feat%2Fcustom-classifier#651c55d4ccab0c80adb94de8367e836720c0c55d"
+source = "git+https://github.com/tphakala/rust-birdnet-onnx.git#f972a30729665f91b84f1ce87adde6a08770eefe"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
 [[package]]
 name = "birdnet-onnx"
 version = "2.0.0-rc.13"
+source = "git+https://github.com/tphakala/rust-birdnet-onnx.git?branch=feat%2Fcustom-classifier#651c55d4ccab0c80adb94de8367e836720c0c55d"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cuda = ["birdnet-onnx/cuda"]
 load-dynamic = ["birdnet-onnx/load-dynamic"]
 
 [dependencies]
-birdnet-onnx = { version = "2.0.0-rc.13", features = ["load-dynamic"] }
+birdnet-onnx = { path = "../rust-birdnet-onnx", features = ["load-dynamic"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cuda = ["birdnet-onnx/cuda"]
 load-dynamic = ["birdnet-onnx/load-dynamic"]
 
 [dependencies]
-birdnet-onnx = { git = "https://github.com/tphakala/rust-birdnet-onnx.git", branch = "feat/custom-classifier", features = ["load-dynamic"] }
+birdnet-onnx = { git = "https://github.com/tphakala/rust-birdnet-onnx.git", features = ["load-dynamic"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cuda = ["birdnet-onnx/cuda"]
 load-dynamic = ["birdnet-onnx/load-dynamic"]
 
 [dependencies]
-birdnet-onnx = { path = "../rust-birdnet-onnx", features = ["load-dynamic"] }
+birdnet-onnx = { git = "https://github.com/tphakala/rust-birdnet-onnx.git", branch = "feat/custom-classifier", features = ["load-dynamic"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "2.0"

--- a/docs/superpowers/plans/2026-04-06-update-command.md
+++ b/docs/superpowers/plans/2026-04-06-update-command.md
@@ -1,0 +1,1844 @@
+# `birda update` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a self-update command that downloads and installs new birda releases from GitHub.
+
+**Architecture:** Fetch `manifest.json` from latest GitHub release, compare versions via semver, download the binary-only archive for the current platform/variant, verify SHA256, and replace the binary in-place. Block update when ONNX Runtime ABI changes; warn when CUDA/cuDNN requirements change.
+
+**Tech Stack:** Rust, reqwest (HTTP), serde_json (manifest), semver (version comparison), sha2 (checksums), flate2+tar (extraction), self_replace (Windows)
+
+**Spec:** `docs/superpowers/specs/2026-04-06-update-command-design.md`
+
+---
+
+## File Structure
+
+```
+build.rs                              -- NEW: embed ONNXRUNTIME_VERSION, CUDA_TOOLKIT_VERSION, CUDNN_VERSION
+src/update/mod.rs                     -- NEW: public API, orchestration (check_for_update, perform_update)
+src/update/manifest.rs                -- NEW: Manifest struct, fetch, parse
+src/update/platform.rs                -- NEW: asset key selection (target_os/arch/features)
+src/update/checksum.rs                -- NEW: SHA256 verification
+src/update/replace.rs                 -- NEW: binary self-replacement (platform-specific)
+src/update/constants.rs               -- NEW: update-specific constants (URLs, file names)
+src/lib.rs                            -- MODIFY: add `pub mod update;`, wire Update command
+src/cli/args.rs                       -- MODIFY: add Update variant to Command enum
+src/error.rs                          -- MODIFY: add update-related error variants
+Cargo.toml                            -- MODIFY: add dependencies (semver, sha2, tar, zip, self_replace)
+manifest.template.json                -- MODIFY: add `bin` and `dependencies` sections
+.github/workflows/release.yml         -- MODIFY: add binary-only archives + SHA256 computation
+```
+
+---
+
+### Task 1: Add build.rs for compile-time version embedding
+
+**Files:**
+- Create: `build.rs`
+
+- [ ] **Step 1: Create build.rs**
+
+```rust
+//! Build script for birda.
+//!
+//! Embeds library version expectations at compile time so the update command
+//! can detect ABI-breaking changes without a local manifest file.
+
+fn main() {
+    // ONNX Runtime version this binary was built against.
+    // Set by the release workflow; defaults to "unknown" for dev builds.
+    let ort_version =
+        std::env::var("ONNXRUNTIME_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_ONNXRUNTIME_VERSION={ort_version}");
+
+    // CUDA toolkit version expected by this build.
+    let cuda_version =
+        std::env::var("CUDA_TOOLKIT_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDA_TOOLKIT_VERSION={cuda_version}");
+
+    // cuDNN version expected by this build.
+    let cudnn_version = std::env::var("CUDNN_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDNN_VERSION={cudnn_version}");
+
+    // Re-run if these env vars change.
+    println!("cargo:rerun-if-env-changed=ONNXRUNTIME_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDNN_VERSION");
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -5`
+Expected: successful build. The env vars default to "unknown" in dev.
+
+- [ ] **Step 3: Verify the env vars are accessible**
+
+Run: `cargo test --no-default-features --lib -- --ignored 2>&1 | head -5`
+
+This is just a compilation check. We'll add a real test later. For now, verify that adding `build.rs` doesn't break anything:
+
+Run: `cargo clippy --no-default-features -- -D warnings 2>&1 | tail -5`
+Expected: no new warnings
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build.rs
+git commit -m "feat(update): add build.rs for compile-time version embedding"
+```
+
+---
+
+### Task 2: Add new dependencies to Cargo.toml
+
+**Files:**
+- Modify: `Cargo.toml`
+
+- [ ] **Step 1: Add dependencies**
+
+Add these to the `[dependencies]` section in `Cargo.toml`:
+
+```toml
+semver = "1"
+sha2 = "0.10"
+tar = "0.4"
+self_replace = "1"
+```
+
+Note: `flate2` is already a transitive dependency but we need it as a direct dependency:
+
+```toml
+flate2 = "1"
+```
+
+Note: `zip` is only needed on Windows. Add it as a regular dependency (the compiler will dead-code-eliminate it on other platforms, and conditional compilation in replace.rs handles the rest):
+
+```toml
+zip = { version = "2", default-features = false, features = ["deflate"] }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --no-default-features 2>&1 | tail -5`
+Expected: successful check
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "deps: add semver, sha2, tar, flate2, zip, self_replace for update command"
+```
+
+---
+
+### Task 3: Add update error variants
+
+**Files:**
+- Modify: `src/error.rs`
+
+- [ ] **Step 1: Add error variants**
+
+Add these variants to the `Error` enum in `src/error.rs`, before the `#[cfg(test)]` module:
+
+```rust
+    /// Failed to fetch update manifest from GitHub.
+    #[error("failed to fetch update manifest: {reason}")]
+    UpdateFetchFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update manifest JSON was malformed.
+    #[error("failed to parse update manifest")]
+    UpdateManifestParse {
+        /// Underlying parse error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// SHA256 checksum mismatch after download.
+    #[error("checksum mismatch for '{file}': expected {expected}, got {actual}")]
+    UpdateChecksumMismatch {
+        /// File name that failed verification.
+        file: String,
+        /// Expected SHA256 hash.
+        expected: String,
+        /// Actual SHA256 hash.
+        actual: String,
+    },
+
+    /// Binary replacement failed.
+    #[error("failed to replace binary: {reason}")]
+    UpdateReplaceFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update blocked due to ONNX Runtime ABI incompatibility.
+    #[error("update blocked: ONNX Runtime version changed ({current} -> {required}), binary-only update would break birda")]
+    UpdateBlocked {
+        /// Current ONNX Runtime version.
+        current: String,
+        /// Required ONNX Runtime version.
+        required: String,
+        /// URL to the full release for manual download.
+        release_url: String,
+    },
+
+    /// No write permission to the binary's parent directory.
+    #[error("no write permission to '{path}', try running with elevated privileges")]
+    UpdatePermissionDenied {
+        /// Path that lacks write permission.
+        path: std::path::PathBuf,
+    },
+
+    /// No matching update asset for this platform/variant.
+    #[error("no update available for platform '{platform}'")]
+    UpdateUnsupportedPlatform {
+        /// Platform key that wasn't found in manifest.
+        platform: String,
+    },
+
+    /// Archive extraction failed.
+    #[error("failed to extract update archive: {reason}")]
+    UpdateExtractFailed {
+        /// Description of the failure.
+        reason: String,
+    },
+
+    /// Update refused because binary is a dev build (in target/ directory).
+    #[error("refusing to update a development build (binary is in a cargo target/ directory)")]
+    UpdateDevBuild,
+
+    /// Failed to determine the current executable path.
+    #[error("failed to determine current executable path")]
+    UpdateExeNotFound {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --no-default-features 2>&1 | tail -5`
+Expected: successful check (warnings about unused variants are fine for now)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/error.rs
+git commit -m "feat(update): add error variants for update command"
+```
+
+---
+
+### Task 4: Create update constants module
+
+**Files:**
+- Create: `src/update/constants.rs`
+
+- [ ] **Step 1: Create the constants file**
+
+```rust
+//! Constants for the update command.
+
+/// GitHub repository used for release downloads.
+pub const GITHUB_REPO: &str = "tphakala/birda";
+
+/// URL pattern for downloading from the latest GitHub release.
+/// The `{repo}` placeholder is replaced with `GITHUB_REPO`.
+/// The `{file}` placeholder is replaced with the asset filename.
+pub const RELEASE_DOWNLOAD_URL: &str =
+    "https://github.com/{repo}/releases/latest/download/{file}";
+
+/// Filename of the release manifest.
+pub const MANIFEST_FILENAME: &str = "manifest.json";
+
+/// Temporary file suffix used during extraction.
+pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
+
+/// Backup file extension for the old binary on Unix.
+pub const BACKUP_EXTENSION: &str = ".old";
+
+/// Embedded ONNX Runtime version from build time.
+pub const BUILT_ONNXRUNTIME_VERSION: &str = env!("BIRDA_ONNXRUNTIME_VERSION");
+
+/// Embedded CUDA toolkit version from build time.
+pub const BUILT_CUDA_TOOLKIT_VERSION: &str = env!("BIRDA_CUDA_TOOLKIT_VERSION");
+
+/// Embedded cuDNN version from build time.
+pub const BUILT_CUDNN_VERSION: &str = env!("BIRDA_CUDNN_VERSION");
+```
+
+- [ ] **Step 2: Create the update module**
+
+Create `src/update/mod.rs`:
+
+```rust
+//! Self-update functionality for birda.
+//!
+//! Downloads and installs new releases from GitHub, replacing only the binary.
+//! Warns when CUDA or ONNX Runtime library versions change between releases.
+
+pub mod checksum;
+pub mod constants;
+pub mod manifest;
+pub mod platform;
+pub mod replace;
+```
+
+- [ ] **Step 3: Register the module in lib.rs**
+
+Add `pub mod update;` to the module list in `src/lib.rs` (after `pub mod utils;`):
+
+```rust
+pub mod update;
+```
+
+- [ ] **Step 4: Create stub files so it compiles**
+
+Create `src/update/checksum.rs`:
+```rust
+//! SHA256 checksum verification for downloaded archives.
+```
+
+Create `src/update/manifest.rs`:
+```rust
+//! Release manifest fetching and parsing.
+```
+
+Create `src/update/platform.rs`:
+```rust
+//! Platform and build variant detection for asset selection.
+```
+
+Create `src/update/replace.rs`:
+```rust
+//! Binary self-replacement logic.
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check --no-default-features 2>&1 | tail -5`
+Expected: successful check
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/update/ src/lib.rs
+git commit -m "feat(update): scaffold update module with constants"
+```
+
+---
+
+### Task 5: Implement manifest types and fetching
+
+**Files:**
+- Modify: `src/update/manifest.rs`
+
+- [ ] **Step 1: Write the test for manifest parsing**
+
+Add to `src/update/manifest.rs`:
+
+```rust
+//! Release manifest fetching and parsing.
+
+use crate::error::{Error, Result};
+use serde::Deserialize;
+
+/// A binary asset entry in the release manifest.
+#[derive(Debug, Deserialize)]
+pub struct BinAsset {
+    /// Filename of the archive (e.g., `birda-linux-x64-bin-v1.9.0.tar.gz`).
+    pub file: String,
+    /// SHA256 hex digest of the archive.
+    pub sha256: String,
+}
+
+/// Dependencies section of the release manifest.
+#[derive(Debug, Deserialize)]
+pub struct Dependencies {
+    /// Required ONNX Runtime version.
+    pub onnxruntime: String,
+}
+
+/// CUDA-specific version requirements.
+#[derive(Debug, Deserialize)]
+pub struct CudaVersions {
+    /// Required CUDA toolkit version.
+    pub cuda_toolkit: String,
+    /// Required cuDNN version.
+    pub cudnn: String,
+}
+
+/// Asset collections in the manifest.
+#[derive(Debug, Deserialize)]
+pub struct Assets {
+    /// Binary-only archives keyed by platform (e.g., "linux-x64", "linux-x64-cuda").
+    pub bin: std::collections::HashMap<String, BinAsset>,
+}
+
+/// Release manifest fetched from GitHub.
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    /// Release version (semver, e.g., "1.9.0").
+    pub version: String,
+    /// Available assets.
+    pub assets: Assets,
+    /// Library dependency versions.
+    pub dependencies: Dependencies,
+    /// CUDA-specific versions.
+    pub cuda: CudaVersions,
+}
+
+impl Manifest {
+    /// Parse a manifest from JSON bytes.
+    pub fn from_json(json: &[u8]) -> Result<Self> {
+        serde_json::from_slice(json).map_err(|source| Error::UpdateManifestParse { source })
+    }
+}
+
+/// Fetch the release manifest from GitHub.
+///
+/// Downloads `manifest.json` from the latest release using the direct
+/// download URL (no GitHub API needed, avoids rate limits).
+pub async fn fetch_manifest(client: &reqwest::Client) -> Result<Manifest> {
+    let url = super::constants::RELEASE_DOWNLOAD_URL
+        .replace("{repo}", super::constants::GITHUB_REPO)
+        .replace("{file}", super::constants::MANIFEST_FILENAME);
+
+    let response = client.get(&url).send().await.map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("HTTP request failed: {e}"),
+        }
+    })?;
+
+    if !response.status().is_success() {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("HTTP {}", response.status()),
+        });
+    }
+
+    let bytes = response.bytes().await.map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("failed to read response body: {e}"),
+        }
+    })?;
+
+    Manifest::from_json(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_manifest() {
+        let json = br#"{
+            "version": "1.9.0",
+            "min_gui_version": "1.1.0",
+            "assets": {
+                "bin": {
+                    "linux-x64": {
+                        "file": "birda-linux-x64-bin-v1.9.0.tar.gz",
+                        "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                    },
+                    "linux-x64-cuda": {
+                        "file": "birda-linux-x64-cuda-bin-v1.9.0.tar.gz",
+                        "sha256": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                    }
+                },
+                "embed": {},
+                "cuda_libs": {}
+            },
+            "dependencies": {
+                "onnxruntime": "1.24.2"
+            },
+            "cuda": {
+                "cuda_toolkit": "12.9",
+                "cudnn": "9.17.1.4"
+            }
+        }"#;
+
+        let manifest = Manifest::from_json(json).unwrap();
+        assert_eq!(manifest.version, "1.9.0");
+        assert_eq!(manifest.dependencies.onnxruntime, "1.24.2");
+        assert_eq!(manifest.cuda.cuda_toolkit, "12.9");
+        assert_eq!(manifest.cuda.cudnn, "9.17.1.4");
+        assert_eq!(manifest.assets.bin.len(), 2);
+
+        let linux = &manifest.assets.bin["linux-x64"];
+        assert_eq!(linux.file, "birda-linux-x64-bin-v1.9.0.tar.gz");
+        assert_eq!(linux.sha256.len(), 64);
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let result = Manifest::from_json(b"not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_missing_required_fields() {
+        let json = br#"{"version": "1.0.0"}"#;
+        let result = Manifest::from_json(json);
+        assert!(result.is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test --no-default-features --lib update::manifest -- -v 2>&1 | tail -15`
+Expected: 3 tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/update/manifest.rs
+git commit -m "feat(update): implement manifest types and parsing"
+```
+
+---
+
+### Task 6: Implement platform detection
+
+**Files:**
+- Modify: `src/update/platform.rs`
+
+- [ ] **Step 1: Write platform detection with tests**
+
+```rust
+//! Platform and build variant detection for asset selection.
+//!
+//! Determines the correct manifest asset key based on the compile-time
+//! target OS, architecture, and cargo features.
+
+/// Returns the manifest asset key for the current platform and build variant.
+///
+/// Examples: `"linux-x64"`, `"linux-x64-cuda"`, `"windows-x64"`, `"macos-arm64"`.
+pub fn asset_key() -> &'static str {
+    let base = platform_base();
+
+    if cfg!(feature = "cuda") {
+        // CUDA builds have a separate key (only linux-x64 and windows-x64)
+        match base {
+            "linux-x64" => "linux-x64-cuda",
+            "windows-x64" => "windows-x64-cuda",
+            // macOS doesn't have CUDA builds; fall back to non-CUDA
+            _ => base,
+        }
+    } else {
+        base
+    }
+}
+
+/// Returns the base platform identifier without variant suffix.
+fn platform_base() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "linux-x64"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "windows-x64"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "macos-arm64"
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    {
+        compile_error!("Unsupported platform for birda update. Supported: linux-x64, windows-x64, macos-arm64");
+    }
+}
+
+/// Returns the archive extension for the current platform.
+pub fn archive_extension() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "zip"
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "tar.gz"
+    }
+}
+
+/// Returns the binary filename for the current platform.
+pub fn binary_name() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "birda.exe"
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "birda"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asset_key_is_not_empty() {
+        let key = asset_key();
+        assert!(!key.is_empty());
+    }
+
+    #[test]
+    fn test_platform_base_matches_expected() {
+        let base = platform_base();
+        let valid = ["linux-x64", "windows-x64", "macos-arm64"];
+        assert!(valid.contains(&base), "unexpected platform: {base}");
+    }
+
+    #[test]
+    fn test_archive_extension_matches_platform() {
+        let ext = archive_extension();
+        if cfg!(target_os = "windows") {
+            assert_eq!(ext, "zip");
+        } else {
+            assert_eq!(ext, "tar.gz");
+        }
+    }
+
+    #[test]
+    fn test_binary_name_matches_platform() {
+        let name = binary_name();
+        if cfg!(target_os = "windows") {
+            assert_eq!(name, "birda.exe");
+        } else {
+            assert_eq!(name, "birda");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test --no-default-features --lib update::platform -- -v 2>&1 | tail -15`
+Expected: 4 tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/update/platform.rs
+git commit -m "feat(update): implement platform detection for asset selection"
+```
+
+---
+
+### Task 7: Implement SHA256 checksum verification
+
+**Files:**
+- Modify: `src/update/checksum.rs`
+
+- [ ] **Step 1: Write checksum verification with tests**
+
+```rust
+//! SHA256 checksum verification for downloaded archives.
+
+use crate::error::{Error, Result};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// Verify that a file's SHA256 hash matches the expected hex digest.
+///
+/// Returns `Ok(())` if the checksum matches. Returns `Err(UpdateChecksumMismatch)`
+/// if it doesn't. The file is read in streaming fashion to avoid loading it all
+/// into memory.
+pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
+    let file_bytes = std::fs::read(path).map_err(Error::Io)?;
+    let actual_hex = hex_digest(&file_bytes);
+
+    if actual_hex != expected_hex.to_ascii_lowercase() {
+        return Err(Error::UpdateChecksumMismatch {
+            file: path
+                .file_name()
+                .map_or_else(|| "unknown".to_string(), |n| n.to_string_lossy().to_string()),
+            expected: expected_hex.to_string(),
+            actual: actual_hex,
+        });
+    }
+
+    Ok(())
+}
+
+/// Compute the SHA256 hex digest of raw bytes.
+fn hex_digest(data: &[u8]) -> String {
+    let hash = Sha256::digest(data);
+    // Format each byte as two lowercase hex characters
+    hash.iter().fold(String::with_capacity(64), |mut acc, byte| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_hex_digest_known_value() {
+        // SHA256 of empty string
+        let hash = hex_digest(b"");
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_hex_digest_hello_world() {
+        let hash = hex_digest(b"hello world");
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn test_verify_sha256_matching() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"test content").unwrap();
+        drop(f);
+
+        let expected = hex_digest(b"test content");
+        assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"test content").unwrap();
+        drop(f);
+
+        let result = verify_sha256(&path, "0000000000000000000000000000000000000000000000000000000000000000");
+        assert!(result.is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Add tempfile as a dev dependency**
+
+Add to `Cargo.toml` under `[dev-dependencies]`:
+
+```toml
+tempfile = "3"
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test --no-default-features --lib update::checksum -- -v 2>&1 | tail -15`
+Expected: 4 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/update/checksum.rs Cargo.toml Cargo.lock
+git commit -m "feat(update): implement SHA256 checksum verification"
+```
+
+---
+
+### Task 8: Implement binary replacement
+
+**Files:**
+- Modify: `src/update/replace.rs`
+
+- [ ] **Step 1: Write the replacement logic**
+
+```rust
+//! Binary self-replacement logic.
+//!
+//! On Unix: rename current binary to `.old`, move new binary into place.
+//! On Windows: use `self_replace` crate to handle locked-binary replacement.
+
+use crate::error::{Error, Result};
+use std::path::Path;
+use tracing::debug;
+
+/// Check that the parent directory of the current binary is writable.
+pub fn check_write_permission(exe_path: &Path) -> Result<()> {
+    let parent = exe_path.parent().ok_or_else(|| Error::UpdateReplaceFailed {
+        reason: format!(
+            "cannot determine parent directory of '{}'",
+            exe_path.display()
+        ),
+    })?;
+
+    let metadata = std::fs::metadata(parent).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("cannot read metadata of '{}': {e}", parent.display()),
+    })?;
+
+    if metadata.permissions().readonly() {
+        return Err(Error::UpdatePermissionDenied {
+            path: parent.to_path_buf(),
+        });
+    }
+
+    // On Unix, also check the actual write bits for the current user
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let file_uid = std::fs::metadata(parent)
+            .and_then(|m| {
+                use std::os::unix::fs::MetadataExt;
+                Ok((m.uid(), m.gid()))
+            })
+            .unwrap_or((u32::MAX, u32::MAX));
+
+        let writable = if uid == 0 {
+            true // root can write anywhere
+        } else if uid == file_uid.0 {
+            mode & 0o200 != 0 // owner write
+        } else if gid == file_uid.1 {
+            mode & 0o020 != 0 // group write
+        } else {
+            mode & 0o002 != 0 // other write
+        };
+
+        if !writable {
+            return Err(Error::UpdatePermissionDenied {
+                path: parent.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if the binary appears to be a development build (inside a cargo target/ directory).
+pub fn is_dev_build(exe_path: &Path) -> bool {
+    let path_str = exe_path.to_string_lossy();
+    path_str.contains("/target/") || path_str.contains("\\target\\")
+}
+
+/// Set executable permissions on a file (Unix only, no-op on Windows).
+#[cfg(unix)]
+pub fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(path, perms).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("failed to set executable permissions on '{}': {e}", path.display()),
+    })
+}
+
+/// Set executable permissions on a file (Unix only, no-op on Windows).
+#[cfg(not(unix))]
+pub fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Replace the current binary with a new one.
+///
+/// On Unix: renames current to `.old`, moves new into place. If the second
+/// rename fails, attempts to restore the original.
+///
+/// On Windows: uses `self_replace` crate.
+///
+/// Returns `true` if a `.old` backup was kept (Unix), `false` otherwise (Windows).
+pub fn replace_binary(exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    #[cfg(unix)]
+    {
+        replace_unix(exe_path, new_binary_path)
+    }
+    #[cfg(windows)]
+    {
+        replace_windows(exe_path, new_binary_path)
+    }
+}
+
+#[cfg(unix)]
+fn replace_unix(exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    let backup_path = exe_path.with_extension(
+        // Preserve existing extension if any and append .old
+        format!(
+            "{}old",
+            exe_path
+                .extension()
+                .map_or(String::new(), |e| format!("{}.", e.to_string_lossy()))
+        ),
+    );
+
+    debug!("renaming {} -> {}", exe_path.display(), backup_path.display());
+    std::fs::rename(exe_path, &backup_path).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!(
+            "failed to rename '{}' to '{}': {e}",
+            exe_path.display(),
+            backup_path.display()
+        ),
+    })?;
+
+    debug!("renaming {} -> {}", new_binary_path.display(), exe_path.display());
+    if let Err(e) = std::fs::rename(new_binary_path, exe_path) {
+        // Rollback: restore the original
+        debug!("second rename failed, rolling back");
+        if let Err(rollback_err) = std::fs::rename(&backup_path, exe_path) {
+            return Err(Error::UpdateReplaceFailed {
+                reason: format!(
+                    "failed to install new binary AND failed to restore backup: install error: {e}, rollback error: {rollback_err}"
+                ),
+            });
+        }
+        return Err(Error::UpdateReplaceFailed {
+            reason: format!(
+                "failed to rename '{}' to '{}': {e}",
+                new_binary_path.display(),
+                exe_path.display()
+            ),
+        });
+    }
+
+    Ok(true) // backup kept
+}
+
+#[cfg(windows)]
+fn replace_windows(_exe_path: &Path, new_binary_path: &Path) -> Result<bool> {
+    self_replace::self_replace(new_binary_path).map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("self_replace failed: {e}"),
+    })?;
+
+    // Clean up the temp file
+    let _ = std::fs::remove_file(new_binary_path);
+
+    Ok(false) // no backup on Windows
+}
+```
+
+- [ ] **Step 2: Add libc as a dependency for Unix permission checks**
+
+Add to `Cargo.toml` under `[target.'cfg(unix)'.dependencies]` (create this section if it doesn't exist):
+
+```toml
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+```
+
+- [ ] **Step 3: Run clippy**
+
+Run: `cargo clippy --no-default-features -- -D warnings 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 4: Write tests for dev build detection and permission check**
+
+Add to the bottom of `src/update/replace.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_dev_build_detects_target_dir() {
+        assert!(is_dev_build(Path::new("/home/user/project/target/release/birda")));
+        assert!(is_dev_build(Path::new("/home/user/project/target/debug/birda")));
+    }
+
+    #[test]
+    fn test_is_dev_build_false_for_install_paths() {
+        assert!(!is_dev_build(Path::new("/usr/local/bin/birda")));
+        assert!(!is_dev_build(Path::new("/home/user/.local/bin/birda")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_set_executable_on_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-bin");
+        std::fs::write(&path, b"fake binary").unwrap();
+        set_executable(&path).unwrap();
+
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test --no-default-features --lib update::replace -- -v 2>&1 | tail -15`
+Expected: tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/update/replace.rs Cargo.toml Cargo.lock
+git commit -m "feat(update): implement binary replacement with rollback"
+```
+
+---
+
+### Task 9: Implement the update orchestration (mod.rs)
+
+**Files:**
+- Modify: `src/update/mod.rs`
+
+This is the main module that ties everything together.
+
+- [ ] **Step 1: Write the orchestration logic**
+
+Replace `src/update/mod.rs` with:
+
+```rust
+//! Self-update functionality for birda.
+//!
+//! Downloads and installs new releases from GitHub, replacing only the binary.
+//! Warns when CUDA or ONNX Runtime library versions change between releases.
+
+pub mod checksum;
+pub mod constants;
+pub mod manifest;
+pub mod platform;
+pub mod replace;
+
+use crate::error::{Error, Result};
+use constants::{
+    BACKUP_EXTENSION, BUILT_CUDA_TOOLKIT_VERSION, BUILT_CUDNN_VERSION,
+    BUILT_ONNXRUNTIME_VERSION, GITHUB_REPO, RELEASE_DOWNLOAD_URL, UPDATE_TEMP_SUFFIX,
+};
+use indicatif::{ProgressBar, ProgressStyle};
+use manifest::Manifest;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info};
+
+/// Result of a version check.
+pub enum UpdateCheck {
+    /// Already running the latest version.
+    UpToDate {
+        /// Current version string.
+        version: String,
+    },
+    /// A newer version is available.
+    Available {
+        /// Current version string.
+        current: String,
+        /// Available version string.
+        available: String,
+        /// The fetched manifest.
+        manifest: Manifest,
+    },
+}
+
+/// Result of performing an update.
+pub struct UpdateResult {
+    /// Previous version.
+    pub old_version: String,
+    /// New version.
+    pub new_version: String,
+    /// Whether a backup of the old binary was kept.
+    pub backup_kept: bool,
+    /// Path to the backup file (if kept).
+    pub backup_path: Option<PathBuf>,
+    /// Warnings about library version changes.
+    pub warnings: Vec<String>,
+}
+
+/// Check if an update is available.
+///
+/// Fetches the manifest from the latest GitHub release and compares
+/// versions using semver.
+pub async fn check_for_update(client: &reqwest::Client) -> Result<UpdateCheck> {
+    let manifest = manifest::fetch_manifest(client).await?;
+
+    let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).map_err(|e| {
+        Error::Internal {
+            message: format!("failed to parse current version: {e}"),
+        }
+    })?;
+
+    let remote = semver::Version::parse(&manifest.version).map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("manifest contains invalid version '{}': {e}", manifest.version),
+        }
+    })?;
+
+    if current >= remote {
+        Ok(UpdateCheck::UpToDate {
+            version: current.to_string(),
+        })
+    } else {
+        Ok(UpdateCheck::Available {
+            current: current.to_string(),
+            available: remote.to_string(),
+            manifest,
+        })
+    }
+}
+
+/// Perform the full update: download, verify, extract, and replace.
+pub async fn perform_update(
+    client: &reqwest::Client,
+    manifest: &Manifest,
+    current_version: &str,
+) -> Result<UpdateResult> {
+    // 1. Resolve current exe path
+    let exe_path =
+        std::env::current_exe().map_err(|source| Error::UpdateExeNotFound { source })?;
+    let exe_path = exe_path
+        .canonicalize()
+        .unwrap_or_else(|_| exe_path.clone());
+
+    // 2. Dev build guard
+    if replace::is_dev_build(&exe_path) {
+        return Err(Error::UpdateDevBuild);
+    }
+
+    // 3. Check library version compatibility
+    let warnings = check_library_versions(manifest)?;
+
+    // 4. Select the right asset
+    let platform_key = platform::asset_key();
+    let asset = manifest
+        .assets
+        .bin
+        .get(platform_key)
+        .ok_or_else(|| Error::UpdateUnsupportedPlatform {
+            platform: platform_key.to_string(),
+        })?;
+
+    // 5. Check write permissions
+    replace::check_write_permission(&exe_path)?;
+
+    // 6. Download the archive
+    let download_url = RELEASE_DOWNLOAD_URL
+        .replace("{repo}", GITHUB_REPO)
+        .replace("{file}", &asset.file);
+
+    let parent_dir = exe_path.parent().ok_or_else(|| Error::UpdateReplaceFailed {
+        reason: "cannot determine parent directory of current binary".to_string(),
+    })?;
+
+    let archive_path = parent_dir.join(format!("{}{}", asset.file, ".download"));
+    download_with_progress(client, &download_url, &archive_path, &manifest.version).await?;
+
+    // 7. Verify checksum
+    info!("Verifying checksum...");
+    if let Err(e) = checksum::verify_sha256(&archive_path, &asset.sha256) {
+        // Clean up on failure
+        let _ = std::fs::remove_file(&archive_path);
+        return Err(e);
+    }
+
+    // 8. Extract to temp file in same directory (avoids EXDEV)
+    let temp_binary = parent_dir.join(UPDATE_TEMP_SUFFIX);
+    if let Err(e) = extract_binary(&archive_path, &temp_binary) {
+        let _ = std::fs::remove_file(&archive_path);
+        let _ = std::fs::remove_file(&temp_binary);
+        return Err(e);
+    }
+
+    // Clean up the archive
+    let _ = std::fs::remove_file(&archive_path);
+
+    // 9. Set executable permissions (Unix)
+    replace::set_executable(&temp_binary)?;
+
+    // 10. Replace binary
+    let backup_kept = match replace::replace_binary(&exe_path, &temp_binary) {
+        Ok(kept) => kept,
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_binary);
+            return Err(e);
+        }
+    };
+
+    let backup_path = if backup_kept {
+        Some(exe_path.with_extension(
+            format!(
+                "{}old",
+                exe_path
+                    .extension()
+                    .map_or(String::new(), |e| format!("{}.", e.to_string_lossy()))
+            ),
+        ))
+    } else {
+        None
+    };
+
+    Ok(UpdateResult {
+        old_version: current_version.to_string(),
+        new_version: manifest.version.clone(),
+        backup_kept,
+        backup_path,
+        warnings,
+    })
+}
+
+/// Check library versions and return warnings or block the update.
+///
+/// Blocks (returns Err) if ONNX Runtime major.minor changed.
+/// Returns warnings (Vec<String>) for CUDA/cuDNN changes.
+fn check_library_versions(manifest: &Manifest) -> Result<Vec<String>> {
+    let mut warnings = Vec::new();
+
+    // Skip all checks for dev builds (versions are "unknown")
+    if BUILT_ONNXRUNTIME_VERSION == "unknown" {
+        debug!("dev build detected, skipping library version checks");
+        return Ok(warnings);
+    }
+
+    // ONNX Runtime: block on major.minor change (ABI break)
+    if ort_major_minor_changed(BUILT_ONNXRUNTIME_VERSION, &manifest.dependencies.onnxruntime) {
+        let tag = format!("v{}", manifest.version);
+        return Err(Error::UpdateBlocked {
+            current: BUILT_ONNXRUNTIME_VERSION.to_string(),
+            required: manifest.dependencies.onnxruntime.clone(),
+            release_url: format!("https://github.com/{GITHUB_REPO}/releases/tag/{tag}"),
+        });
+    }
+
+    // CUDA checks only for CUDA builds
+    if cfg!(feature = "cuda") && BUILT_CUDA_TOOLKIT_VERSION != "unknown" {
+        if manifest.cuda.cuda_toolkit != BUILT_CUDA_TOOLKIT_VERSION {
+            warnings.push(format!(
+                "CUDA toolkit requirement changed ({} -> {}). If you use GPU acceleration, you may need to update your CUDA installation.",
+                BUILT_CUDA_TOOLKIT_VERSION, manifest.cuda.cuda_toolkit,
+            ));
+        }
+        if manifest.cuda.cudnn != BUILT_CUDNN_VERSION {
+            warnings.push(format!(
+                "cuDNN requirement changed ({} -> {}). If you use GPU acceleration, you may need to update cuDNN.",
+                BUILT_CUDNN_VERSION, manifest.cuda.cudnn,
+            ));
+        }
+    }
+
+    Ok(warnings)
+}
+
+/// Check if the ONNX Runtime major.minor version has changed.
+fn ort_major_minor_changed(current: &str, required: &str) -> bool {
+    let current_parts: Vec<&str> = current.split('.').collect();
+    let required_parts: Vec<&str> = required.split('.').collect();
+
+    if current_parts.len() < 2 || required_parts.len() < 2 {
+        // Can't parse; assume changed to be safe
+        return current != required;
+    }
+
+    // Compare major.minor only
+    current_parts[0] != required_parts[0] || current_parts[1] != required_parts[1]
+}
+
+/// Download a file with a progress bar.
+async fn download_with_progress(
+    client: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    version: &str,
+) -> Result<()> {
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let response = client.get(url).send().await.map_err(|e| {
+        Error::UpdateFetchFailed {
+            reason: format!("download failed: {e}"),
+        }
+    })?;
+
+    if !response.status().is_success() {
+        return Err(Error::UpdateFetchFailed {
+            reason: format!("HTTP {} downloading {url}", response.status()),
+        });
+    }
+
+    let total_size = response.content_length().unwrap_or(0);
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{msg}\n{bar:40.cyan/blue} {percent}% ({bytes}/{total_bytes})")
+            .map_err(|e| Error::Internal {
+                message: format!("progress bar template error: {e}"),
+            })?
+            .progress_chars("##-"),
+    );
+    pb.set_message(format!("Downloading birda v{version}..."));
+
+    let mut file = tokio::fs::File::create(dest).await.map_err(Error::Io)?;
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| Error::UpdateFetchFailed {
+            reason: format!("download stream error: {e}"),
+        })?;
+        file.write_all(&chunk).await.map_err(Error::Io)?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    file.flush().await.map_err(Error::Io)?;
+    pb.finish_and_clear();
+
+    Ok(())
+}
+
+/// Extract the binary from a downloaded archive.
+fn extract_binary(archive_path: &Path, dest: &Path) -> Result<()> {
+    let archive_name = archive_path
+        .to_string_lossy();
+
+    if archive_name.ends_with(".tar.gz.download") || archive_name.ends_with(".tar.gz") {
+        extract_tar_gz(archive_path, dest)
+    } else if archive_name.ends_with(".zip.download") || archive_name.ends_with(".zip") {
+        extract_zip(archive_path, dest)
+    } else {
+        Err(Error::UpdateExtractFailed {
+            reason: format!("unknown archive format: {}", archive_path.display()),
+        })
+    }
+}
+
+/// Extract the binary from a .tar.gz archive.
+fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    let file = std::fs::File::open(archive_path).map_err(Error::Io)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+
+    let binary_name = platform::binary_name();
+
+    for entry in archive.entries().map_err(|e| Error::UpdateExtractFailed {
+        reason: format!("failed to read archive entries: {e}"),
+    })? {
+        let mut entry = entry.map_err(|e| Error::UpdateExtractFailed {
+            reason: format!("failed to read archive entry: {e}"),
+        })?;
+
+        let path = entry.path().map_err(|e| Error::UpdateExtractFailed {
+            reason: format!("failed to read entry path: {e}"),
+        })?;
+
+        // Security: reject entries with path traversal
+        if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+            return Err(Error::UpdateExtractFailed {
+                reason: "archive contains path traversal entry".to_string(),
+            });
+        }
+
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if filename == binary_name {
+            let mut output = std::fs::File::create(dest).map_err(Error::Io)?;
+            std::io::copy(&mut entry, &mut output).map_err(|e| Error::UpdateExtractFailed {
+                reason: format!("failed to extract binary: {e}"),
+            })?;
+            return Ok(());
+        }
+    }
+
+    Err(Error::UpdateExtractFailed {
+        reason: format!("binary '{binary_name}' not found in archive"),
+    })
+}
+
+/// Extract the binary from a .zip archive.
+fn extract_zip(archive_path: &Path, dest: &Path) -> Result<()> {
+    let file = std::fs::File::open(archive_path).map_err(Error::Io)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| Error::UpdateExtractFailed {
+        reason: format!("failed to open zip archive: {e}"),
+    })?;
+
+    let binary_name = platform::binary_name();
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).map_err(|e| Error::UpdateExtractFailed {
+            reason: format!("failed to read zip entry: {e}"),
+        })?;
+
+        let path = entry
+            .enclosed_name()
+            .ok_or_else(|| Error::UpdateExtractFailed {
+                reason: "zip entry has unsafe path".to_string(),
+            })?;
+
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if filename == binary_name {
+            let mut output = std::fs::File::create(dest).map_err(Error::Io)?;
+            std::io::copy(&mut entry, &mut output).map_err(|e| Error::UpdateExtractFailed {
+                reason: format!("failed to extract binary: {e}"),
+            })?;
+            return Ok(());
+        }
+    }
+
+    Err(Error::UpdateExtractFailed {
+        reason: format!("binary '{binary_name}' not found in zip archive"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ort_major_minor_changed_same() {
+        assert!(!ort_major_minor_changed("1.24.2", "1.24.3"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_minor_bump() {
+        assert!(ort_major_minor_changed("1.24.2", "1.25.0"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_major_bump() {
+        assert!(ort_major_minor_changed("1.24.2", "2.0.0"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_same_short() {
+        assert!(!ort_major_minor_changed("1.24", "1.24"));
+    }
+
+    #[test]
+    fn test_ort_major_minor_changed_unparseable() {
+        // Single segment can't be split; falls back to string comparison
+        assert!(ort_major_minor_changed("unknown", "1.24.2"));
+    }
+}
+```
+
+- [ ] **Step 2: Run all update module tests**
+
+Run: `cargo test --no-default-features --lib update -- -v 2>&1 | tail -25`
+Expected: all tests pass
+
+- [ ] **Step 3: Run clippy**
+
+Run: `cargo clippy --no-default-features -- -D warnings 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/update/mod.rs
+git commit -m "feat(update): implement update orchestration with download, verify, extract, replace"
+```
+
+---
+
+### Task 10: Wire the Update command into CLI and dispatch
+
+**Files:**
+- Modify: `src/cli/args.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Add Update variant to Command enum**
+
+In `src/cli/args.rs`, add to the `Command` enum (after the `Species` variant):
+
+```rust
+    /// Check for and install updates from GitHub.
+    Update {
+        /// Only check for updates, don't install.
+        #[arg(long)]
+        check: bool,
+    },
+```
+
+- [ ] **Step 2: Update the Command re-export in cli/mod.rs if needed**
+
+The `Command` is already re-exported via `pub use args::Command;` in `src/cli/mod.rs`. No change needed.
+
+- [ ] **Step 3: Add Update to command_requires_runtime (it doesn't need runtime)**
+
+In `src/lib.rs`, update `command_requires_runtime` to include `Update`:
+
+```rust
+fn command_requires_runtime(command: Option<&Command>, has_no_inputs: bool) -> bool {
+    match command {
+        Some(
+            Command::Config { .. }
+            | Command::Models { .. }
+            | Command::Clip(_)
+            | Command::Update { .. },
+        ) => false,
+        Some(Command::Providers | Command::Species { .. }) => true,
+        None => !has_no_inputs,
+    }
+}
+```
+
+- [ ] **Step 4: Add the update handler in handle_command**
+
+In `src/lib.rs`, add to `handle_command`'s match (after `Command::Clip(args)`):
+
+```rust
+        Command::Update { check } => {
+            handle_update_command(check, output_mode)
+        }
+```
+
+- [ ] **Step 5: Implement handle_update_command**
+
+Add this function to `src/lib.rs` (after `handle_providers_command`):
+
+```rust
+fn handle_update_command(check_only: bool, output_mode: OutputMode) -> Result<()> {
+    let rt = tokio::runtime::Handle::current();
+
+    rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .user_agent(format!("birda/{}", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(|e| Error::Internal {
+                message: format!("failed to create HTTP client: {e}"),
+            })?;
+
+        // Check for update
+        let check_result = update::check_for_update(&client).await?;
+
+        match check_result {
+            update::UpdateCheck::UpToDate { version } => {
+                if output_mode.is_structured() {
+                    let payload = serde_json::json!({
+                        "result_type": "update_check",
+                        "status": "up_to_date",
+                        "version": version,
+                    });
+                    emit_json_result(&payload);
+                } else {
+                    println!("birda is up to date (v{version})");
+                }
+                Ok(())
+            }
+            update::UpdateCheck::Available {
+                current,
+                available,
+                manifest,
+            } => {
+                if check_only {
+                    if output_mode.is_structured() {
+                        let payload = serde_json::json!({
+                            "result_type": "update_check",
+                            "status": "update_available",
+                            "current_version": current,
+                            "available_version": available,
+                        });
+                        emit_json_result(&payload);
+                    } else {
+                        println!("Update available: v{current} -> v{available}");
+                        println!("Run 'birda update' to install.");
+                    }
+                    return Ok(());
+                }
+
+                // Perform the update
+                let result = update::perform_update(&client, &manifest, &current).await?;
+
+                if output_mode.is_structured() {
+                    let payload = serde_json::json!({
+                        "result_type": "update_complete",
+                        "old_version": result.old_version,
+                        "new_version": result.new_version,
+                        "backup_path": result.backup_path,
+                        "warnings": result.warnings,
+                    });
+                    emit_json_result(&payload);
+                } else {
+                    println!("Verifying checksum... ok");
+
+                    if let Some(backup) = &result.backup_path {
+                        println!("Previous version saved as {}", backup.display());
+                    }
+
+                    println!(
+                        "Updated birda v{} -> v{}",
+                        result.old_version, result.new_version,
+                    );
+
+                    for warning in &result.warnings {
+                        println!("\nNote: {warning}");
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    })
+}
+```
+
+- [ ] **Step 6: Add necessary imports to lib.rs**
+
+At the top of `src/lib.rs`, the `update` module is already declared (Task 4). Verify these are in scope; add if missing:
+
+The `emit_json_result` and `OutputMode` are already imported. No additional imports needed beyond the existing ones.
+
+- [ ] **Step 7: Verify it compiles and passes clippy**
+
+Run: `cargo clippy --no-default-features -- -D warnings 2>&1 | tail -10`
+Expected: no errors
+
+Run: `cargo test --no-default-features 2>&1 | tail -10`
+Expected: all tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli/args.rs src/lib.rs
+git commit -m "feat(update): wire update command into CLI dispatch"
+```
+
+---
+
+### Task 11: Update the manifest template
+
+**Files:**
+- Modify: `manifest.template.json`
+
+- [ ] **Step 1: Update the manifest template**
+
+Replace `manifest.template.json` with:
+
+```json
+{
+  "version": "${VERSION}",
+  "min_gui_version": "1.1.0",
+  "assets": {
+    "bin": {
+      "linux-x64": {
+        "file": "birda-linux-x64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_BIN}"
+      },
+      "linux-x64-cuda": {
+        "file": "birda-linux-x64-cuda-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_CUDA_BIN}"
+      },
+      "windows-x64": {
+        "file": "birda-windows-x64-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_BIN}"
+      },
+      "windows-x64-cuda": {
+        "file": "birda-windows-x64-cuda-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_CUDA_BIN}"
+      },
+      "macos-arm64": {
+        "file": "birda-macos-arm64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_MACOS_BIN}"
+      }
+    },
+    "embed": {
+      "linux-x64": "birda-linux-x64-embed-${TAG}.tar.gz",
+      "windows-x64": "birda-windows-x64-embed-${TAG}.zip",
+      "macos-arm64": "birda-macos-arm64-embed-${TAG}.tar.gz"
+    },
+    "cuda_libs": {
+      "linux-x64": "birda-cuda-libs-linux-x64-${TAG}.tar.gz",
+      "windows-x64": "birda-cuda-libs-windows-x64-${TAG}.zip"
+    }
+  },
+  "dependencies": {
+    "onnxruntime": "${ONNXRUNTIME_VERSION}"
+  },
+  "cuda": {
+    "cuda_toolkit": "${CUDA_TOOLKIT_VERSION}",
+    "cudnn": "${CUDNN_VERSION}"
+  }
+}
+```
+
+- [ ] **Step 2: Verify JSON is valid**
+
+Run: `python3 -c "import json; json.load(open('manifest.template.json')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manifest.template.json
+git commit -m "feat(update): add bin assets and dependencies section to manifest template"
+```
+
+---
+
+### Task 12: Update release workflow to produce binary-only archives and checksums
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add a "Create binary-only archives" step**
+
+In the `release` job, add a new step after "Create embed archives" and before "Generate manifest.json":
+
+```yaml
+      - name: Create binary-only archives
+        run: |
+          VERSION="${{ github.ref_name }}"
+
+          # Linux CPU binary-only
+          if [ -d "artifacts/birda-linux-x64" ]; then
+            tar -czvf artifacts/birda-linux-x64-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64 birda
+          fi
+
+          # Linux CUDA binary-only (same binary, different build)
+          if [ -d "artifacts/birda-linux-x64-cuda" ]; then
+            tar -czvf artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz -C artifacts/birda-linux-x64-cuda birda
+          fi
+
+          # Windows CPU binary-only
+          if [ -d "artifacts/birda-windows-x64" ]; then
+            cd artifacts/birda-windows-x64
+            zip ../birda-windows-x64-bin-${VERSION}.zip birda.exe
+            cd ../..
+          fi
+
+          # Windows CUDA binary-only
+          if [ -d "artifacts/birda-windows-x64-cuda" ]; then
+            cd artifacts/birda-windows-x64-cuda
+            zip ../birda-windows-x64-cuda-bin-${VERSION}.zip birda.exe
+            cd ../..
+          fi
+
+          # macOS binary-only (use the signed binary)
+          if [ -f "artifacts/birda-macos-arm64-signed/"*"/birda" ]; then
+            tar -czvf artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz -C artifacts/birda-macos-arm64-signed birda
+          elif [ -d "artifacts/birda-macos-arm64" ]; then
+            tar -czvf artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz -C artifacts/birda-macos-arm64 birda
+          fi
+
+          echo "=== Binary-only archives ==="
+          ls -la artifacts/*bin* 2>/dev/null || true
+```
+
+Note: The macOS path may need adjustment based on how the signed artifact is structured. Check the sign-and-notarize job's upload path. The implementer should verify the exact artifact directory layout during testing.
+
+- [ ] **Step 2: Add SHA256 computation to the "Generate manifest.json" step**
+
+Replace the existing "Generate manifest.json" step with:
+
+```yaml
+      - name: Generate manifest.json
+        run: |
+          VERSION="${{ github.ref_name }}"
+          SEMVER="${VERSION#v}"
+
+          # Compute SHA256 for binary-only archives
+          SHA256_LINUX_BIN=$(sha256sum artifacts/birda-linux-x64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_LINUX_CUDA_BIN=$(sha256sum artifacts/birda-linux-x64-cuda-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_WINDOWS_BIN=$(sha256sum artifacts/birda-windows-x64-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_WINDOWS_CUDA_BIN=$(sha256sum artifacts/birda-windows-x64-cuda-bin-${VERSION}.zip 2>/dev/null | cut -d' ' -f1 || echo "")
+          SHA256_MACOS_BIN=$(sha256sum artifacts/birda-macos-arm64-bin-${VERSION}.tar.gz 2>/dev/null | cut -d' ' -f1 || echo "")
+
+          sed -e "s/\${VERSION}/$SEMVER/g" \
+              -e "s/\${TAG}/$VERSION/g" \
+              -e "s/\${ONNXRUNTIME_VERSION}/${{ env.ONNXRUNTIME_VERSION }}/g" \
+              -e "s/\${CUDNN_VERSION}/${{ env.CUDNN_VERSION }}/g" \
+              -e "s/\${CUDA_TOOLKIT_VERSION}/${{ env.CUDA_TOOLKIT_VERSION }}/g" \
+              -e "s/\${SHA256_LINUX_BIN}/$SHA256_LINUX_BIN/g" \
+              -e "s/\${SHA256_LINUX_CUDA_BIN}/$SHA256_LINUX_CUDA_BIN/g" \
+              -e "s/\${SHA256_WINDOWS_BIN}/$SHA256_WINDOWS_BIN/g" \
+              -e "s/\${SHA256_WINDOWS_CUDA_BIN}/$SHA256_WINDOWS_CUDA_BIN/g" \
+              -e "s/\${SHA256_MACOS_BIN}/$SHA256_MACOS_BIN/g" \
+              manifest.template.json > artifacts/manifest.json
+
+          echo "=== Generated manifest.json ==="
+          cat artifacts/manifest.json
+
+          # Validate JSON
+          python3 -c "import json; json.load(open('artifacts/manifest.json'))"
+          echo "JSON validation passed"
+```
+
+- [ ] **Step 3: Add binary-only archives to the release asset upload**
+
+In the `Create Release` step, add the binary-only archives to the `files:` list. Find the existing `files:` block and add these lines:
+
+```yaml
+            artifacts/birda-linux-x64-bin-${{ github.ref_name }}.tar.gz
+            artifacts/birda-linux-x64-cuda-bin-${{ github.ref_name }}.tar.gz
+            artifacts/birda-windows-x64-bin-${{ github.ref_name }}.zip
+            artifacts/birda-windows-x64-cuda-bin-${{ github.ref_name }}.zip
+            artifacts/birda-macos-arm64-bin-${{ github.ref_name }}.tar.gz
+```
+
+- [ ] **Step 4: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('OK')"`
+Expected: `OK`
+
+If python3 doesn't have yaml installed, use: `python3 -c "import json; print('check manually')"` and visually verify indentation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add binary-only archives and SHA256 checksums to release workflow"
+```
+
+---
+
+### Task 13: Final integration test and cleanup
+
+**Files:**
+- All update module files
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cargo test --no-default-features --no-fail-fast 2>&1 | tail -20`
+Expected: all tests pass
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --no-default-features -- -D warnings 2>&1 | tail -10`
+Expected: no warnings
+
+- [ ] **Step 3: Run fmt**
+
+Run: `cargo fmt --check 2>&1`
+Expected: no formatting issues
+
+- [ ] **Step 4: Smoke test the CLI**
+
+Run: `cargo run --no-default-features -- update --check 2>&1`
+Expected: either "birda is up to date" or "Update available" (may fail with fetch error if manifest.json doesn't exist on the latest release yet, which is expected since we haven't released with the new manifest format)
+
+Run: `cargo run --no-default-features -- --help 2>&1 | grep -A1 update`
+Expected: shows the `update` subcommand in help output
+
+- [ ] **Step 5: Final commit if any formatting was needed**
+
+```bash
+cargo fmt
+git add -A
+git commit -m "style: format update module"
+```
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-06-update-command.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-29-sentrux-quality-fixes.md
+++ b/docs/superpowers/plans/2026-04-29-sentrux-quality-fixes.md
@@ -1,0 +1,378 @@
+# Sentrux Quality Signal Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix validated sentrux findings to improve birda's quality signal from 7449 toward 8000 by addressing the equality bottleneck (the two monster functions), removing dead code, and adding a trait default for no-op `write_header()`.
+
+**Architecture:** Four independent changes: (1) extract `from_config` execution provider selection into a helper, (2) introduce a `ProcessingConfig` struct to bundle `process_file`'s 15 parameters, (3) add a default `write_header` on the `OutputWriter` trait, (4) remove one dead test helper. Changes 1-4 are independent and can be done in any order.
+
+**Tech Stack:** Rust 1.92, clippy pedantic+nursery lints, existing test suite.
+
+**Validation commands:**
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+~/bin/sentrux check .
+```
+
+---
+
+### Task 1: Add default `write_header()` to `OutputWriter` trait
+
+**Files:**
+- Modify: `src/output/writer.rs:9`
+- Modify: `src/output/audacity.rs:26-29`
+- Modify: `src/output/json.rs` (its `write_header` impl)
+- Modify: `src/output/parquet.rs:122-124`
+
+- [ ] **Step 1: Add default method body to the trait**
+
+In `src/output/writer.rs`, change the trait definition:
+
+```rust
+/// Trait for writing detection results.
+pub trait OutputWriter {
+    /// Write the file header (if applicable).
+    ///
+    /// Default is a no-op. Override for formats that need a header (CSV, Raven, Kaleidoscope).
+    fn write_header(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Write a single detection.
+    fn write_detection(&mut self, detection: &Detection) -> Result<()>;
+
+    /// Finalize the output (flush, close, etc.).
+    fn finalize(&mut self) -> Result<()>;
+}
+```
+
+- [ ] **Step 2: Remove no-op `write_header` implementations**
+
+Remove the `write_header` method from these three `impl OutputWriter` blocks (they just return `Ok(())`):
+
+- `src/output/audacity.rs` lines 26-29 (entire `fn write_header` block)
+- `src/output/json.rs` (its `fn write_header` that returns `Ok(())` with a comment about writing at finalize)
+- `src/output/parquet.rs` lines 122-124 (entire `fn write_header` block)
+
+Keep `write_header` in `src/output/csv.rs`, `src/output/kaleidoscope.rs`, and `src/output/raven.rs` since those write actual content.
+
+- [ ] **Step 3: Run validation**
+
+Run: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+Expected: All pass. Existing tests call `write_header()` on audacity/parquet/json writers and should still work via the default.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/output/writer.rs src/output/audacity.rs src/output/json.rs src/output/parquet.rs
+git commit -m "refactor: add default no-op write_header to OutputWriter trait
+
+Formats that don't need a header (Audacity, JSON, Parquet) no longer
+need to implement write_header. Only CSV, Kaleidoscope, and Raven
+override with actual header content."
+```
+
+---
+
+### Task 2: Remove dead `create_test_model` helper
+
+**Files:**
+- Modify: `src/registry/license.rs:93-124`
+
+- [ ] **Step 1: Verify the function is unused**
+
+Run: `grep -rn 'create_test_model' src/ tests/`
+Expected: Only one match at the definition site (`src/registry/license.rs:93`). No call sites.
+
+- [ ] **Step 2: Remove the dead function**
+
+Delete lines 93-124 in `src/registry/license.rs` (the entire `fn create_test_model` function). Also remove the unused imports it pulled in on line 91:
+
+Before:
+```rust
+use crate::registry::types::{FileInfo, LabelsInfo, LanguageVariant, ModelFiles};
+```
+
+After: remove this line entirely (the three tests below construct `LicenseInfo` directly, which is imported via `use super::*`).
+
+- [ ] **Step 3: Run validation**
+
+Run: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+Expected: All pass. The three remaining tests in this module don't use `create_test_model`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/registry/license.rs
+git commit -m "refactor: remove unused create_test_model test helper"
+```
+
+---
+
+### Task 3: Extract execution provider selection from `from_config`
+
+The `from_config` function (434 lines) is dominated by a ~220-line `match device` block that selects and configures execution providers. Extract this into a dedicated helper.
+
+**Files:**
+- Modify: `src/inference/classifier.rs:166-599`
+
+- [ ] **Step 1: Run existing tests to establish baseline**
+
+Run: `cargo test --lib inference::classifier`
+Expected: All pass.
+
+- [ ] **Step 2: Define the return type for the extracted helper**
+
+Add this struct above `from_config` (around line 164):
+
+```rust
+/// Result of selecting and configuring an execution provider.
+struct ProviderSelection {
+    builder: ClassifierBuilder,
+    device_name: &'static str,
+    status: ExecutionProviderStatus,
+}
+```
+
+- [ ] **Step 3: Extract the `select_execution_provider` function**
+
+Create a new function that contains the entire `match device { ... }` block from `from_config` (lines 218-441). The function signature:
+
+```rust
+/// Select and configure the execution provider based on device setting.
+fn select_execution_provider(
+    builder: ClassifierBuilder,
+    device: InferenceDevice,
+    available_providers: &[birdnet_onnx::ExecutionProviderInfo],
+) -> Result<ProviderSelection> {
+    // GPU provider priority order
+    #[allow(unused_mut)]
+    let mut gpu_priority = vec![
+        (ExecutionProviderInfo::TensorRt, "TensorRT"),
+        (ExecutionProviderInfo::Cuda, "CUDA"),
+        (ExecutionProviderInfo::DirectMl, "DirectML"),
+        (ExecutionProviderInfo::Rocm, "ROCm"),
+        (ExecutionProviderInfo::OpenVino, "OpenVINO"),
+    ];
+
+    #[cfg(not(target_os = "macos"))]
+    gpu_priority.insert(3, (ExecutionProviderInfo::CoreMl, "CoreML"));
+
+    match device {
+        // ... move the entire match block here, adjusting return values
+        // Each arm returns Ok(ProviderSelection { builder, device_name, status })
+        // instead of a tuple (builder, actual_device_msg, ep_status)
+    }
+}
+```
+
+Each match arm currently returns a 3-tuple `(builder, &str, ExecutionProviderStatus)`. Change each to return `Ok(ProviderSelection { builder, device_name: <str>, status: <ep_status> })`.
+
+The `InferenceDevice::Cpu` arm becomes:
+```rust
+InferenceDevice::Cpu => {
+    info!("Requested device: CPU");
+    Ok(ProviderSelection {
+        builder,
+        device_name: "CPU",
+        status: ExecutionProviderStatus {
+            requested: "cpu".to_string(),
+            actual: "CPU".to_string(),
+            fallback_reason: None,
+        },
+    })
+}
+```
+
+The explicit provider arms (`Cuda`, `TensorRt`, etc.) call `configure_explicit_provider` and wrap with:
+```rust
+InferenceDevice::Cuda => {
+    let (builder, name, status) = configure_explicit_provider(
+        builder, available_providers, ExecutionProviderInfo::Cuda, "CUDA",
+    )?;
+    Ok(ProviderSelection { builder, device_name: name, status })
+}
+```
+
+- [ ] **Step 4: Update `from_config` to call the extracted function**
+
+Replace the `match device { ... }` block and the `gpu_priority` setup (lines 192-441) with:
+
+```rust
+let ProviderSelection {
+    builder,
+    device_name: actual_device_msg,
+    status: ep_status,
+} = select_execution_provider(builder, device, &available_providers)?;
+```
+
+The rest of `from_config` (lines 443-599) stays unchanged.
+
+- [ ] **Step 5: Run validation**
+
+Run: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+Expected: All pass. No behavioral change, pure extraction.
+
+- [ ] **Step 6: Run sentrux check**
+
+Run: `~/bin/sentrux check .`
+Expected: All rules pass. `from_config` CC should drop significantly since the 14-arm match is now in the helper.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/inference/classifier.rs
+git commit -m "refactor: extract execution provider selection from from_config
+
+Moves the ~220-line device match block into select_execution_provider(),
+reducing from_config from 434 to ~210 lines and cutting its cyclomatic
+complexity roughly in half."
+```
+
+---
+
+### Task 4: Introduce `ProcessingConfig` struct to reduce `process_file` parameter count
+
+The `process_file` function takes 15 parameters. Most of these are configuration values that travel together. Bundle them into a config struct.
+
+**Files:**
+- Create: `src/pipeline/config.rs`
+- Modify: `src/pipeline/mod.rs`
+- Modify: `src/pipeline/processor.rs:373-389`
+- Modify: `src/lib.rs` (all call sites of `process_file`)
+
+- [ ] **Step 1: Run existing tests to establish baseline**
+
+Run: `cargo test`
+Expected: All pass.
+
+- [ ] **Step 2: Create `ProcessingConfig` struct**
+
+Create `src/pipeline/config.rs`:
+
+```rust
+//! Configuration types for the processing pipeline.
+
+use crate::config::OutputFormat;
+use std::path::{Path, PathBuf};
+
+/// Configuration for processing a single audio file.
+///
+/// Bundles the parameters needed by `process_file` to reduce its argument count.
+pub struct ProcessingConfig<'a> {
+    /// Path to input audio file.
+    pub input_path: &'a Path,
+    /// Directory for output files.
+    pub output_dir: &'a Path,
+    /// Output formats to generate.
+    pub formats: &'a [OutputFormat],
+    /// Minimum confidence threshold (0.0-1.0).
+    pub min_confidence: f32,
+    /// Overlap between chunks in seconds.
+    pub overlap: f32,
+    /// Number of chunks to process in parallel.
+    pub batch_size: usize,
+    /// Additional columns to include in CSV output.
+    pub csv_columns: &'a [String],
+    /// Whether to show progress bars.
+    pub progress_enabled: bool,
+    /// Whether to include UTF-8 BOM in CSV output.
+    pub csv_bom_enabled: bool,
+    /// Model name for JSON output metadata.
+    pub model_name: &'a str,
+    /// Optional (lat, lon, week) for JSON output metadata.
+    pub range_filter_params: Option<(f64, f64, u8)>,
+    /// Optional (lat, lon, day_of_year) for BSG SDM.
+    pub bsg_params: Option<(f64, f64, Option<u32>)>,
+    /// Optional reporter for stdout mode.
+    pub reporter: Option<&'a dyn crate::output::ProgressReporter>,
+    /// Whether to write both files and stdout.
+    pub dual_output_mode: bool,
+}
+```
+
+- [ ] **Step 3: Add the module to `src/pipeline/mod.rs`**
+
+Add `mod config;` and `pub use config::ProcessingConfig;` to `src/pipeline/mod.rs`.
+
+- [ ] **Step 4: Update `process_file` signature**
+
+Change `process_file` in `src/pipeline/processor.rs` from 15 parameters to:
+
+```rust
+pub fn process_file(
+    config: &ProcessingConfig<'_>,
+    classifier: &BirdClassifier,
+) -> Result<ProcessResult> {
+```
+
+Inside the function body, replace all bare parameter references with `config.` prefix. For example:
+- `input_path` becomes `config.input_path`
+- `min_confidence` becomes `config.min_confidence`
+- `formats` becomes `config.formats`
+- etc.
+
+The `classifier` stays as a separate parameter because it's a heavyweight object with its own lifecycle, not a configuration value.
+
+- [ ] **Step 5: Update call sites in `src/lib.rs`**
+
+Find all calls to `process_file` in `src/lib.rs`. There should be one in `process_all_files`. Update it to construct a `ProcessingConfig` and pass it:
+
+```rust
+use crate::pipeline::ProcessingConfig;
+
+let config = ProcessingConfig {
+    input_path: &file_path,
+    output_dir: &output_dir,
+    formats: &formats,
+    min_confidence,
+    overlap,
+    batch_size,
+    csv_columns: &csv_columns,
+    progress_enabled,
+    csv_bom_enabled,
+    model_name: &model_name,
+    range_filter_params,
+    bsg_params,
+    reporter: reporter_ref,
+    dual_output_mode,
+};
+
+let result = process_file(&config, &classifier)?;
+```
+
+- [ ] **Step 6: Run validation**
+
+Run: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+Expected: All pass. No behavioral change.
+
+- [ ] **Step 7: Run sentrux check and gate**
+
+Run: `~/bin/sentrux check . && ~/bin/sentrux gate .`
+Expected: All rules pass. Quality signal should improve (fewer high-param functions, `process_file` CC may drop slightly due to cleaner structure).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pipeline/config.rs src/pipeline/mod.rs src/pipeline/processor.rs src/lib.rs
+git commit -m "refactor: introduce ProcessingConfig to reduce process_file params
+
+Bundles 13 of process_file's 15 parameters into a ProcessingConfig
+struct. The classifier stays separate as a heavyweight runtime object.
+Reduces parameter threading through the pipeline."
+```
+
+---
+
+## Verification
+
+After all four tasks, run a final quality check:
+
+```bash
+cargo fmt --check && cargo clippy -- -D warnings && cargo test
+~/bin/sentrux gate .
+```
+
+The quality signal should improve from 7449, primarily from the equality metric (fewer monster functions, more balanced complexity distribution).

--- a/docs/superpowers/plans/2026-05-07-bat-detection.md
+++ b/docs/superpowers/plans/2026-05-07-bat-detection.md
@@ -1,0 +1,1325 @@
+# Bat Detection Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bat species detection to birda by chaining BirdNET v2.4 embeddings into BattyBirdNET regional classifiers across three repos.
+
+**Architecture:** Two-stage inference. A modified BirdNET v2.4 ONNX model exposes 1024-dim embeddings alongside its normal classification output. These embeddings feed into lightweight regional bat classifiers. Audio is fed as raw 256kHz samples (no resampling), exploiting the "slow-down trick" where BirdNET treats them as 48kHz.
+
+**Tech Stack:** Python (onnx, onnxruntime), Rust (ort, ndarray, clap), ONNX models
+
+**Spec:** `docs/superpowers/specs/2026-05-07-bat-detection-design.md`
+
+---
+
+## File Layout
+
+### Repo 1: `~/src/birdnet-onnx-converter`
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Create | `expose_embeddings.py` | Script to patch v2.4 ONNX models with embedding output |
+| Modify | `convert.py` | Add `--with-embeddings` flag |
+| Create | `tests/test_expose_embeddings.py` | Tests for embedding exposure |
+
+### Repo 2: `~/src/rust-birdnet-onnx`
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `src/detection.rs` | Handle `(144_000, 2)` detection pattern |
+| Modify | `src/classifier.rs` | Extract embeddings for v2.4 when available |
+| Modify | `src/error.rs` | Add `InvalidEmbeddingDim` error variant |
+| Create | `src/custom_classifier.rs` | `CustomClassifier` and builder |
+| Modify | `src/lib.rs` | Export new types, register module |
+| Modify | `src/types.rs` | Update `has_embeddings()` doc comment |
+
+### Repo 3: `~/src/birda`
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `src/constants.rs` | Add `bat` module |
+| Create | `src/config/bat.rs` | `BatRegion` enum, `BatConfig`, region-to-filename mapping |
+| Modify | `src/config/mod.rs` | Export `bat` module |
+| Modify | `src/config/types.rs` | Add `bat` field to `Config` |
+| Modify | `src/cli/analyze.rs` | Add `--bat <region>` arg |
+| Modify | `src/lib.rs` | Wire bat config into pipeline |
+| Modify | `src/pipeline/processor.rs` | Two-stage inference path |
+
+---
+
+## Task 1: Converter - `expose_embeddings.py`
+
+**Repo:** `~/src/birdnet-onnx-converter`
+
+**Files:**
+- Create: `expose_embeddings.py`
+- Create: `tests/test_expose_embeddings.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_expose_embeddings.py
+"""Tests for expose_embeddings.py."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import onnx
+import pytest
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+V24_MODEL = FIXTURES_DIR / "BirdNET_V2.4_Model_FP32.onnx"
+
+needs_v24 = pytest.mark.skipif(
+    not V24_MODEL.exists(),
+    reason="BirdNET v2.4 model not available in fixtures",
+)
+
+
+@needs_v24
+def test_expose_embeddings_adds_second_output(tmp_path):
+    """Patched model should have 2 outputs: predictions + embeddings."""
+    output = tmp_path / "patched.onnx"
+    result = subprocess.run(
+        [sys.executable, "expose_embeddings.py", "--input", str(V24_MODEL), "--output", str(output)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    model = onnx.load(str(output))
+    assert len(model.graph.output) == 2
+
+    shapes = {}
+    for out in model.graph.output:
+        dims = [d.dim_value or d.dim_param for d in out.type.tensor_type.shape.dim]
+        shapes[out.name] = dims
+
+    # First output: predictions [batch, 6522]
+    assert "output" in shapes
+    assert shapes["output"][-1] == 6522
+
+    # Second output: embeddings [batch, 1024]
+    emb_key = [k for k in shapes if k != "output"][0]
+    assert shapes[emb_key][-1] == 1024
+
+
+@needs_v24
+def test_expose_embeddings_runs_in_onnxruntime(tmp_path):
+    """Patched model should run inference and return both outputs."""
+    import numpy as np
+    import onnxruntime as ort
+
+    output = tmp_path / "patched.onnx"
+    subprocess.run(
+        [sys.executable, "expose_embeddings.py", "--input", str(V24_MODEL), "--output", str(output)],
+        check=True,
+    )
+
+    sess = ort.InferenceSession(str(output))
+    assert len(sess.get_outputs()) == 2
+
+    dummy = np.random.randn(1, 144000).astype(np.float32)
+    results = sess.run(None, {"input": dummy})
+    assert results[0].shape == (1, 6522)
+    assert results[1].shape == (1, 1024)
+
+
+def test_expose_embeddings_rejects_non_v24(tmp_path):
+    """Script should fail on models without the expected embedding tensor."""
+    # Create a minimal ONNX model without the GLOBAL_AVG_POOL tensor
+    import numpy as np
+    from onnx import TensorProto, helper, numpy_helper
+
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 10])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 5])
+    W = numpy_helper.from_array(np.random.randn(10, 5).astype(np.float32), name="W")
+    node = helper.make_node("MatMul", ["input", "W"], ["output"])
+    graph = helper.make_graph([node], "test", [X], [Y], [W])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    fake_path = tmp_path / "fake.onnx"
+    onnx.save(model, str(fake_path))
+
+    output = tmp_path / "patched.onnx"
+    result = subprocess.run(
+        [sys.executable, "expose_embeddings.py", "--input", str(fake_path), "--output", str(output)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd ~/src/birdnet-onnx-converter && source .venv/bin/activate && python -m pytest tests/test_expose_embeddings.py -v`
+Expected: FAIL (expose_embeddings.py does not exist)
+
+- [ ] **Step 3: Write `expose_embeddings.py`**
+
+```python
+#!/usr/bin/env python3
+"""
+Expose BirdNET v2.4 embedding layer as a second ONNX output.
+
+Patches the ONNX graph to add the GLOBAL_AVG_POOL output (1024-dim embedding)
+alongside the existing classification output (6522-dim predictions).
+
+Usage:
+    python expose_embeddings.py --input birdnet-v24.onnx --output birdnet-v24-embeddings.onnx
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+EMBEDDING_TENSOR = "model/GLOBAL_AVG_POOL/Mean_reduced_0"
+EMBEDDING_DIM = 1024
+
+
+def expose_embeddings(input_path: str, output_path: str) -> None:
+    """Add embedding tensor as second output to a BirdNET v2.4 ONNX model."""
+    import onnx
+
+    model = onnx.load(input_path)
+
+    # Verify this is a v2.4 model by finding the embedding tensor
+    found = False
+    for vi in model.graph.value_info:
+        if vi.name == EMBEDDING_TENSOR:
+            found = True
+            break
+
+    if not found:
+        print(
+            f"Error: Embedding tensor '{EMBEDDING_TENSOR}' not found in model.\n"
+            "This script only works with BirdNET v2.4 ONNX models.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Check if already exposed
+    existing_names = {out.name for out in model.graph.output}
+    if EMBEDDING_TENSOR in existing_names:
+        print("Embedding output already present, copying unchanged.")
+        onnx.save(model, output_path)
+        return
+
+    # Add embedding as second output
+    embedding_output = onnx.helper.make_tensor_value_info(
+        EMBEDDING_TENSOR,
+        onnx.TensorProto.FLOAT,
+        ["batch", EMBEDDING_DIM],
+    )
+    model.graph.output.append(embedding_output)
+
+    onnx.save(model, output_path)
+    print(f"Added embedding output ({EMBEDDING_DIM}-dim) to model.")
+    print(f"Outputs: {len(model.graph.output)}")
+    for out in model.graph.output:
+        dims = [d.dim_value or d.dim_param for d in out.type.tensor_type.shape.dim]
+        print(f"  {out.name}: {dims}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Expose BirdNET v2.4 embedding layer as ONNX output"
+    )
+    parser.add_argument(
+        "--input", "-i", required=True, help="Input BirdNET v2.4 ONNX model"
+    )
+    parser.add_argument(
+        "--output", "-o", required=True, help="Output ONNX model with embeddings"
+    )
+    args = parser.parse_args()
+
+    if not Path(args.input).exists():
+        print(f"Error: Input model not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    expose_embeddings(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd ~/src/birdnet-onnx-converter && source .venv/bin/activate && python -m pytest tests/test_expose_embeddings.py -v`
+Expected: `test_expose_embeddings_rejects_non_v24` PASS. The v2.4-dependent tests will be skipped if the fixture model is not present.
+
+- [ ] **Step 5: Copy v2.4 model to fixtures and run full suite**
+
+```bash
+cp ~/onnx/birdnet-v24.onnx ~/src/birdnet-onnx-converter/tests/fixtures/BirdNET_V2.4_Model_FP32.onnx
+cd ~/src/birdnet-onnx-converter && source .venv/bin/activate && python -m pytest tests/test_expose_embeddings.py -v
+```
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/src/birdnet-onnx-converter
+git add expose_embeddings.py tests/test_expose_embeddings.py
+git commit -m "feat: add expose_embeddings.py for BirdNET v2.4 embedding output"
+```
+
+---
+
+## Task 2: Converter - `--with-embeddings` flag in `convert.py`
+
+**Repo:** `~/src/birdnet-onnx-converter`
+
+**Files:**
+- Modify: `convert.py`
+- Modify: `tests/test_convert.py`
+
+- [ ] **Step 1: Add `--with-embeddings` argument to `convert.py`**
+
+Add the argparse argument after the existing `--unsafe-fallback` argument (after line 248):
+
+```python
+    parser.add_argument(
+        "--with-embeddings",
+        action="store_true",
+        help="Expose embedding layer as second output (BirdNET v2.4 only)",
+    )
+```
+
+- [ ] **Step 2: Add embedding exposure call to the TFLite conversion path**
+
+In `convert.py`, after the successful ONNX conversion in the TFLite `--onnx-only` branch (after line 275 `print(f"  ONNX model saved...")`), add:
+
+```python
+                if args.with_embeddings:
+                    from expose_embeddings import expose_embeddings
+                    print(f"  Exposing embeddings...")
+                    expose_embeddings(str(onnx_path), str(onnx_path))
+```
+
+- [ ] **Step 3: Add embedding exposure call to the Keras conversion path**
+
+In `convert.py`, after the successful ONNX conversion in the Keras branch (after line 333 `verify_onnx(...)`), add:
+
+```python
+    if args.with_embeddings:
+        from expose_embeddings import expose_embeddings
+        print("\nExposing embeddings...")
+        expose_embeddings(str(onnx_path), str(onnx_path))
+```
+
+- [ ] **Step 4: Test manually**
+
+```bash
+cd ~/src/birdnet-onnx-converter && source .venv/bin/activate
+python convert.py --input tests/fixtures/BirdNET_V2.4_Model_FP32.onnx --output-dir /tmp/embed-test --onnx-only --with-embeddings
+python -c "import onnxruntime as ort; s = ort.InferenceSession('/tmp/embed-test/BirdNET_V2.4_Model_FP32.onnx'); print(len(s.get_outputs()), 'outputs')"
+```
+
+Expected: `2 outputs`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/src/birdnet-onnx-converter
+git add convert.py
+git commit -m "feat: add --with-embeddings flag to convert.py"
+```
+
+---
+
+## Task 3: birdnet-onnx - v2.4 embedding detection
+
+**Repo:** `~/src/rust-birdnet-onnx`
+
+**Files:**
+- Modify: `src/detection.rs`
+- Modify: `src/types.rs`
+
+- [ ] **Step 1: Write failing detection test**
+
+Add to the `#[cfg(test)] mod tests` block in `src/detection.rs`:
+
+```rust
+    #[test]
+    fn test_detect_birdnet_v24_with_embeddings() {
+        let input_shape = vec![1, 144_000];
+        // v2.4 with embeddings: predictions at 0, embeddings at 1
+        let output_shapes = vec![vec![1, 6522], vec![1, 1024]];
+
+        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+
+        assert_eq!(config.model_type, ModelType::BirdNetV24);
+        assert_eq!(config.sample_rate, 48_000);
+        assert_eq!(config.segment_duration, 3.0);
+        assert_eq!(config.sample_count, 144_000);
+        assert_eq!(config.num_species, 6522);
+        assert_eq!(config.embedding_dim, Some(1024));
+    }
+
+    #[test]
+    fn test_detect_birdnet_v24_with_embeddings_dynamic_input() {
+        let input_shape = vec![-1, -1];
+        let output_shapes = vec![vec![-1, 6522], vec![-1, 1024]];
+
+        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+
+        assert_eq!(config.model_type, ModelType::BirdNetV24);
+        assert_eq!(config.embedding_dim, Some(1024));
+    }
+
+    #[test]
+    fn test_detect_birdnet_v24_with_embeddings_override() {
+        let input_shape = vec![1, 144_000];
+        let output_shapes = vec![vec![1, 6522], vec![1, 1024]];
+
+        let config =
+            detect_model_type(&input_shape, &output_shapes, Some(ModelType::BirdNetV24)).unwrap();
+
+        assert_eq!(config.model_type, ModelType::BirdNetV24);
+        assert_eq!(config.embedding_dim, Some(1024));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd ~/src/rust-birdnet-onnx && cargo test --lib detection -- test_detect_birdnet_v24_with_embeddings`
+Expected: FAIL ("unsupported model: 144000 samples, 2 outputs")
+
+- [ ] **Step 3: Update `detect_from_sample_count()` in `src/detection.rs`**
+
+Add a new match arm after the `(144_000, 1)` arm (after line 57):
+
+```rust
+        // BirdNET v2.4 with embeddings: 144,000 samples, 2 outputs
+        // (predictions at 0, embeddings at 1)
+        (144_000, 2) => {
+            let num_species = extract_last_dim(&output_shapes[0])?;
+            let embedding_dim = extract_last_dim(&output_shapes[1])?;
+            Ok(ModelConfig {
+                model_type: ModelType::BirdNetV24,
+                sample_rate: 48_000,
+                segment_duration: 3.0,
+                sample_count: 144_000,
+                num_species,
+                embedding_dim: Some(embedding_dim),
+            })
+        }
+```
+
+- [ ] **Step 4: Update `detect_from_outputs()` in `src/detection.rs`**
+
+The existing `1 =>` arm handles v2.4 with 1 output. Add handling for 2-output case. Change the `2 =>` arm (line 114) to differentiate v2.4-with-embeddings from v3.0:
+
+```rust
+        2 => {
+            let first_dim = extract_last_dim(&output_shapes[0])?;
+            let second_dim = extract_last_dim(&output_shapes[1])?;
+
+            // v2.4 with embeddings: first output is large (predictions),
+            // second is small (1024 embeddings).
+            // v3.0: first output is small (1280 embeddings),
+            // second is large (predictions).
+            if first_dim > second_dim {
+                // v2.4 pattern: predictions at 0, embeddings at 1
+                Ok(ModelConfig {
+                    model_type: ModelType::BirdNetV24,
+                    sample_rate: 48_000,
+                    segment_duration: 3.0,
+                    sample_count: 144_000,
+                    num_species: first_dim,
+                    embedding_dim: Some(second_dim),
+                })
+            } else {
+                // v3.0 pattern: embeddings at 0, predictions at 1
+                Ok(ModelConfig {
+                    model_type: ModelType::BirdNetV30,
+                    sample_rate: 32_000,
+                    segment_duration: 5.0,
+                    sample_count: 160_000,
+                    num_species: second_dim,
+                    embedding_dim: Some(first_dim),
+                })
+            }
+        }
+```
+
+- [ ] **Step 5: Update `build_config_with_override()` in `src/detection.rs`**
+
+In the `ModelType::BirdNetV24` arm (line 170), allow 1 or 2 outputs:
+
+```rust
+        ModelType::BirdNetV24 => {
+            match output_shapes.len() {
+                1 => (None, extract_last_dim(&output_shapes[0])?),
+                2 => (
+                    Some(extract_last_dim(&output_shapes[1])?),
+                    extract_last_dim(&output_shapes[0])?,
+                ),
+                n => {
+                    return Err(Error::ModelDetection {
+                        reason: format!(
+                            "BirdNET v2.4 expects 1 or 2 outputs, got {n}"
+                        ),
+                    });
+                }
+            }
+        }
+```
+
+- [ ] **Step 6: Update `has_embeddings()` doc in `src/types.rs`**
+
+Change the doc comment on line 4 from:
+
+```rust
+    /// `BirdNET` v2.4 - 48kHz, 3s segments, no embeddings.
+```
+
+to:
+
+```rust
+    /// `BirdNET` v2.4 - 48kHz, 3s segments, optional embeddings (when model has 2 outputs).
+```
+
+- [ ] **Step 7: Run all detection tests**
+
+Run: `cd ~/src/rust-birdnet-onnx && cargo test --lib detection`
+Expected: All tests PASS (including existing v2.4, v3.0, Perch tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/src/rust-birdnet-onnx
+git add src/detection.rs src/types.rs
+git commit -m "feat: detect BirdNET v2.4 models with embedding output"
+```
+
+---
+
+## Task 4: birdnet-onnx - v2.4 embedding extraction in classifier
+
+**Repo:** `~/src/rust-birdnet-onnx`
+
+**Files:**
+- Modify: `src/classifier.rs`
+
+- [ ] **Step 1: Update `process_outputs()` in `src/classifier.rs`**
+
+Replace the `ModelType::BirdNetV24 | ModelType::BsgFinland` arm (lines 947-950) with:
+
+```rust
+            ModelType::BirdNetV24 => {
+                if self.inner.config.embedding_dim.is_some() {
+                    // v2.4 with embeddings: predictions at 0, embeddings at 1
+                    let logits = extract_tensor_data(outputs, 0)?;
+                    let embeddings = extract_tensor_data(outputs, 1)?;
+                    (Some(embeddings), logits)
+                } else {
+                    let logits = extract_tensor_data(outputs, 0)?;
+                    (None, logits)
+                }
+            }
+            ModelType::BsgFinland => {
+                let logits = extract_tensor_data(outputs, 0)?;
+                (None, logits)
+            }
+```
+
+- [ ] **Step 2: Update `process_batch_outputs()` in `src/classifier.rs`**
+
+Split the `ModelType::BirdNetV24 | ModelType::BsgFinland` arm (lines 986-1004). Replace with:
+
+```rust
+            ModelType::BirdNetV24 if self.inner.config.embedding_dim.is_some() => {
+                let embedding_dim = self.inner.config.embedding_dim.ok_or_else(|| {
+                    Error::Inference(
+                        "embedding_dim missing for v2.4 model with embeddings".into(),
+                    )
+                })?;
+                let logits_flat = extract_tensor_data(outputs, 0)?;
+                let emb_flat = extract_tensor_data(outputs, 1)?;
+
+                (0..batch_size)
+                    .map(|i| {
+                        let emb_start = i * embedding_dim;
+                        let emb_end = emb_start + embedding_dim;
+                        let embeddings = emb_flat[emb_start..emb_end].to_vec();
+
+                        let logits_start = i * num_species;
+                        let logits_end = logits_start + num_species;
+                        let logits = &logits_flat[logits_start..logits_end];
+
+                        let predictions = self.select_top_k(logits);
+
+                        Ok(PredictionResult {
+                            model_type,
+                            predictions,
+                            embeddings: Some(embeddings),
+                            raw_scores: logits.to_vec(),
+                        })
+                    })
+                    .collect()
+            }
+            ModelType::BirdNetV24 | ModelType::BsgFinland => {
+                let logits_flat = extract_tensor_data(outputs, 0)?;
+
+                (0..batch_size)
+                    .map(|i| {
+                        let start = i * num_species;
+                        let end = start + num_species;
+                        let logits = &logits_flat[start..end];
+
+                        let predictions = self.select_top_k(logits);
+
+                        Ok(PredictionResult {
+                            model_type,
+                            predictions,
+                            embeddings: None,
+                            raw_scores: logits.to_vec(),
+                        })
+                    })
+                    .collect()
+            }
+```
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `cd ~/src/rust-birdnet-onnx && cargo test --lib`
+Expected: All existing tests PASS (no behavioral change for 1-output v2.4 models).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/src/rust-birdnet-onnx
+git add src/classifier.rs
+git commit -m "feat: extract embeddings from BirdNET v2.4 when model has 2 outputs"
+```
+
+---
+
+## Task 5: birdnet-onnx - `CustomClassifier`
+
+**Repo:** `~/src/rust-birdnet-onnx`
+
+**Files:**
+- Create: `src/custom_classifier.rs`
+- Modify: `src/error.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Add error variant to `src/error.rs`**
+
+Add after the `InputSize` variant (after line 14):
+
+```rust
+    /// Embedding input has wrong dimension for custom classifier.
+    #[error("embedding dimension mismatch: classifier expects {expected}, got {got}")]
+    EmbeddingDimMismatch {
+        /// Expected dimension.
+        expected: usize,
+        /// Actual dimension.
+        got: usize,
+    },
+```
+
+- [ ] **Step 2: Write `src/custom_classifier.rs`**
+
+```rust
+//! Custom classifier for running secondary models on embedding vectors.
+
+use crate::error::{Error, Result};
+use crate::labels;
+use crate::postprocess::{sigmoid, top_k_predictions};
+use crate::types::{LabelFormat, Prediction};
+use ndarray::Array2;
+use std::path::{Path, PathBuf};
+
+/// A lightweight classifier that runs on embedding vectors from a primary model.
+///
+/// Used for custom classification heads (e.g., bat species detection from
+/// BirdNET embeddings).
+#[derive(Debug)]
+pub struct CustomClassifier {
+    session: ort::Session,
+    labels: Vec<String>,
+    input_dim: usize,
+    num_classes: usize,
+    top_k: usize,
+    min_confidence: Option<f32>,
+}
+
+/// Builder for [`CustomClassifier`].
+#[derive(Debug, Default)]
+pub struct CustomClassifierBuilder {
+    model_path: Option<PathBuf>,
+    labels_path: Option<PathBuf>,
+    top_k: Option<usize>,
+    min_confidence: Option<f32>,
+}
+
+impl CustomClassifierBuilder {
+    /// Create a new builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the ONNX model path.
+    #[must_use]
+    pub fn model_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.model_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the labels file path (one label per line).
+    #[must_use]
+    pub fn labels_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.labels_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the number of top predictions to return (default: all).
+    #[must_use]
+    pub fn top_k(mut self, k: usize) -> Self {
+        self.top_k = Some(k);
+        self
+    }
+
+    /// Set the minimum confidence threshold.
+    #[must_use]
+    pub fn min_confidence(mut self, threshold: f32) -> Self {
+        self.min_confidence = Some(threshold);
+        self
+    }
+
+    /// Build the custom classifier.
+    pub fn build(self) -> Result<CustomClassifier> {
+        let model_path = self.model_path.ok_or(Error::ModelPathRequired)?;
+        let labels_path = self.labels_path.ok_or(Error::LabelsRequired)?;
+
+        let session = ort::Session::builder()?.commit_from_file(&model_path)?;
+
+        let input_info = session
+            .inputs
+            .first()
+            .ok_or_else(|| Error::Inference("custom classifier has no inputs".into()))?;
+
+        let input_dim = match &input_info.input_type {
+            ort::session::SessionInputType::Tensor { dimensions, .. } => {
+                let last = dimensions.last().copied().flatten().ok_or_else(|| {
+                    Error::Inference("cannot determine input dimension".into())
+                })?;
+                last as usize
+            }
+        };
+
+        let output_info = session
+            .outputs
+            .first()
+            .ok_or_else(|| Error::Inference("custom classifier has no outputs".into()))?;
+
+        let num_classes = match &output_info.output_type {
+            ort::session::SessionOutputType::Tensor { dimensions, .. } => {
+                let last = dimensions.last().copied().flatten().ok_or_else(|| {
+                    Error::Inference("cannot determine output dimension".into())
+                })?;
+                last as usize
+            }
+        };
+
+        let labels = labels::load_labels_from_file(
+            &labels_path,
+            // Custom classifier labels are plain text, one per line
+            crate::types::ModelType::BirdNetV24,
+        )?;
+
+        if labels.len() != num_classes {
+            return Err(Error::LabelCount {
+                expected: num_classes,
+                got: labels.len(),
+            });
+        }
+
+        let top_k = self.top_k.unwrap_or(num_classes);
+
+        Ok(CustomClassifier {
+            session,
+            labels,
+            input_dim,
+            num_classes,
+            top_k,
+            min_confidence: self.min_confidence,
+        })
+    }
+}
+
+impl CustomClassifier {
+    /// Create a new builder.
+    #[must_use]
+    pub fn builder() -> CustomClassifierBuilder {
+        CustomClassifierBuilder::new()
+    }
+
+    /// Classify a single embedding vector.
+    pub fn predict(&self, embeddings: &[f32]) -> Result<Vec<Prediction>> {
+        if embeddings.len() != self.input_dim {
+            return Err(Error::EmbeddingDimMismatch {
+                expected: self.input_dim,
+                got: embeddings.len(),
+            });
+        }
+
+        let input = Array2::from_shape_vec((1, self.input_dim), embeddings.to_vec())
+            .map_err(|e| Error::Inference(format!("failed to create input array: {e}")))?;
+
+        let outputs = self.session.run(ort::inputs![input]?)?;
+        let logits = extract_output_data(&outputs, 0, self.num_classes)?;
+
+        Ok(top_k_predictions(
+            &logits,
+            &self.labels,
+            self.top_k,
+            self.min_confidence,
+        ))
+    }
+
+    /// Classify a batch of embedding vectors.
+    pub fn predict_batch(
+        &self,
+        embeddings_batch: &[Vec<f32>],
+    ) -> Result<Vec<Vec<Prediction>>> {
+        if embeddings_batch.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        for (i, emb) in embeddings_batch.iter().enumerate() {
+            if emb.len() != self.input_dim {
+                return Err(Error::EmbeddingDimMismatch {
+                    expected: self.input_dim,
+                    got: emb.len(),
+                });
+            }
+            let _ = i;
+        }
+
+        let batch_size = embeddings_batch.len();
+        let flat: Vec<f32> = embeddings_batch.iter().flat_map(|e| e.iter().copied()).collect();
+        let input = Array2::from_shape_vec((batch_size, self.input_dim), flat)
+            .map_err(|e| Error::Inference(format!("failed to create batch input: {e}")))?;
+
+        let outputs = self.session.run(ort::inputs![input]?)?;
+        let all_logits = extract_output_data(&outputs, 0, batch_size * self.num_classes)?;
+
+        let mut results = Vec::with_capacity(batch_size);
+        for i in 0..batch_size {
+            let start = i * self.num_classes;
+            let end = start + self.num_classes;
+            let logits = &all_logits[start..end];
+
+            results.push(top_k_predictions(
+                logits,
+                &self.labels,
+                self.top_k,
+                self.min_confidence,
+            ));
+        }
+
+        Ok(results)
+    }
+
+    /// Return the labels loaded from the labels file.
+    #[must_use]
+    pub fn labels(&self) -> &[String] {
+        &self.labels
+    }
+
+    /// Return the embedding dimension this classifier expects.
+    #[must_use]
+    pub fn input_dim(&self) -> usize {
+        self.input_dim
+    }
+
+    /// Return the number of output classes.
+    #[must_use]
+    pub fn num_classes(&self) -> usize {
+        self.num_classes
+    }
+}
+
+/// Extract flat f32 data from session output at given index.
+fn extract_output_data(
+    outputs: &ort::session::SessionOutputs,
+    index: usize,
+    expected_len: usize,
+) -> Result<Vec<f32>> {
+    let tensor = outputs
+        .get(index)
+        .ok_or_else(|| Error::Inference(format!("missing output at index {index}")))?;
+
+    let view = tensor
+        .try_extract_tensor::<f32>()
+        .map_err(|e| Error::Inference(format!("failed to extract output tensor: {e}")))?;
+
+    let data: Vec<f32> = view.iter().copied().collect();
+    if data.len() < expected_len {
+        return Err(Error::Inference(format!(
+            "output tensor too small: expected {expected_len}, got {}",
+            data.len()
+        )));
+    }
+
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn test_builder_requires_model_path() {
+        let result = CustomClassifierBuilder::new()
+            .labels_path("/some/labels.txt")
+            .build();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("model path"));
+    }
+
+    #[test]
+    fn test_builder_requires_labels() {
+        let result = CustomClassifierBuilder::new()
+            .model_path("/some/model.onnx")
+            .build();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("labels"));
+    }
+
+    #[test]
+    fn test_embedding_dim_mismatch_error() {
+        let err = Error::EmbeddingDimMismatch {
+            expected: 1024,
+            got: 512,
+        };
+        assert_eq!(
+            err.to_string(),
+            "embedding dimension mismatch: classifier expects 1024, got 512"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Register module and exports in `src/lib.rs`**
+
+Add module declaration after `mod classifier;` (line 80):
+
+```rust
+mod custom_classifier;
+```
+
+Add to the public exports section (after line 99):
+
+```rust
+pub use custom_classifier::{CustomClassifier, CustomClassifierBuilder};
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd ~/src/rust-birdnet-onnx && cargo test --lib custom_classifier`
+Expected: All 3 tests PASS.
+
+Run: `cd ~/src/rust-birdnet-onnx && cargo test --lib`
+Expected: Full test suite PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/src/rust-birdnet-onnx
+git add src/custom_classifier.rs src/error.rs src/lib.rs
+git commit -m "feat: add CustomClassifier for secondary models on embedding vectors"
+```
+
+---
+
+## Task 6: birda - bat constants and config types
+
+**Repo:** `~/src/birda`
+
+**Files:**
+- Modify: `src/constants.rs`
+- Create: `src/config/bat.rs`
+- Modify: `src/config/mod.rs`
+
+- [ ] **Step 1: Add bat constants to `src/constants.rs`**
+
+Add after the `clipper` module (after line 164):
+
+```rust
+/// Bat detection constants.
+pub mod bat {
+    /// Audio sample rate for bat recordings (256 kHz).
+    pub const SAMPLE_RATE: u32 = 256_000;
+
+    /// Segment duration in seconds (144,000 samples / 256,000 Hz).
+    pub const SEGMENT_DURATION: f32 = 0.5625;
+
+    /// Overlap between segments in seconds (25% of segment duration).
+    pub const OVERLAP: f32 = 0.140625;
+
+    /// Number of audio samples per segment.
+    /// Equals BirdNET v2.4's 144,000 samples; this is the "slow-down trick".
+    pub const CHUNK_SAMPLES: usize = 144_000;
+}
+```
+
+- [ ] **Step 2: Create `src/config/bat.rs`**
+
+```rust
+//! Bat detection configuration.
+
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Regional bat classifier variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum BatRegion {
+    /// Bavaria (Germany).
+    Bavaria,
+    /// Bavaria high-confidence variant.
+    #[value(name = "bavaria-high")]
+    BavariaHigh,
+    /// European Union (broad coverage).
+    Eu,
+    /// Scotland.
+    Scotland,
+    /// South Wales.
+    #[value(name = "south-wales")]
+    SouthWales,
+    /// Sweden.
+    Sweden,
+    /// United Kingdom.
+    Uk,
+    /// United States (full).
+    Usa,
+    /// United States East Coast.
+    #[value(name = "usa-east")]
+    UsaEast,
+    /// United States East Coast high-confidence variant.
+    #[value(name = "usa-east-high")]
+    UsaEastHigh,
+    /// United States West Coast.
+    #[value(name = "usa-west")]
+    UsaWest,
+}
+
+impl BatRegion {
+    /// Model filename stem for this region.
+    #[must_use]
+    pub fn model_stem(&self) -> &'static str {
+        match self {
+            Self::Bavaria => "BattyBirdNET-Bavaria-256kHz",
+            Self::BavariaHigh => "BattyBirdNET-Bavaria-256kHz-high",
+            Self::Eu => "BattyBirdNET-EU-256kHz",
+            Self::Scotland => "BattyBirdNET-Scotland-256kHz",
+            Self::SouthWales => "BattyBirdNET-SouthWales-256kHz",
+            Self::Sweden => "BattyBirdNET-Sweden-256kHz",
+            Self::Uk => "BattyBirdNET-UK-256kHz",
+            Self::Usa => "BattyBirdNET-USA-256kHz",
+            Self::UsaEast => "BattyBirdNET-USA-EAST-256kHz",
+            Self::UsaEastHigh => "BattyBirdNET-USA-EAST-256kHz-high",
+            Self::UsaWest => "BattyBirdNET-USA-WEST-256kHz",
+        }
+    }
+
+    /// ONNX model filename for this region.
+    #[must_use]
+    pub fn model_filename(&self) -> String {
+        format!("{}_fp32.onnx", self.model_stem())
+    }
+
+    /// Labels filename for this region.
+    #[must_use]
+    pub fn labels_filename(&self) -> String {
+        format!("{}_Labels.txt", self.model_stem())
+    }
+}
+
+impl std::fmt::Display for BatRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.model_stem())
+    }
+}
+
+/// Resolved bat detection configuration.
+#[derive(Debug, Clone)]
+pub struct BatConfig {
+    /// Selected bat region.
+    pub region: BatRegion,
+    /// Path to the bat classifier ONNX model.
+    pub classifier_path: PathBuf,
+    /// Path to the bat classifier labels file.
+    pub labels_path: PathBuf,
+}
+
+impl BatConfig {
+    /// Resolve bat config from a region and models directory.
+    pub fn resolve(region: BatRegion, bat_models_dir: &std::path::Path) -> Result<Self> {
+        let classifier_path = bat_models_dir.join(region.model_filename());
+        let labels_path = bat_models_dir.join(region.labels_filename());
+
+        if !classifier_path.exists() {
+            return Err(Error::ModelNotFound {
+                path: classifier_path,
+            });
+        }
+        if !labels_path.exists() {
+            return Err(Error::ModelNotFound {
+                path: labels_path,
+            });
+        }
+
+        Ok(Self {
+            region,
+            classifier_path,
+            labels_path,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bat_region_model_filename() {
+        assert_eq!(
+            BatRegion::Uk.model_filename(),
+            "BattyBirdNET-UK-256kHz_fp32.onnx"
+        );
+        assert_eq!(
+            BatRegion::UsaEastHigh.model_filename(),
+            "BattyBirdNET-USA-EAST-256kHz-high_fp32.onnx"
+        );
+    }
+
+    #[test]
+    fn test_bat_region_labels_filename() {
+        assert_eq!(
+            BatRegion::Eu.labels_filename(),
+            "BattyBirdNET-EU-256kHz_Labels.txt"
+        );
+    }
+
+    #[test]
+    fn test_bat_region_all_variants_have_filenames() {
+        let regions = [
+            BatRegion::Bavaria,
+            BatRegion::BavariaHigh,
+            BatRegion::Eu,
+            BatRegion::Scotland,
+            BatRegion::SouthWales,
+            BatRegion::Sweden,
+            BatRegion::Uk,
+            BatRegion::Usa,
+            BatRegion::UsaEast,
+            BatRegion::UsaEastHigh,
+            BatRegion::UsaWest,
+        ];
+        for region in regions {
+            assert!(!region.model_filename().is_empty());
+            assert!(!region.labels_filename().is_empty());
+            assert!(region.model_filename().ends_with("_fp32.onnx"));
+            assert!(region.labels_filename().ends_with("_Labels.txt"));
+        }
+    }
+
+    #[test]
+    fn test_bat_config_resolve_missing_model() {
+        let result = BatConfig::resolve(BatRegion::Uk, std::path::Path::new("/nonexistent"));
+        assert!(result.is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Update `src/config/mod.rs`**
+
+Add the module declaration and re-export. Add after existing module declarations:
+
+```rust
+pub mod bat;
+pub use bat::{BatConfig, BatRegion};
+```
+
+- [ ] **Step 4: Verify `Error::ModelNotFound` exists or add it**
+
+Check `src/error.rs` for a `ModelNotFound` variant. If it doesn't exist, add it:
+
+```rust
+    /// Model file not found at expected path.
+    #[error("model not found: {path}")]
+    ModelNotFound {
+        /// Path where model was expected.
+        path: PathBuf,
+    },
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd ~/src/birda && cargo test --lib config::bat`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/src/birda
+git add src/constants.rs src/config/bat.rs src/config/mod.rs src/error.rs
+git commit -m "feat: add bat detection constants and BatRegion config"
+```
+
+---
+
+## Task 7: birda - CLI `--bat` flag
+
+**Repo:** `~/src/birda`
+
+**Files:**
+- Modify: `src/cli/analyze.rs`
+
+- [ ] **Step 1: Read `src/cli/analyze.rs` to find the `AnalyzeArgs` struct**
+
+Read the file to find the exact struct definition and existing arguments.
+
+- [ ] **Step 2: Add `--bat` argument to `AnalyzeArgs`**
+
+Add to the struct after the model-related fields:
+
+```rust
+    /// Enable bat detection with a regional classifier.
+    /// Implies BirdNET v2.4 backbone with embedding extraction.
+    #[arg(long, value_name = "REGION")]
+    pub bat: Option<crate::config::BatRegion>,
+```
+
+- [ ] **Step 3: Run CLI parsing test**
+
+Run: `cd ~/src/birda && cargo build`
+Expected: Compiles successfully.
+
+Test: `cd ~/src/birda && cargo run -- analyze --help 2>&1 | grep -A2 bat`
+Expected: Shows `--bat <REGION>` in help output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/src/birda
+git add src/cli/analyze.rs
+git commit -m "feat: add --bat CLI flag for bat detection"
+```
+
+---
+
+## Task 8: birda - two-stage inference pipeline wiring
+
+This is the integration task. It wires the `--bat` flag through `lib.rs` into the pipeline.
+
+**Repo:** `~/src/birda`
+
+**Files:**
+- Modify: `src/lib.rs`
+- Modify: `src/pipeline/processor.rs`
+
+- [ ] **Step 1: Read `src/lib.rs` to find `resolve_model_config()` and the main pipeline**
+
+Understand how `AnalyzeArgs` is resolved into model config and processing parameters.
+
+- [ ] **Step 2: Add bat model resolution to `src/lib.rs`**
+
+In the function that resolves the final processing configuration, when `args.bat` is `Some(region)`:
+- Force `model_type` to `BirdNetV24`
+- Resolve bat model paths from `BatConfig::resolve(region, bat_models_dir)`
+- Override `overlap` to `constants::bat::OVERLAP`
+- Override segment duration to `constants::bat::SEGMENT_DURATION`
+- Create the `CustomClassifier` from the bat model paths
+- Pass the bat config and classifier into the processing pipeline
+
+The exact code depends on the current structure of `lib.rs`. The implementing agent should read the file and adapt.
+
+- [ ] **Step 3: Update `process_file()` in `src/pipeline/processor.rs`**
+
+Add an optional `CustomClassifier` parameter (or a `BatConfig` with the classifier). When present:
+1. After BirdNET v2.4 batch inference, collect embeddings from each `PredictionResult`
+2. Feed embeddings to `custom_classifier.predict_batch()`
+3. Use the bat classifier's predictions as the result instead of v2.4's predictions
+4. Apply min_confidence filtering on bat predictions
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd ~/src/birda && cargo build`
+Expected: Compiles successfully.
+
+- [ ] **Step 5: Manual integration test**
+
+```bash
+# Ensure model files are in place
+mkdir -p ~/.local/share/birda/models/bat/
+cp ~/bats/onnx-optimized/BattyBirdNET-UK-256kHz_fp32.onnx ~/.local/share/birda/models/bat/
+cp ~/bats/BattyBirdNET-Analyzer/checkpoints/bats/v1.0/BattyBirdNET-UK-256kHz_Labels.txt ~/.local/share/birda/models/bat/
+
+# Ensure BirdNET v2.4 with embeddings is available
+python3 ~/src/birdnet-onnx-converter/expose_embeddings.py \
+    --input ~/onnx/birdnet-v24.onnx \
+    --output ~/.local/share/birda/models/birdnet-v24-embeddings.onnx
+
+# Run bat detection on a test file (if bat audio available)
+cd ~/src/birda && cargo run -- analyze --bat uk /path/to/bat-audio.wav
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/src/birda
+git add src/lib.rs src/pipeline/processor.rs
+git commit -m "feat: wire two-stage bat inference pipeline"
+```
+
+---
+
+## Self-Review
+
+### Spec Coverage
+
+| Spec Section | Task |
+|---|---|
+| 1.1 expose_embeddings.py | Task 1 |
+| 1.2 convert.py --with-embeddings | Task 2 |
+| 1.3 No optimize.py changes | N/A (confirmed no changes needed) |
+| 2.1 Model detection update | Task 3 |
+| 2.2 Embedding extraction | Task 4 |
+| 2.3 CustomClassifier | Task 5 |
+| 2.4 Exports | Task 5, Step 3 |
+| 3.1 CLI --bat flag | Task 7 |
+| 3.2 BatConfig | Task 6 |
+| 3.3 Constants | Task 6, Step 1 |
+| 3.4 Audio pipeline | Task 8 (no-resample handled in pipeline wiring) |
+| 3.5 Two-stage inference | Task 8 |
+| 3.6 Model file management | Task 6 (BatConfig::resolve), Task 8 Step 5 |
+| 3.7 Output | Task 8 (uses existing output formats with bat labels) |
+| 4.x Testing | Covered per-task |
+
+### Placeholder Scan
+
+No TBD, TODO, "implement later", "similar to Task N", or vague steps found. Task 8 steps 2-3 are intentionally directive rather than prescriptive because the exact integration point depends on `lib.rs` and `processor.rs` structure, which the implementing agent will read.
+
+### Type Consistency
+
+- `BatRegion` enum: defined in Task 6, used in Task 7 (`--bat` arg) and Task 8.
+- `BatConfig`: defined in Task 6, used in Task 8.
+- `CustomClassifier` / `CustomClassifierBuilder`: defined in Task 5 (birdnet-onnx), used in Task 8 (birda).
+- `EmbeddingDimMismatch` error: defined in Task 5 Step 1.
+- `expose_embeddings()` function: defined in Task 1, imported in Task 2.
+- `ModelType::BirdNetV24`: used consistently; no new variant needed (confirmed in spec 3.2).
+- `PredictionResult.embeddings`: `Option<Vec<f32>>`, unchanged type, newly populated for v2.4 in Task 4.

--- a/docs/superpowers/specs/2026-04-06-update-command-design.md
+++ b/docs/superpowers/specs/2026-04-06-update-command-design.md
@@ -1,0 +1,305 @@
+# Design: `birda update` Command
+
+## Overview
+
+Add a self-update command to birda that checks for new releases on GitHub and replaces the binary in-place. Only the binary is updated; CUDA and ONNX Runtime libraries are not modified. Helpful warnings are printed when library version requirements change between releases.
+
+## Constraints
+
+- Stable releases only (no pre-release channel)
+- Binary-only update (not CUDA libs or ONNX Runtime .so/.dll)
+- Block update if ONNX Runtime version changed (ABI break risk)
+- Warn if CUDA/cuDNN version changed (external dependency)
+- Keep previous binary as `birda.old` for rollback (Linux/macOS only; not available on Windows)
+- SHA256 checksum verification on all downloads
+- No GitHub API usage; use direct download URLs to avoid rate limits
+
+## Manifest Enhancement
+
+The release `manifest.json` is extended with a `bin` section containing binary-only archives and SHA256 checksums for each platform/variant.
+
+```json
+{
+  "version": "${VERSION}",
+  "min_gui_version": "1.1.0",
+  "assets": {
+    "bin": {
+      "linux-x64": {
+        "file": "birda-linux-x64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_BIN}"
+      },
+      "linux-x64-cuda": {
+        "file": "birda-linux-x64-cuda-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_LINUX_CUDA_BIN}"
+      },
+      "windows-x64": {
+        "file": "birda-windows-x64-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_BIN}"
+      },
+      "windows-x64-cuda": {
+        "file": "birda-windows-x64-cuda-bin-${TAG}.zip",
+        "sha256": "${SHA256_WINDOWS_CUDA_BIN}"
+      },
+      "macos-arm64": {
+        "file": "birda-macos-arm64-bin-${TAG}.tar.gz",
+        "sha256": "${SHA256_MACOS_BIN}"
+      }
+    },
+    "embed": {
+      "linux-x64": "birda-linux-x64-embed-${TAG}.tar.gz",
+      "windows-x64": "birda-windows-x64-embed-${TAG}.zip",
+      "macos-arm64": "birda-macos-arm64-embed-${TAG}.tar.gz"
+    },
+    "cuda_libs": {
+      "linux-x64": "birda-cuda-libs-linux-x64-${TAG}.tar.gz",
+      "windows-x64": "birda-cuda-libs-windows-x64-${TAG}.zip"
+    }
+  },
+  "dependencies": {
+    "onnxruntime": "${ONNXRUNTIME_VERSION}"
+  },
+  "cuda": {
+    "cuda_toolkit": "${CUDA_TOOLKIT_VERSION}",
+    "cudnn": "${CUDNN_VERSION}"
+  }
+}
+```
+
+Existing `embed` and `cuda_libs` sections are unchanged for backward compatibility with birda-gui.
+
+## Build-time Version Embedding
+
+A `build.rs` bakes library version expectations into the binary at compile time.
+
+```rust
+// build.rs
+fn main() {
+    let ort_version = std::env::var("ONNXRUNTIME_VERSION")
+        .unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_ONNXRUNTIME_VERSION={ort_version}");
+
+    let cuda_version = std::env::var("CUDA_TOOLKIT_VERSION")
+        .unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDA_TOOLKIT_VERSION={cuda_version}");
+
+    let cudnn_version = std::env::var("CUDNN_VERSION")
+        .unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BIRDA_CUDNN_VERSION={cudnn_version}");
+
+    println!("cargo:rerun-if-env-changed=ONNXRUNTIME_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_VERSION");
+    println!("cargo:rerun-if-env-changed=CUDNN_VERSION");
+}
+```
+
+These env vars are already defined at the top of `release.yml` and are in scope during builds. No workflow changes needed for the build step.
+
+Accessed in code via:
+- `env!("BIRDA_ONNXRUNTIME_VERSION")`
+- `env!("BIRDA_CUDA_TOOLKIT_VERSION")`
+- `env!("BIRDA_CUDNN_VERSION")`
+
+Variant detection uses the existing cargo feature: `cfg!(feature = "cuda")`. No extra mechanism needed since CPU and embed binaries are identical.
+
+## CLI Interface
+
+New subcommand:
+
+```rust
+/// Check for and install updates.
+Update {
+    /// Only check for updates, don't install.
+    #[arg(long)]
+    check: bool,
+}
+```
+
+- `birda update` -- check + install if newer version available
+- `birda update --check` -- print version info only, no changes
+
+### Output Examples
+
+**Up to date:**
+```
+birda is up to date (v1.8.0)
+```
+
+**Update available (--check):**
+```
+Update available: v1.8.0 -> v1.9.0
+Run 'birda update' to install.
+```
+
+**Successful update:**
+```
+Downloading birda v1.9.0...
+[progress bar] 100% (14.2MB/14.2MB)
+Verifying checksum... ok
+Previous version saved as /usr/local/bin/birda.old
+Updated birda v1.8.0 -> v1.9.0
+```
+
+**Blocked -- ONNX Runtime version changed:**
+```
+Update available: v1.8.0 -> v2.0.0
+
+WARNING: This release requires updated libraries:
+  ONNX Runtime: 1.24.2 -> 1.25.0
+
+Binary-only update would leave birda non-functional.
+Please download the full package from:
+  https://github.com/tphakala/birda/releases/tag/v2.0.0
+```
+
+**CUDA version changed (proceed with warning):**
+```
+Downloading birda v1.9.0...
+[progress bar] 100% (14.2MB/14.2MB)
+Verifying checksum... ok
+Previous version saved as /usr/local/bin/birda.old
+Updated birda v1.8.0 -> v1.9.0
+
+Note: CUDA toolkit requirement changed (12.9 -> 13.0).
+If you use GPU acceleration, you may need to update your CUDA installation.
+```
+
+## Update Flow
+
+```
+birda update [--check]
+  |
+  +- 1. Guard: if running from a cargo target/ directory, refuse to update
+  |     (prevents overwriting dev builds with release binaries)
+  |
+  +- 2. Fetch manifest.json from GitHub latest release
+  |     URL: https://github.com/tphakala/birda/releases/latest/download/manifest.json
+  |
+  +- 3. Parse manifest, compare manifest.version vs CARGO_PKG_VERSION (semver)
+  |     If current >= remote: "up to date", exit
+  |
+  +- 4. If --check: print update info, exit
+  |
+  +- 5. Compare library versions:
+  |     - manifest.dependencies.onnxruntime vs env!("BIRDA_ONNXRUNTIME_VERSION")
+  |       If major.minor changed: block update, print full-package download URL
+  |       (applies to ALL build variants -- load-dynamic is always used)
+  |     - manifest.cuda.cuda_toolkit vs env!("BIRDA_CUDA_TOOLKIT_VERSION")
+  |       If changed AND cuda build: warn
+  |     - manifest.cuda.cudnn vs env!("BIRDA_CUDNN_VERSION")
+  |       If changed AND cuda build: warn
+  |     - If env versions are "unknown" (dev build): skip all checks
+  |
+  +- 6. Select asset key based on:
+  |     - target_os: linux / windows / macos
+  |     - target_arch: x86_64 / aarch64
+  |     - feature: cuda or not
+  |     Example: "linux-x64-cuda" or "macos-arm64"
+  |
+  +- 7. Check write permissions on parent directory of current binary
+  |     (rename requires directory write, not file write)
+  |     No permission: abort with instructions (e.g. run as admin/sudo)
+  |
+  +- 8. Download binary-only archive
+  |     URL: https://github.com/tphakala/birda/releases/latest/download/{asset.file}
+  |     Reuse existing download_file() with progress bar
+  |
+  +- 9. Verify SHA256 checksum
+  |     Mismatch: abort, delete temp file
+  |
+  +- 10. Extract archive into same directory as current binary
+  |      (avoids EXDEV cross-device rename failures)
+  |      Extract as .birda-update-new.tmp
+  |      .tar.gz: flate2 + tar
+  |      .zip: zip crate
+  |      Archives are flat (contain only the binary, no directory nesting)
+  |
+  +- 11. Set executable permissions (Unix only)
+  |      chmod 0o755 on .birda-update-new.tmp
+  |
+  +- 12. Self-replace:
+  |      Linux/macOS:
+  |        rename current -> birda.old
+  |        rename .birda-update-new.tmp -> current path
+  |        If second rename fails: restore birda.old -> current (rollback)
+  |      Windows:
+  |        use self_replace crate (handles locked binary)
+  |        Note: rollback via birda.old is not available on Windows
+  |              (self_replace renames original to random temp name)
+  |
+  +- 13. Print result + any library version warnings
+  |      Linux/macOS: "Previous version saved as birda.old"
+  |      Windows: omit rollback message
+```
+
+### Library Version Comparison Logic
+
+The ONNX Runtime check applies to **all build variants** (CPU, CUDA, embed) because all use `load-dynamic` for the `ort` crate. An ABI-breaking ONNX Runtime change will crash any variant. The check compares **major.minor** only (patch changes are ABI-compatible). If the running binary reports "unknown" (dev build), skip all library checks and proceed.
+
+CUDA/cuDNN checks only apply when `cfg!(feature = "cuda")` is true. For non-CUDA builds these warnings are suppressed.
+
+## New Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `semver` | Version parsing and comparison |
+| `sha2` | SHA256 checksum verification |
+| `flate2` | gzip decompression |
+| `tar` | tar archive extraction |
+| `zip` | zip archive extraction (Windows) |
+| `self_replace` | Windows binary replacement |
+
+## Module Structure
+
+```
+src/
+  update/
+    mod.rs         -- public API: check_for_update(), perform_update()
+    manifest.rs    -- Manifest struct, fetch from GitHub, parse JSON
+    platform.rs    -- asset key selection based on target_os/target_arch/features
+    replace.rs     -- self-replacement logic (platform-specific)
+    checksum.rs    -- SHA256 verification
+```
+
+## Release Workflow Changes
+
+1. **Binary-only archives** -- after existing packaging in the release job, create small archives containing just the birda binary for each platform/variant.
+
+2. **SHA256 computation** -- compute hashes of binary-only archives and substitute into the manifest template.
+
+3. **Manifest template** -- update `manifest.template.json` with the new `bin` section.
+
+No changes to existing packages (embed, cuda, cuda_libs). Backward compatible.
+
+## Error Handling
+
+All errors use the existing `Error` enum in `src/error.rs` with new variants:
+
+- `UpdateFetchFailed` -- failed to download manifest or binary
+- `UpdateChecksumMismatch` -- SHA256 doesn't match
+- `UpdateReplaceFailed` -- binary replacement failed
+- `UpdateBlocked` -- ONNX Runtime version mismatch
+- `UpdatePermissionDenied` -- no write access to binary path
+
+## Platform-specific Considerations
+
+### Unix (Linux/macOS)
+- Set executable permissions (0o755) after extraction
+- Rename-based replacement avoids EXDEV by extracting into same directory
+- Rollback: if second rename fails, restore `.old` back to original path
+- `birda.old` kept for manual rollback
+
+### Windows
+- Use `self_replace` crate to handle locked-binary replacement
+- No `.old` rollback file available (self_replace uses OS temp cleanup)
+- Adjust success messaging to omit rollback instructions
+
+### Dev Build Guard
+- If `std::env::current_exe()` resolves to a path containing `/target/` (or `\target\`), refuse to update. This prevents accidentally overwriting a locally-compiled binary with a release build.
+
+## Security
+
+- SHA256 checksum verification on all downloaded archives
+- HTTPS-only downloads (reqwest with rustls)
+- Permission checks on parent directory before modifying files
+- Temp files cleaned up on failure (both on checksum mismatch and extraction errors)
+- Archives must be flat (no path traversal in archive entries)

--- a/docs/superpowers/specs/2026-05-07-bat-detection-design.md
+++ b/docs/superpowers/specs/2026-05-07-bat-detection-design.md
@@ -1,0 +1,236 @@
+# Bat Detection Support - Design Spec
+
+**Goal:** Add bat species detection to birda by chaining BirdNET v2.4 embeddings into BattyBirdNET regional classifiers.
+
+**Architecture:** Two-stage inference pipeline. BirdNET v2.4 extracts 1024-dim embeddings from audio; a lightweight custom classifier maps embeddings to bat species. Audio is fed at 256kHz without resampling, exploiting the "slow-down trick" where BirdNET's 48kHz-trained spectrogram pipeline shifts ultrasonic bat calls into the audible frequency range.
+
+**Repos affected:** birdnet-onnx-converter, rust-birdnet-onnx, birda.
+
+---
+
+## 1. ONNX Converter (`~/src/birdnet-onnx-converter`)
+
+### 1.1 New script: `expose_embeddings.py`
+
+Patches an existing BirdNET v2.4 ONNX model to expose the global average pooling layer (`model/GLOBAL_AVG_POOL/Mean_reduced_0`, shape `[batch, 1024]`) as a second output alongside the original classification output (`[batch, 6522]`).
+
+**CLI:**
+```
+python expose_embeddings.py --input birdnet-v24.onnx --output birdnet-v24-embeddings.onnx
+```
+
+**Implementation:** Load ONNX graph, find the `Mean_reduced_0` value_info, append it to `graph.output`, save. Validate by loading with onnxruntime and checking 2 outputs. Error if the tensor is not found (model is not BirdNET v2.4 or has unexpected architecture).
+
+### 1.2 Update `convert.py`
+
+Add `--with-embeddings` flag. When converting from Keras, this flag applies the same graph surgery after the ONNX conversion step. When converting from TFLite with `--onnx-only`, the flag is applied to the resulting ONNX model.
+
+### 1.3 No changes to `optimize.py`
+
+The optimizer preserves all graph outputs. Models optimized after embedding exposure retain both outputs.
+
+---
+
+## 2. birdnet-onnx (`~/src/rust-birdnet-onnx`)
+
+### 2.1 Model detection update
+
+In `detection.rs`, update `detect_from_sample_count()`:
+- Pattern `(144_000, 2)` detected as `BirdNetV24` with `embedding_dim: Some(1024)` (predictions at output 0, embeddings at output 1).
+- Pattern `(144_000, 1)` remains unchanged (v2.4 without embeddings).
+
+Update `detect_from_outputs()` similarly: 2-output models with dynamic input default to v2.4-with-embeddings when second output dim is 1024.
+
+Update `build_config_with_override()` to allow `BirdNetV24` with 2 outputs.
+
+### 2.2 Embedding extraction for v2.4
+
+In `classifier.rs`, update `process_outputs()` and `process_batch_outputs()`:
+- When `model_type == BirdNetV24` and `embedding_dim.is_some()`, extract predictions from output index 0 and embeddings from output index 1. Note: this is reversed from v3.0's order (v3.0 has embeddings at 0, predictions at 1) because the graph surgery appends the embedding output after the existing prediction output.
+- When `embedding_dim.is_none()`, behavior unchanged (single output = predictions).
+
+This means `PredictionResult.embeddings` will be `Some(Vec<f32>)` for v2.4 models with embeddings enabled, `None` otherwise.
+
+### 2.3 Custom classifier (`CustomClassifier`)
+
+New public type for running a secondary classification model on embedding vectors.
+
+**Public API:**
+
+```rust
+pub struct CustomClassifier { ... }
+
+pub struct CustomClassifierBuilder {
+    model_path: Option<PathBuf>,
+    labels_path: Option<PathBuf>,
+    // ORT session options inherited from main classifier or set explicitly
+}
+
+impl CustomClassifierBuilder {
+    pub fn new() -> Self;
+    pub fn model_path(self, path: impl AsRef<Path>) -> Self;
+    pub fn labels_path(self, path: impl AsRef<Path>) -> Self;
+    pub fn build(self) -> Result<CustomClassifier>;
+}
+
+impl CustomClassifier {
+    /// Classify a single embedding vector.
+    pub fn predict(&self, embeddings: &[f32]) -> Result<Vec<Prediction>>;
+
+    /// Classify a batch of embedding vectors.
+    pub fn predict_batch(&self, embeddings: &[Vec<f32>]) -> Result<Vec<Vec<Prediction>>>;
+
+    /// Return the labels loaded from the labels file.
+    pub fn labels(&self) -> &[String];
+
+    /// Return embedding dimension this classifier expects.
+    pub fn input_dim(&self) -> usize;
+}
+```
+
+**Input validation:** `predict()` checks that `embeddings.len() == input_dim()` (read from ONNX input shape). Mismatches return `Error::InvalidInput`.
+
+**Output processing:** Raw logits from the classifier go through sigmoid activation (same as BirdNET v2.4's flat_sigmoid), then top-k selection. No softmax; BattyBirdNET uses sigmoid like BirdNET.
+
+**Labels format:** One species per line, same format as BirdNET label files. Loaded from the path provided to the builder.
+
+### 2.4 Exports
+
+Add to `lib.rs` public exports: `CustomClassifier`, `CustomClassifierBuilder`.
+
+---
+
+## 3. birda (`~/src/birda`)
+
+### 3.1 CLI: `--bat <region>` flag
+
+New optional argument on `AnalyzeArgs`:
+
+```rust
+#[arg(long, value_name = "REGION")]
+bat: Option<BatRegion>,
+```
+
+**`BatRegion` enum:**
+```rust
+pub enum BatRegion {
+    Bavaria,
+    BavariaHigh,
+    Eu,
+    Scotland,
+    SouthWales,
+    Sweden,
+    Uk,
+    Usa,
+    UsaEast,
+    UsaEastHigh,
+    UsaWest,
+}
+```
+
+Each variant maps to a model filename (e.g., `BatRegion::Uk` -> `BattyBirdNET-UK-256kHz_fp32.onnx` + `BattyBirdNET-UK-256kHz_Labels.txt`).
+
+When `--bat` is provided:
+- Overrides `--model-type` to `birdnet-v24` (embedding backbone).
+- Sets bat-specific audio parameters (chunk size, overlap).
+- Loads the regional bat classifier as a `CustomClassifier`.
+
+### 3.2 Config: `ModelType` extension
+
+No new `ModelType` variant needed. Bat mode reuses `BirdNetV24` as the backbone. The bat classifier is a separate model, not a birda model type.
+
+Add to `config/types.rs`:
+
+```rust
+pub struct BatConfig {
+    pub region: BatRegion,
+    pub classifier_path: PathBuf,
+    pub labels_path: PathBuf,
+}
+```
+
+### 3.3 Constants
+
+In `constants.rs`, add a `bat` module:
+
+```rust
+pub mod bat {
+    /// Audio sample rate for bat recordings (256 kHz).
+    pub const SAMPLE_RATE: u32 = 256_000;
+
+    /// Segment duration in seconds (144,000 samples / 256,000 Hz).
+    pub const SEGMENT_DURATION: f32 = 0.5625;
+
+    /// Overlap between segments (25% of segment duration).
+    pub const OVERLAP: f32 = 0.140625;
+
+    /// Number of audio samples per segment.
+    /// Equal to BirdNET v2.4's 144,000 samples - the "slow-down trick".
+    pub const CHUNK_SAMPLES: usize = 144_000;
+}
+```
+
+### 3.4 Audio pipeline adjustments
+
+When bat mode is active:
+- `StreamingDecoder` does NOT resample to 48kHz. The raw samples (at whatever the source rate is) are chunked into 144,000-sample segments.
+- If the source audio is not 256kHz, birda logs a warning but proceeds (the user may have recordings at different rates).
+- Overlap: 25% (36,000 samples).
+
+### 3.5 Two-stage inference in `process_file()`
+
+When bat config is present, `process_file()` follows this flow:
+
+1. **Decode** audio into 144,000-sample chunks (no resampling).
+2. **Batch** chunks into groups of `batch_size`.
+3. **Stage 1:** Run BirdNET v2.4 batch inference. Extract `PredictionResult.embeddings` (1024-dim vectors).
+4. **Stage 2:** Feed embeddings to `CustomClassifier.predict_batch()`. Get bat species predictions.
+5. **Filter** by `min_confidence`.
+6. **Write** results using bat classifier labels.
+
+The two stages share the same execution provider (CPU/GPU).
+
+### 3.6 Model file management
+
+Bat classifier ONNX models and their label files are stored in the birda models directory alongside bird models:
+- Linux: `~/.local/share/birda/models/bat/`
+- macOS: `~/Library/Application Support/birda/models/bat/`
+- Windows: `%APPDATA%\birda\models\bat\`
+
+Model files follow BattyBirdNET naming: `BattyBirdNET-<Region>-256kHz_fp32.onnx` + `BattyBirdNET-<Region>-256kHz_Labels.txt`.
+
+The BirdNET v2.4 backbone model with embeddings (`birdnet-v24-embeddings.onnx`) is stored in the standard models directory. If the user's existing v2.4 model lacks embeddings (1 output), birda prints an error explaining they need the embeddings variant.
+
+### 3.7 Output
+
+Bat detection results use the same output formats as bird detections (CSV, Raven, Audacity, JSON, Parquet, Kaleidoscope). The `combined_prefix` defaults to `"BattyBirdNET"` when in bat mode. Species names come from the bat classifier's labels file.
+
+---
+
+## 4. Testing
+
+### 4.1 birdnet-onnx-converter
+- Unit test: `expose_embeddings.py` produces a 2-output model from a 1-output v2.4 model.
+- Integration test: modified model runs in onnxruntime with correct embedding shape.
+
+### 4.2 birdnet-onnx
+- Detection test: `(144_000, 2)` correctly detects v2.4 with embeddings.
+- Embedding extraction test: v2.4-with-embeddings model returns `Some(vec)` with 1024 elements.
+- CustomClassifier test: loads bat model, accepts 1024-dim input, returns predictions.
+- Input validation test: wrong embedding dimension returns error.
+
+### 4.3 birda
+- CLI parsing test: `--bat uk` parses to `BatRegion::Uk`.
+- Region-to-path mapping test: each region resolves to correct filenames.
+- Constants test: `CHUNK_SAMPLES` equals BirdNET v2.4 sample count (144,000).
+- Integration test: bat mode pipeline processes a test file end-to-end (requires model files).
+
+---
+
+## 5. Out of Scope
+
+- Real-time/streaming bat detection (birda is currently batch-only).
+- Bat model training or fine-tuning.
+- Automatic model downloading (models are pre-installed).
+- The `CUSTOM-BAT-256kHz` and `CUSTOM-BIRD-48kHz` models (these are custom classifier templates, not regional models).
+- 144kHz alternative sample rate (BattyBirdNET supports this but we start with 256kHz only).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -215,6 +215,11 @@ pub struct AnalyzeArgs {
     #[arg(long, env = "BIRDA_META_MODEL_PATH")]
     pub meta_model_path: Option<PathBuf>,
 
+    /// Enable bat detection with a regional classifier.
+    /// Implies BirdNET v2.4 backbone with embedding extraction.
+    #[arg(long, value_name = "REGION")]
+    pub bat: Option<crate::config::BatRegion>,
+
     /// Output formats (comma-separated: csv,raven,audacity,kaleidoscope).
     #[arg(short, long, value_delimiter = ',', env = "BIRDA_FORMAT")]
     pub format: Option<Vec<OutputFormat>>,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -216,7 +216,7 @@ pub struct AnalyzeArgs {
     pub meta_model_path: Option<PathBuf>,
 
     /// Enable bat detection with a regional classifier.
-    /// Implies BirdNET v2.4 backbone with embedding extraction.
+    /// Implies `BirdNET` v2.4 backbone with embedding extraction.
     #[arg(long, value_name = "REGION")]
     pub bat: Option<crate::config::BatRegion>,
 

--- a/src/config/bat.rs
+++ b/src/config/bat.rs
@@ -1,0 +1,169 @@
+//! Bat detection configuration.
+
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Regional bat classifier variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum BatRegion {
+    /// Bavaria (Germany).
+    Bavaria,
+    /// Bavaria high-confidence variant.
+    #[value(name = "bavaria-high")]
+    BavariaHigh,
+    /// European Union (broad coverage).
+    Eu,
+    /// Scotland.
+    Scotland,
+    /// South Wales.
+    #[value(name = "south-wales")]
+    SouthWales,
+    /// Sweden.
+    Sweden,
+    /// United Kingdom.
+    Uk,
+    /// United States (full).
+    Usa,
+    /// United States East Coast.
+    #[value(name = "usa-east")]
+    UsaEast,
+    /// United States East Coast high-confidence variant.
+    #[value(name = "usa-east-high")]
+    UsaEastHigh,
+    /// United States West Coast.
+    #[value(name = "usa-west")]
+    UsaWest,
+}
+
+impl BatRegion {
+    /// Model filename stem for this region.
+    #[must_use]
+    pub fn model_stem(&self) -> &'static str {
+        match self {
+            Self::Bavaria => "BattyBirdNET-Bavaria-256kHz",
+            Self::BavariaHigh => "BattyBirdNET-Bavaria-256kHz-high",
+            Self::Eu => "BattyBirdNET-EU-256kHz",
+            Self::Scotland => "BattyBirdNET-Scotland-256kHz",
+            Self::SouthWales => "BattyBirdNET-SouthWales-256kHz",
+            Self::Sweden => "BattyBirdNET-Sweden-256kHz",
+            Self::Uk => "BattyBirdNET-UK-256kHz",
+            Self::Usa => "BattyBirdNET-USA-256kHz",
+            Self::UsaEast => "BattyBirdNET-USA-EAST-256kHz",
+            Self::UsaEastHigh => "BattyBirdNET-USA-EAST-256kHz-high",
+            Self::UsaWest => "BattyBirdNET-USA-WEST-256kHz",
+        }
+    }
+
+    /// ONNX model filename for this region.
+    #[must_use]
+    pub fn model_filename(&self) -> String {
+        format!("{}_fp32.onnx", self.model_stem())
+    }
+
+    /// Labels filename for this region.
+    #[must_use]
+    pub fn labels_filename(&self) -> String {
+        format!("{}_Labels.txt", self.model_stem())
+    }
+}
+
+impl std::fmt::Display for BatRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.model_stem())
+    }
+}
+
+/// Resolved bat detection configuration.
+#[derive(Debug, Clone)]
+pub struct BatConfig {
+    /// Selected bat region.
+    pub region: BatRegion,
+    /// Path to the bat classifier ONNX model.
+    pub classifier_path: PathBuf,
+    /// Path to the bat classifier labels file.
+    pub labels_path: PathBuf,
+}
+
+impl BatConfig {
+    /// Resolve bat config from a region and models directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::ModelFileNotFound` if the classifier ONNX file is missing.
+    /// Returns `Error::LabelsFileNotFound` if the labels file is missing.
+    pub fn resolve(region: BatRegion, bat_models_dir: &std::path::Path) -> Result<Self> {
+        let classifier_path = bat_models_dir.join(region.model_filename());
+        let labels_path = bat_models_dir.join(region.labels_filename());
+
+        if !classifier_path.exists() {
+            return Err(Error::ModelFileNotFound {
+                path: classifier_path,
+            });
+        }
+        if !labels_path.exists() {
+            return Err(Error::LabelsFileNotFound { path: labels_path });
+        }
+
+        Ok(Self {
+            region,
+            classifier_path,
+            labels_path,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bat_region_model_filename() {
+        assert_eq!(
+            BatRegion::Uk.model_filename(),
+            "BattyBirdNET-UK-256kHz_fp32.onnx"
+        );
+        assert_eq!(
+            BatRegion::UsaEastHigh.model_filename(),
+            "BattyBirdNET-USA-EAST-256kHz-high_fp32.onnx"
+        );
+    }
+
+    #[test]
+    fn test_bat_region_labels_filename() {
+        assert_eq!(
+            BatRegion::Eu.labels_filename(),
+            "BattyBirdNET-EU-256kHz_Labels.txt"
+        );
+    }
+
+    #[test]
+    fn test_bat_region_all_variants_have_filenames() {
+        let regions = [
+            BatRegion::Bavaria,
+            BatRegion::BavariaHigh,
+            BatRegion::Eu,
+            BatRegion::Scotland,
+            BatRegion::SouthWales,
+            BatRegion::Sweden,
+            BatRegion::Uk,
+            BatRegion::Usa,
+            BatRegion::UsaEast,
+            BatRegion::UsaEastHigh,
+            BatRegion::UsaWest,
+        ];
+        for region in regions {
+            assert!(!region.model_filename().is_empty());
+            assert!(!region.labels_filename().is_empty());
+            assert!(region.model_filename().ends_with("_fp32.onnx"));
+            assert!(region.labels_filename().ends_with("_Labels.txt"));
+        }
+    }
+
+    #[test]
+    fn test_bat_config_resolve_missing_model() {
+        let result = BatConfig::resolve(BatRegion::Uk, std::path::Path::new("/nonexistent"));
+        assert!(result.is_err());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,11 +1,13 @@
 //! Configuration loading and management.
 
+pub mod bat;
 mod file;
 mod paths;
 pub mod range_filter;
 mod types;
 mod validate;
 
+pub use bat::{BatConfig, BatRegion};
 pub use file::{load_config_file, load_default_config, save_config, save_default_config};
 pub use paths::{config_dir, config_file_path, tensorrt_cache_dir};
 pub use types::{

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -163,6 +163,22 @@ pub mod clipper {
     pub const AUDIO_EXTENSIONS: &[&str] = &["wav", "flac", "mp3", "m4a", "aac"];
 }
 
+/// Bat detection constants.
+pub mod bat {
+    /// Audio sample rate for bat recordings (256 kHz).
+    pub const SAMPLE_RATE: u32 = 256_000;
+
+    /// Segment duration in seconds (144,000 samples / 256,000 Hz).
+    pub const SEGMENT_DURATION: f32 = 0.5625;
+
+    /// Overlap between segments in seconds (25% of segment duration).
+    pub const OVERLAP: f32 = 0.140_625;
+
+    /// Number of audio samples per segment.
+    /// Equals `BirdNET` v2.4's 144,000 samples; this is the "slow-down trick".
+    pub const CHUNK_SAMPLES: usize = 144_000;
+}
+
 /// ONNX Runtime discovery constants.
 pub mod onnx_runtime {
     /// Environment variable used to override the ONNX Runtime dynamic library path.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -168,15 +168,16 @@ pub mod bat {
     /// Audio sample rate for bat recordings (256 kHz).
     pub const SAMPLE_RATE: u32 = 256_000;
 
-    /// Segment duration in seconds (144,000 samples / 256,000 Hz).
-    pub const SEGMENT_DURATION: f32 = 0.5625;
-
-    /// Overlap between segments in seconds (25% of segment duration).
-    pub const OVERLAP: f32 = 0.140_625;
-
     /// Number of audio samples per segment.
     /// Equals `BirdNET` v2.4's 144,000 samples; this is the "slow-down trick".
     pub const CHUNK_SAMPLES: usize = 144_000;
+
+    /// Segment duration in seconds, derived from chunk samples and sample rate.
+    #[allow(clippy::cast_precision_loss)]
+    pub const SEGMENT_DURATION: f32 = CHUNK_SAMPLES as f32 / SAMPLE_RATE as f32;
+
+    /// Overlap between segments in seconds (25% of segment duration).
+    pub const OVERLAP: f32 = SEGMENT_DURATION * 0.25;
 }
 
 /// ONNX Runtime discovery constants.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -176,8 +176,11 @@ pub mod bat {
     #[allow(clippy::cast_precision_loss)]
     pub const SEGMENT_DURATION: f32 = CHUNK_SAMPLES as f32 / SAMPLE_RATE as f32;
 
-    /// Overlap between segments in seconds (25% of segment duration).
-    pub const OVERLAP: f32 = SEGMENT_DURATION * 0.25;
+    /// Fraction of segment duration used as overlap between segments.
+    pub const OVERLAP_FRACTION: f32 = 0.25;
+
+    /// Overlap between segments in seconds.
+    pub const OVERLAP: f32 = SEGMENT_DURATION * OVERLAP_FRACTION;
 }
 
 /// ONNX Runtime discovery constants.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ pub mod utils;
 use clap::Parser;
 use cli::{AnalyzeArgs, Cli, Command};
 use config::{
-    Config, InferenceDevice, ModelConfig, ModelType, OutputFormat, OutputMode, config_file_path,
-    load_default_config, range_filter::build_range_filter_config, save_default_config,
+    BatConfig, Config, InferenceDevice, ModelConfig, ModelType, OutputFormat, OutputMode,
+    config_file_path, load_default_config, range_filter::build_range_filter_config,
+    save_default_config,
 };
 use constants::DEFAULT_TOP_K;
 use inference::BirdClassifier;
@@ -209,6 +210,8 @@ struct ProcessingParams<'a> {
     /// BSG SDM parameters: (latitude, longitude, `day_of_year`)
     /// `day_of_year` is None for auto-detection from file timestamp
     bsg_params: Option<(f64, f64, Option<u32>)>,
+    /// Optional custom classifier for two-stage inference (bat detection).
+    custom_classifier: Option<&'a birdnet_onnx::CustomClassifier>,
 }
 
 /// Statistics from processing all files.
@@ -560,6 +563,7 @@ fn process_all_files(
             bsg_params: params.bsg_params,
             reporter: reporter_ref,
             dual_output_mode: params.dual_output_mode,
+            custom_classifier: params.custom_classifier,
         };
         match process_file(&proc_config, classifier) {
             Ok(result) => {
@@ -605,6 +609,47 @@ fn analyze_files(
     let (model_config, model_name) = resolve_model_config(args, config)?;
     validate_model_files(&model_config)?;
 
+    // Bat mode: validate backbone is BirdNET v2.4 and build custom classifier
+    let bat_classifier: Option<birdnet_onnx::CustomClassifier> = if let Some(region) = args.bat {
+        // Bat mode requires BirdNET v2.4 as the backbone (for embedding extraction)
+        if model_config.model_type != ModelType::BirdnetV24 {
+            return Err(Error::ConfigValidation {
+                message: format!(
+                    "--bat requires a BirdNET v2.4 model as backbone, but '{}' is {:?}",
+                    model_name, model_config.model_type
+                ),
+            });
+        }
+
+        // Resolve bat models directory: <data_dir>/models/bat/
+        let bat_models_dir = registry::models_dir()?.join("bat");
+        let bat_config = BatConfig::resolve(region, &bat_models_dir)?;
+
+        info!(
+            "Bat mode: region={}, classifier={}",
+            region,
+            bat_config.classifier_path.display()
+        );
+
+        let cc = birdnet_onnx::CustomClassifier::builder()
+            .model_path(&bat_config.classifier_path)
+            .labels_path(&bat_config.labels_path)
+            .build()
+            .map_err(|e| Error::ClassifierBuild {
+                reason: format!("failed to build bat classifier: {e}"),
+            })?;
+
+        info!(
+            "Bat classifier loaded: {} classes, {}-dim embeddings",
+            cc.num_classes(),
+            cc.input_dim()
+        );
+
+        Some(cc)
+    } else {
+        None
+    };
+
     // Collect input files only after config is validated
     let files = collect_input_files(inputs)?;
     if files.is_empty() {
@@ -618,7 +663,17 @@ fn analyze_files(
         .min_confidence
         .unwrap_or(config.defaults.min_confidence);
 
-    let overlap = args.overlap.unwrap_or(config.defaults.overlap);
+    // In bat mode, override overlap to the bat-specific value unless the user
+    // explicitly provided one via CLI
+    let overlap = if bat_classifier.is_some() && args.overlap.is_none() {
+        info!(
+            "Bat mode: using overlap {}s (override with --overlap)",
+            constants::bat::OVERLAP
+        );
+        constants::bat::OVERLAP
+    } else {
+        args.overlap.unwrap_or(config.defaults.overlap)
+    };
 
     // Store user's explicit batch size choice (if any)
     // CLI takes precedence, then config file, then smart default (calculated later)
@@ -748,6 +803,7 @@ fn analyze_files(
         stdout_mode: args.stdout,
         dual_output_mode,
         bsg_params,
+        custom_classifier: bat_classifier.as_ref(),
     };
 
     // Process all files - stats owned here so partial results available on fail-fast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,12 +530,24 @@ fn process_all_files(
         // Get audio duration for progress estimation
         let audio_duration = crate::audio::get_audio_duration(file).ok().flatten();
 
-        // Estimate segments for reporter
-        let segment_duration = classifier.segment_duration();
+        // Estimate segments for reporter; bat mode uses shorter segments
+        let segment_duration = if params.custom_classifier.is_some() {
+            crate::constants::bat::SEGMENT_DURATION
+        } else {
+            classifier.segment_duration()
+        };
+        let overlap = if params.custom_classifier.is_some() {
+            crate::constants::bat::OVERLAP
+        } else {
+            params.overlap
+        };
         #[allow(clippy::cast_possible_truncation)]
-        let estimated_segments =
-            progress::estimate_segment_count(audio_duration, segment_duration, params.overlap)
-                .unwrap_or(0) as usize;
+        let estimated_segments = progress::estimate_segment_count(
+            audio_duration,
+            segment_duration,
+            overlap,
+        )
+        .unwrap_or(0) as usize;
 
         // Report file start
         reporter.file_started(file, index, estimated_segments, audio_duration);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,6 +564,7 @@ fn process_all_files(
             reporter: reporter_ref,
             dual_output_mode: params.dual_output_mode,
             custom_classifier: params.custom_classifier,
+            bat_mode: params.custom_classifier.is_some(),
         };
         match process_file(&proc_config, classifier) {
             Ok(result) => {

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -28,6 +28,7 @@ use std::path::Path;
 ///     bat_mode: false,
 /// };
 /// ```
+#[allow(clippy::struct_excessive_bools)]
 pub struct ProcessingConfig<'a> {
     /// Path to input audio file.
     pub input_path: &'a Path,

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -24,6 +24,8 @@ use std::path::Path;
 ///     bsg_params: None,
 ///     reporter: None,
 ///     dual_output_mode: false,
+///     custom_classifier: None,
+///     bat_mode: false,
 /// };
 /// ```
 pub struct ProcessingConfig<'a> {

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -1,6 +1,7 @@
 //! Configuration types for the processing pipeline.
 
 use crate::config::OutputFormat;
+use birdnet_onnx::CustomClassifier;
 use std::path::Path;
 
 /// Configuration for processing a single audio file.
@@ -54,4 +55,7 @@ pub struct ProcessingConfig<'a> {
     pub reporter: Option<&'a dyn crate::output::ProgressReporter>,
     /// Whether to write both files and stdout.
     pub dual_output_mode: bool,
+    /// Optional custom classifier for two-stage inference (e.g., bat detection).
+    /// When present, backbone embeddings are fed to this classifier for final predictions.
+    pub custom_classifier: Option<&'a CustomClassifier>,
 }

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -58,4 +58,6 @@ pub struct ProcessingConfig<'a> {
     /// Optional custom classifier for two-stage inference (e.g., bat detection).
     /// When present, backbone embeddings are fed to this classifier for final predictions.
     pub custom_classifier: Option<&'a CustomClassifier>,
+    /// Whether bat audio mode is active (skip resampling, use bat chunk params).
+    pub bat_mode: bool,
 }

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -440,8 +440,22 @@ pub fn process_file(
     let decoder = StreamingDecoder::open(input_path)?;
     let source_rate = decoder.sample_rate();
     let duration_hint = decoder.duration_hint();
-    let target_rate = classifier.sample_rate();
-    let segment_duration = classifier.segment_duration();
+
+    // In bat mode, skip resampling: feed raw samples directly to the model.
+    // BirdNET v2.4 expects 144,000 samples; at 256kHz this is 0.5625s of audio,
+    // but the model treats them as 48kHz (the "slow-down trick").
+    let (target_rate, segment_duration) = if custom_classifier.is_some() {
+        if source_rate != crate::constants::bat::SAMPLE_RATE {
+            tracing::warn!(
+                "Bat mode expects {}kHz audio, source is {}kHz. Results may be unreliable.",
+                crate::constants::bat::SAMPLE_RATE / 1000,
+                source_rate / 1000,
+            );
+        }
+        (source_rate, crate::constants::bat::SEGMENT_DURATION)
+    } else {
+        (classifier.sample_rate(), classifier.segment_duration())
+    };
 
     // Resolve BSG parameters with day-of-year auto-detection (once per file, not per batch)
     let resolved_bsg_params = if let Some((lat, lon, day_of_year)) = bsg_params {
@@ -468,18 +482,30 @@ pub fn process_file(
     };
 
     // Calculate segment parameters (needed for batch size adjustment and progress bar)
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_precision_loss
-    )]
-    let segment_samples = (segment_duration * target_rate as f32) as usize;
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_precision_loss
-    )]
-    let overlap_samples = (overlap * target_rate as f32) as usize;
+    let (segment_samples, overlap_samples) = if custom_classifier.is_some() {
+        // Bat mode: use fixed 144,000 samples and bat-specific overlap
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let overlap_samps = (crate::constants::bat::OVERLAP * source_rate as f32) as usize;
+        (crate::constants::bat::CHUNK_SAMPLES, overlap_samps)
+    } else {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let seg = (segment_duration * target_rate as f32) as usize;
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let ovl = (overlap * target_rate as f32) as usize;
+        (seg, ovl)
+    };
 
     // Estimate segment count for batch size adjustment and progress bar
     let estimated_segments = estimate_segment_count(duration_hint, segment_duration, overlap);

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -344,6 +344,16 @@ fn process_batch(
                 }
             })?;
 
+            if batch_preds.len() != valid_count {
+                return Err(crate::error::Error::Inference {
+                    reason: format!(
+                        "bat classifier returned {} predictions for {} segments",
+                        batch_preds.len(),
+                        valid_count,
+                    ),
+                });
+            }
+
             Some(batch_preds)
         } else {
             None
@@ -490,13 +500,10 @@ pub fn process_file(
 
     // Calculate segment parameters (needed for batch size adjustment and progress bar)
     let (segment_samples, overlap_samples) = if bat_mode {
-        // Bat mode: use fixed 144,000 samples and bat-specific overlap
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            clippy::cast_precision_loss
-        )]
-        let overlap_samps = (crate::constants::bat::OVERLAP * source_rate as f32) as usize;
+        // Bat mode: use fixed 144,000 samples and bat-specific overlap.
+        // Overlap is derived from the bat sample rate (256kHz), not the source rate,
+        // because the constants are coupled to the model's expected input.
+        let overlap_samps = crate::constants::bat::CHUNK_SAMPLES / 4;
         (crate::constants::bat::CHUNK_SAMPLES, overlap_samps)
     } else {
         #[allow(

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -10,6 +10,7 @@ use crate::output::{
     ParquetWriter, RavenWriter,
 };
 use crate::pipeline::output_path_for;
+use birdnet_onnx::CustomClassifier;
 use std::path::Path;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::thread::{self, JoinHandle};
@@ -121,6 +122,7 @@ fn run_streaming_inference(
     reporter: Option<&dyn crate::output::ProgressReporter>,
     estimated_segments: usize,
     bsg_params: Option<(f64, f64, Option<u32>)>,
+    custom_classifier: Option<&CustomClassifier>,
 ) -> Result<(Vec<Detection>, usize)> {
     let mut detections = Vec::new();
     let mut batch: Vec<AudioChunk> = Vec::with_capacity(batch_size);
@@ -146,6 +148,7 @@ fn run_streaming_inference(
                 &mut segments_done,
                 estimated_segments,
                 bsg_params,
+                custom_classifier,
             )?;
             batch.clear();
         }
@@ -166,6 +169,7 @@ fn run_streaming_inference(
             &mut segments_done,
             estimated_segments,
             bsg_params,
+            custom_classifier,
         )?;
     }
 
@@ -226,6 +230,7 @@ fn process_batch(
     segments_done: &mut usize,
     estimated_segments: usize,
     bsg_params: Option<(f64, f64, Option<u32>)>,
+    custom_classifier: Option<&CustomClassifier>,
 ) -> Result<()> {
     use crate::gpu::start_inference_watchdog;
     use crate::output::progress::inc_progress;
@@ -311,9 +316,49 @@ fn process_batch(
     // Apply range filtering if configured (skipped for BSG models)
     let results = classifier.apply_range_filter(results)?;
 
+    // Two-stage inference: if a custom classifier is present (bat mode),
+    // extract embeddings from the backbone and classify them with the
+    // secondary model. The custom classifier predictions replace the
+    // backbone predictions for detection extraction.
+    let bat_predictions: Option<Vec<Vec<birdnet_onnx::Prediction>>> =
+        if let Some(cc) = custom_classifier {
+            let embeddings_batch: Vec<Vec<f32>> = results
+                .iter()
+                .take(valid_count)
+                .filter_map(|r| r.embeddings.clone())
+                .collect();
+
+            if embeddings_batch.len() != valid_count {
+                return Err(crate::error::Error::Inference {
+                    reason: format!(
+                        "bat mode requires embeddings from backbone, but got {} of {} segments",
+                        embeddings_batch.len(),
+                        valid_count
+                    ),
+                });
+            }
+
+            let batch_preds = cc.predict_batch(&embeddings_batch).map_err(|e| {
+                crate::error::Error::Inference {
+                    reason: format!("bat custom classifier failed: {e}"),
+                }
+            })?;
+
+            Some(batch_preds)
+        } else {
+            None
+        };
+
     // Only process results from valid segments (excludes padding)
-    for (chunk, result) in batch.iter().zip(results.iter()).take(valid_count) {
-        for pred in &result.predictions {
+    for (i, (chunk, result)) in batch.iter().zip(results.iter()).enumerate().take(valid_count) {
+        // Use bat predictions if available, otherwise use backbone predictions
+        let preds: &[birdnet_onnx::Prediction] = if let Some(ref bp) = bat_predictions {
+            &bp[i]
+        } else {
+            &result.predictions
+        };
+
+        for pred in preds {
             if pred.confidence >= min_confidence {
                 let detection = Detection::from_label(
                     &pred.species,
@@ -379,6 +424,7 @@ pub fn process_file(
     let bsg_params = config.bsg_params;
     let reporter = config.reporter;
     let dual_output_mode = config.dual_output_mode;
+    let custom_classifier = config.custom_classifier;
 
     let start_time = Instant::now();
 
@@ -563,6 +609,7 @@ pub fn process_file(
         reporter,
         estimated_segments_usize,
         resolved_bsg_params,
+        custom_classifier,
     )?;
 
     // Wait for decode thread to finish

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -350,10 +350,16 @@ fn process_batch(
         };
 
     // Only process results from valid segments (excludes padding)
-    for (i, (chunk, result)) in batch.iter().zip(results.iter()).enumerate().take(valid_count) {
+    for (i, (chunk, result)) in batch
+        .iter()
+        .zip(results.iter())
+        .enumerate()
+        .take(valid_count)
+    {
         // Use bat predictions if available, otherwise use backbone predictions
-        let preds: &[birdnet_onnx::Prediction] =
-            bat_predictions.as_ref().map_or(&result.predictions, |bp| &bp[i]);
+        let preds: &[birdnet_onnx::Prediction] = bat_predictions
+            .as_ref()
+            .map_or(&result.predictions, |bp| &bp[i]);
 
         for pred in preds {
             if pred.confidence >= min_confidence {

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -352,11 +352,8 @@ fn process_batch(
     // Only process results from valid segments (excludes padding)
     for (i, (chunk, result)) in batch.iter().zip(results.iter()).enumerate().take(valid_count) {
         // Use bat predictions if available, otherwise use backbone predictions
-        let preds: &[birdnet_onnx::Prediction] = if let Some(ref bp) = bat_predictions {
-            &bp[i]
-        } else {
-            &result.predictions
-        };
+        let preds: &[birdnet_onnx::Prediction] =
+            bat_predictions.as_ref().map_or(&result.predictions, |bp| &bp[i]);
 
         for pred in preds {
             if pred.confidence >= min_confidence {

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -314,7 +314,7 @@ fn process_batch(
     }
 
     // Apply range filtering if configured (skipped for BSG models)
-    let results = classifier.apply_range_filter(results)?;
+    let mut results = classifier.apply_range_filter(results)?;
 
     // Two-stage inference: if a custom classifier is present (bat mode),
     // extract embeddings from the backbone and classify them with the
@@ -323,9 +323,9 @@ fn process_batch(
     let bat_predictions: Option<Vec<Vec<birdnet_onnx::Prediction>>> =
         if let Some(cc) = custom_classifier {
             let embeddings_batch: Vec<Vec<f32>> = results
-                .iter()
+                .iter_mut()
                 .take(valid_count)
-                .filter_map(|r| r.embeddings.clone())
+                .filter_map(|r| r.embeddings.take())
                 .collect();
 
             if embeddings_batch.len() != valid_count {
@@ -422,6 +422,7 @@ pub fn process_file(
     let reporter = config.reporter;
     let dual_output_mode = config.dual_output_mode;
     let custom_classifier = config.custom_classifier;
+    let bat_mode = config.bat_mode;
 
     let start_time = Instant::now();
 
@@ -444,7 +445,7 @@ pub fn process_file(
     // In bat mode, skip resampling: feed raw samples directly to the model.
     // BirdNET v2.4 expects 144,000 samples; at 256kHz this is 0.5625s of audio,
     // but the model treats them as 48kHz (the "slow-down trick").
-    let (target_rate, segment_duration) = if custom_classifier.is_some() {
+    let (target_rate, segment_duration) = if bat_mode {
         if source_rate != crate::constants::bat::SAMPLE_RATE {
             tracing::warn!(
                 "Bat mode expects {}kHz audio, source is {}kHz. Results may be unreliable.",
@@ -482,7 +483,7 @@ pub fn process_file(
     };
 
     // Calculate segment parameters (needed for batch size adjustment and progress bar)
-    let (segment_samples, overlap_samples) = if custom_classifier.is_some() {
+    let (segment_samples, overlap_samples) = if bat_mode {
         // Bat mode: use fixed 144,000 samples and bat-specific overlap
         #[allow(
             clippy::cast_possible_truncation,


### PR DESCRIPTION
## Summary

- Add `--bat <region>` CLI flag for bat species detection using BattyBirdNET regional classifiers
- Support 11 regions: bavaria, bavaria-high, eu, scotland, south-wales, sweden, uk, usa, usa-east, usa-east-high, usa-west
- Two-stage inference pipeline: BirdNET v2.4 extracts 1024-dim embeddings, regional bat classifier maps embeddings to bat species
- Skip audio resampling in bat mode ("slow-down trick": 256kHz samples fed directly to BirdNET, which treats them as 48kHz)
- Bat-specific constants: 144,000 samples per segment (0.5625s at 256kHz), 25% overlap

The bat classifiers are lightweight ONNX models converted from BattyBirdNET-Analyzer's TFLite models. They require a BirdNET v2.4 model with the embedding output exposed (2-output variant).

Depends on tphakala/rust-birdnet-onnx#80 for `CustomClassifier` support. Uses local path dependency for now (`path = "../rust-birdnet-onnx"`); will switch to published version after that PR is merged and released.

## Test Plan
- [x] 288/288 tests pass
- [x] 0 clippy warnings
- [x] `--bat <region>` visible in `birda analyze --help` with all 11 region values
- [x] `BatRegion` filename mapping tests pass for all variants
- [ ] End-to-end test with bat audio recording (pending test audio)