### PR TITLE
feat(ci): merge the licence PR automatically

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -151,6 +151,9 @@ jobs:
             echo "::error::THIRD_PARTY_LICENSES.txt has $lines lines, expected at least $MIN_LINES. cargo-about likely emitted a truncated file."
             exit 1
           fi
+          # Keep this list in sync with the section headers written by the
+          # "Combine all licenses" step above. A header added there but not here
+          # is simply never checked.
           while IFS= read -r marker; do
             if ! grep -qF "$marker" THIRD_PARTY_LICENSES.txt; then
               echo "::error::THIRD_PARTY_LICENSES.txt is missing the section marker: $marker"
@@ -199,7 +202,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          POLL_ATTEMPTS: '12'
+          POLL_DELAY: '5'
         run: |
           set -euo pipefail
+
+          # GitHub computes mergeability in a background job, so a PR queried
+          # straight after creation reports UNKNOWN. Merging on UNKNOWN fails and
+          # leaves the PR open, which is the exact state this step exists to
+          # avoid, so wait for a real answer first.
+          state=UNKNOWN
+          for attempt in $(seq 1 "$POLL_ATTEMPTS"); do
+            state=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq .mergeStateStatus)
+            if [ "$state" != "UNKNOWN" ]; then
+              echo "mergeability resolved to $state after $attempt attempt(s)"
+              break
+            fi
+            echo "mergeability still UNKNOWN, retrying in ${POLL_DELAY}s ($attempt/$POLL_ATTEMPTS)"
+            sleep "$POLL_DELAY"
+          done
+
+          if [ "$state" = "UNKNOWN" ]; then
+            echo "::error::mergeability never resolved for PR #$PR_NUMBER; leaving it open for review"
+            exit 1
+          fi
+
+          # DIRTY means the base moved under us and the branch now conflicts.
+          # Nothing here can resolve that, so fail rather than thrash.
+          if [ "$state" = "DIRTY" ]; then
+            echo "::error::PR #$PR_NUMBER conflicts with its base; leaving it open for review"
+            exit 1
+          fi
+
           gh pr merge "$PR_NUMBER" --squash --delete-branch
-          echo "merged licence PR #$PR_NUMBER"
+          echo "merged licence PR #$PR_NUMBER (state was $state)"

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -136,7 +136,35 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      # GitHub does not run workflows on a pull request opened with GITHUB_TOKEN,
+      # so Lint and Test never see this file, and the merge below is unattended.
+      # That makes this step the only thing standing between a broken generator
+      # and the base branch. Fail loudly rather than merge nonsense.
+      - name: Validate generated licence file
+        if: steps.check.outputs.changed == 'true'
+        env:
+          MIN_LINES: '1000'
+        run: |
+          set -euo pipefail
+          lines=$(wc -l < THIRD_PARTY_LICENSES.txt)
+          if [ "$lines" -lt "$MIN_LINES" ]; then
+            echo "::error::THIRD_PARTY_LICENSES.txt has $lines lines, expected at least $MIN_LINES. cargo-about likely emitted a truncated file."
+            exit 1
+          fi
+          while IFS= read -r marker; do
+            if ! grep -qF "$marker" THIRD_PARTY_LICENSES.txt; then
+              echo "::error::THIRD_PARTY_LICENSES.txt is missing the section marker: $marker"
+              exit 1
+            fi
+          done <<'MARKERS'
+          THIRD-PARTY SOFTWARE LICENSES
+          SECTION 1: RUST DEPENDENCIES
+          SECTION 2: GPU LIBRARIES (included in CUDA builds only)
+          MARKERS
+          echo "licence file looks sane: $lines lines"
+
       - name: Create Pull Request
+        id: cpr
         if: steps.check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -158,3 +186,20 @@ jobs:
           branch: update-licenses/${{ github.ref_name }}
           delete-branch: true
           labels: dependencies
+
+      # The file is generated from Cargo.lock and contains no code, so there is
+      # nothing for a human to decide here. Merge outright rather than with
+      # --auto: auto-merge only queues behind required checks, and this repo has
+      # none, so enabling it on an already-mergeable PR just errors.
+      #
+      # This does not re-trigger the workflow. The merge only touches
+      # THIRD_PARTY_LICENSES.txt, which is not in the paths filter above.
+      - name: Merge the licence PR
+        if: steps.check.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR_NUMBER" --squash --delete-branch
+          echo "merged licence PR #$PR_NUMBER"

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -222,17 +222,31 @@ jobs:
             sleep "$POLL_DELAY"
           done
 
-          if [ "$state" = "UNKNOWN" ]; then
-            echo "::error::mergeability never resolved for PR #$PR_NUMBER; leaving it open for review"
+          # Name the states worth merging rather than the ones worth rejecting.
+          # An unrecognised state should stop the merge, not fall through it.
+          #
+          # UNSTABLE is expected, not a warning sign: these PRs carry no required
+          # checks, and GitHub reports an empty status set as pending. Refusing
+          # it would mean no licence PR ever merges.
+          case "$state" in
+            CLEAN | UNSTABLE | HAS_HOOKS)
+              ;;
+            UNKNOWN)
+              echo "::error::mergeability never resolved for PR #$PR_NUMBER; leaving it open for review"
+              exit 1 ;;
+            DIRTY)
+              # The base moved and the branch now conflicts. Retrying cannot fix
+              # that, and the next run regenerates the file from scratch anyway.
+              echo "::error::PR #$PR_NUMBER conflicts with its base; leaving it open for review"
+              exit 1 ;;
+            *)
+              # BLOCKED, BEHIND, DRAFT, or anything GitHub adds later.
+              echo "::error::PR #$PR_NUMBER is in merge state $state; leaving it open for review"
+              exit 1 ;;
+          esac
+
+          if ! gh pr merge "$PR_NUMBER" --squash --delete-branch; then
+            echo "::error::merge of PR #$PR_NUMBER failed from state $state; leaving it open for review"
             exit 1
           fi
-
-          # DIRTY means the base moved under us and the branch now conflicts.
-          # Nothing here can resolve that, so fail rather than thrash.
-          if [ "$state" = "DIRTY" ]; then
-            echo "::error::PR #$PR_NUMBER conflicts with its base; leaving it open for review"
-            exit 1
-          fi
-
-          gh pr merge "$PR_NUMBER" --squash --delete-branch
           echo "merged licence PR #$PR_NUMBER (state was $state)"


### PR DESCRIPTION
The licence PR is generated from `Cargo.lock` and contains no code, so there is nothing in it for a human to decide, yet it sat open waiting for one anyway (#269, merged manually just now). This makes the workflow merge its own PR.

## Why merge outright rather than use auto-merge

`--auto` only queues a PR behind required checks. This repo has neither branch protection nor rulesets on `main`:

```
$ gh api repos/tphakala/birda/branches/main/protection
Branch not protected (HTTP 404)
$ gh api repos/tphakala/birda/rulesets
(none)
```

With nothing required, the PR is mergeable the moment it opens, and enabling auto-merge on an already-mergeable PR errors rather than helping. `allow_auto_merge` is also `false` on the repo, so `--auto` would need a settings change to do something that plain `--squash` already does correctly. So the workflow merges directly.

## Why this needs a validation step

**No CI runs on these PRs.** GitHub deliberately does not trigger workflows for a pull request opened with `GITHUB_TOKEN`, to prevent workflow recursion. That is not a theory: #269 ran only the external Socket app checks, with no Lint, no Test, no claude-review, no CodeRabbit.

Until now that was survivable, because a human looked at the diff before merging. Once the merge is unattended, nothing does. If `cargo about` ever emits a truncated or empty file, the workflow would commit it straight to the base branch with nothing objecting.

So the workflow has to become the gate it was outsourcing. Before merging, it now fails if the file is under 1000 lines (the real one is 6590) or is missing any of its three section markers.

## Loop safety

The merge does not re-trigger the workflow. The paths filter is `Cargo.lock`, `Cargo.toml`, `about.toml`, and the merge touches only `THIRD_PARTY_LICENSES.txt`.

## Verification

The guard was executed against four cases rather than eyeballed, since a guard that never fires is worthless:

| Case | Result |
|---|---|
| Real file, 6590 lines | passes |
| Empty file (generator produced nothing) | fails, `truncated (0 lines)` |
| 1203 lines but `SECTION 2` marker missing | fails, `missing marker` |
| 1203 lines, all markers present | passes |

The `pull-request-number` used in the merge comes from the action output, not from user input, and is passed via `env:` rather than interpolated into the shell.

## Test Plan

- [x] YAML parses; step graph and `id: cpr` wiring confirmed
- [x] Guard passes on the real file
- [x] Guard fails on a truncated file
- [x] Guard fails on a file missing a section marker
- [x] Confirmed the merge cannot re-trigger the workflow (paths filter)
- [ ] CI green on this PR
- [ ] End-to-end: a licence PR opens and merges itself on the next `Cargo.lock` change to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect incomplete or malformed third-party license files before they are submitted.
  * Improved license update automation by conditionally merging generated license changes only when the target pull request is confirmed merge-ready, with clear failure messaging otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->