### PR TITLE
feat(deps): migrate to rubato 4 and audioadapter-buffers 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,6 @@ updates:
       - "dependencies"
       - "rust"
     open-pull-requests-limit: 10
-    ignore:
-      # rubato 3.x re-exports audioadapter[-buffers] 3.x types in its public
-      # Adapter trait, so audioadapter-buffers must stay on 3.x until rubato
-      # ships a release built against audioadapter 4.x. A direct 4.0 bump puts
-      # two versions of the crate in the graph and breaks the resampler.
-      # Remove this ignore once rubato moves to audioadapter 4.x.
-      - dependency-name: "audioadapter-buffers"
-        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 
 [[package]]
 name = "audioadapter"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+checksum = "c75c3943c6c7279bb25a449a8d1727480730ab2efd7b6fd5d6ca51927096e6e4"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+checksum = "ece3390b6eb40379094843a1da5aaccc34bc0d85a8cbf68d09fe092fee6de29e"
 dependencies = [
  "audioadapter",
  "audioadapter-sample",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+checksum = "1592f90413568e259413c21a41a3d571feb1774255c209e7966d98f9db708c90"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "rubato"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+checksum = "f57c655d11e929f05a8663b323ff553f8d9773be05dfdc087795955bedeb8d92"
 dependencies = [
  "audioadapter",
  "audioadapter-buffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ load-dynamic = ["birdnet-onnx/load-dynamic"]
 birdnet-onnx = { version = "2.0.0-rc.15", features = ["load-dynamic"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
-rubato = "3.0"
-audioadapter-buffers = "3.0"
+rubato = "4.0"
+audioadapter-buffers = "4.0"
 clap = { version = "4", features = ["derive", "env"] }
 toml = "1.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -124,6 +124,8 @@ mod tests {
     const TEST_RATE_HIGH: u32 = 48_000;
     /// Target rate used by the downsample tests, matching the `BirdNET` input rate.
     const TEST_RATE_LOW: u32 = 32_000;
+    /// The rate of CD sourced audio, and the usual rate for mp3 files.
+    const TEST_RATE_CD: u32 = 44_100;
     /// Length of the generated test signals, one second at the higher rate.
     const TEST_SIGNAL_LEN: usize = 48_000;
     /// A tone in the middle of the range most bird vocalisations occupy.
@@ -250,6 +252,41 @@ mod tests {
             level < 0.1,
             "content above the output Nyquist limit survived resampling: rms {level}"
         );
+    }
+
+    #[test]
+    fn test_resample_from_cd_rate_filters_above_output_nyquist() {
+        // 44.1 kHz is what mp3 and CD sourced files arrive at, so this path is
+        // as real as the 48 kHz one, and it sizes the FFT completely
+        // differently. The block size comes from the greatest common divisor of
+        // the two rates: 48 kHz and 32 kHz share 16000, giving 342 FFT chunks
+        // for a 1024 frame chunk, while 44.1 kHz and 32 kHz share only 100,
+        // giving 3. Passing at one rate pair says little about the other.
+        let input = sine(20_000.0, TEST_RATE_CD, 44_100);
+        let output = resample(input, TEST_RATE_CD, TEST_RATE_LOW).unwrap();
+        let body = steady_state(&output);
+
+        let level = rms(body);
+        assert!(
+            level < 0.1,
+            "content above the output Nyquist limit survived 44.1 kHz to 32 kHz resampling: rms {level}"
+        );
+    }
+
+    #[test]
+    fn test_resample_from_cd_rate_preserves_bird_band_content() {
+        let input = sine(BIRD_BAND_HZ, TEST_RATE_CD, 44_100);
+        let output = resample(input, TEST_RATE_CD, TEST_RATE_LOW).unwrap();
+        let body = steady_state(&output);
+
+        let at_tone = tone_power(body, TEST_RATE_LOW, BIRD_BAND_HZ);
+        for other in [3_000.0, 9_000.0, 12_000.0] {
+            let at_other = tone_power(body, TEST_RATE_LOW, other);
+            assert!(
+                at_tone > at_other * DOMINANCE_RATIO,
+                "6 kHz tone did not dominate {other} Hz after 44.1 kHz resampling: {at_tone} vs {at_other}"
+            );
+        }
     }
 
     #[test]

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -130,8 +130,47 @@ mod tests {
     const TEST_SIGNAL_LEN: usize = 48_000;
     /// A tone in the middle of the range most bird vocalisations occupy.
     const BIRD_BAND_HZ: f32 = 6_000.0;
+    /// A reference tone low in the band, used to check pitch is preserved.
+    const REFERENCE_TONE_HZ: f32 = 1_000.0;
+    /// A tone above the 16 kHz Nyquist limit of the output rate, used to check
+    /// the anti-aliasing filter removes what it cannot represent.
+    const ABOVE_NYQUIST_HZ: f32 = 20_000.0;
+    /// Where a resampler with no anti-aliasing filter folds `ABOVE_NYQUIST_HZ`
+    /// back to, as |20000 - 32000|. Nothing should ever be measurable here.
+    const ALIAS_IMAGE_HZ: f32 = 12_000.0;
     /// How far the measured tone may sit below the strongest competing band.
     const DOMINANCE_RATIO: f32 = 100.0;
+    /// Least of the expected power a tone may retain in its own bin.
+    ///
+    /// Dominance over other bins is not enough on its own: a tone shifted by a
+    /// few Hz leaves its bin while still towering over distant ones, so the
+    /// ratio alone accepts a pitch shift. This pins the energy to where it
+    /// belongs.
+    const MIN_TONE_POWER_FRACTION: f32 = 0.5;
+    /// Highest RMS accepted for a signal that should have been filtered away.
+    const FILTERED_RMS_CEILING: f32 = 0.1;
+    /// Least RMS expected of a tone that must survive resampling intact.
+    ///
+    /// A full amplitude sine has an RMS of about 0.707.
+    const PRESERVED_RMS_FLOOR: f32 = 0.6;
+    /// Most the RMS may drift between input and output.
+    const RMS_TOLERANCE: f32 = 0.05;
+    /// Fraction of a resampled signal trimmed from each end before measuring.
+    const STEADY_STATE_MARGIN: usize = 8;
+    /// Length of the 44.1 kHz test signals, one second at that rate.
+    const TEST_SIGNAL_LEN_CD: usize = 44_100;
+    /// Most of the expected power an aliased image may carry.
+    ///
+    /// A working filter leaves nothing measurable here, so this only needs to
+    /// sit far below a real tone.
+    const ALIAS_POWER_FRACTION: f32 = 1e-6;
+
+    /// Power the Goertzel filter reports for a full amplitude sine sitting
+    /// exactly on the bin being measured. Falls out of the algorithm as n / 4.
+    #[allow(clippy::cast_precision_loss)]
+    fn expected_tone_power(len: usize) -> f32 {
+        len as f32 / 4.0
+    }
 
     /// Generate a pure sine wave.
     #[allow(clippy::cast_precision_loss)]
@@ -173,27 +212,42 @@ mod tests {
     /// The resampler ramps up over its delay and the last chunk is zero padded,
     /// so both ends are unrepresentative. The middle is the steady state.
     fn steady_state(samples: &[f32]) -> &[f32] {
-        let margin = samples.len() / 8;
+        let margin = samples.len() / STEADY_STATE_MARGIN;
         &samples[margin..samples.len() - margin]
+    }
+
+    /// Assert a tone came through at its own frequency and at full strength.
+    ///
+    /// Both halves are needed. The absolute floor catches a tone that drifted
+    /// off its bin, and the dominance check catches energy appearing where it
+    /// should not be.
+    fn assert_tone_intact(body: &[f32], rate: u32, tone_hz: f32, other_bins: &[f32]) {
+        let at_tone = tone_power(body, rate, tone_hz);
+        let floor = expected_tone_power(body.len()) * MIN_TONE_POWER_FRACTION;
+        assert!(
+            at_tone > floor,
+            "{tone_hz} Hz tone lost power in its own bin, so the pitch moved: {at_tone}, expected above {floor}"
+        );
+
+        for other in other_bins {
+            let at_other = tone_power(body, rate, *other);
+            assert!(
+                at_tone > at_other * DOMINANCE_RATIO,
+                "{tone_hz} Hz tone did not dominate {other} Hz: {at_tone} vs {at_other}"
+            );
+        }
     }
 
     #[test]
     fn test_resample_preserves_tone_frequency() {
-        let input = sine(1_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let input = sine(REFERENCE_TONE_HZ, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
         let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
-        let body = steady_state(&output);
-
-        let at_tone = tone_power(body, TEST_RATE_LOW, 1_000.0);
-        // A resampler that shifted the pitch would move the energy to a
-        // different bin, so check the neighbours are quiet rather than just
-        // checking the tone is present.
-        for other in [500.0, 2_000.0, 4_000.0] {
-            let at_other = tone_power(body, TEST_RATE_LOW, other);
-            assert!(
-                at_tone > at_other * DOMINANCE_RATIO,
-                "1 kHz tone did not dominate {other} Hz: {at_tone} vs {at_other}"
-            );
-        }
+        assert_tone_intact(
+            steady_state(&output),
+            TEST_RATE_LOW,
+            REFERENCE_TONE_HZ,
+            &[500.0, 2_000.0, 4_000.0],
+        );
     }
 
     #[test]
@@ -207,20 +261,18 @@ mod tests {
         let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
         let body = steady_state(&output);
 
-        let at_tone = tone_power(body, TEST_RATE_LOW, BIRD_BAND_HZ);
-        for other in [3_000.0, 9_000.0, 12_000.0] {
-            let at_other = tone_power(body, TEST_RATE_LOW, other);
-            assert!(
-                at_tone > at_other * DOMINANCE_RATIO,
-                "6 kHz tone did not dominate {other} Hz: {at_tone} vs {at_other}"
-            );
-        }
+        assert_tone_intact(
+            body,
+            TEST_RATE_LOW,
+            BIRD_BAND_HZ,
+            &[3_000.0, 9_000.0, 12_000.0],
+        );
 
         // The tone must also survive at close to full amplitude. Dominance
         // alone would still pass if everything were attenuated together.
         let level = rms(body);
         assert!(
-            level > 0.6,
+            level > PRESERVED_RMS_FLOOR,
             "6 kHz tone was attenuated by resampling: rms {level}, expected about 0.707"
         );
     }
@@ -237,19 +289,20 @@ mod tests {
         // In-band tones cannot catch this: they stay dominant either way, which
         // is why the other tests here pass even against nearest-neighbour
         // decimation.
-        let input = sine(20_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let input = sine(ABOVE_NYQUIST_HZ, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
         let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
         let body = steady_state(&output);
 
-        let alias = tone_power(body, TEST_RATE_LOW, 12_000.0);
+        let alias = tone_power(body, TEST_RATE_LOW, ALIAS_IMAGE_HZ);
+        let ceiling = expected_tone_power(body.len()) * ALIAS_POWER_FRACTION;
         assert!(
-            alias < 1e-3,
-            "20 kHz folded back to 12 kHz, anti-aliasing filter is not working: power {alias}"
+            alias < ceiling,
+            "20 kHz folded back to {ALIAS_IMAGE_HZ} Hz, anti-aliasing filter is not working: power {alias}"
         );
 
         let level = rms(body);
         assert!(
-            level < 0.1,
+            level < FILTERED_RMS_CEILING,
             "content above the output Nyquist limit survived resampling: rms {level}"
         );
     }
@@ -262,42 +315,38 @@ mod tests {
         // the two rates: 48 kHz and 32 kHz share 16000, giving 342 FFT chunks
         // for a 1024 frame chunk, while 44.1 kHz and 32 kHz share only 100,
         // giving 3. Passing at one rate pair says little about the other.
-        let input = sine(20_000.0, TEST_RATE_CD, 44_100);
+        let input = sine(ABOVE_NYQUIST_HZ, TEST_RATE_CD, TEST_SIGNAL_LEN_CD);
         let output = resample(input, TEST_RATE_CD, TEST_RATE_LOW).unwrap();
         let body = steady_state(&output);
 
         let level = rms(body);
         assert!(
-            level < 0.1,
+            level < FILTERED_RMS_CEILING,
             "content above the output Nyquist limit survived 44.1 kHz to 32 kHz resampling: rms {level}"
         );
     }
 
     #[test]
     fn test_resample_from_cd_rate_preserves_bird_band_content() {
-        let input = sine(BIRD_BAND_HZ, TEST_RATE_CD, 44_100);
+        let input = sine(BIRD_BAND_HZ, TEST_RATE_CD, TEST_SIGNAL_LEN_CD);
         let output = resample(input, TEST_RATE_CD, TEST_RATE_LOW).unwrap();
-        let body = steady_state(&output);
-
-        let at_tone = tone_power(body, TEST_RATE_LOW, BIRD_BAND_HZ);
-        for other in [3_000.0, 9_000.0, 12_000.0] {
-            let at_other = tone_power(body, TEST_RATE_LOW, other);
-            assert!(
-                at_tone > at_other * DOMINANCE_RATIO,
-                "6 kHz tone did not dominate {other} Hz after 44.1 kHz resampling: {at_tone} vs {at_other}"
-            );
-        }
+        assert_tone_intact(
+            steady_state(&output),
+            TEST_RATE_LOW,
+            BIRD_BAND_HZ,
+            &[3_000.0, 9_000.0, 12_000.0],
+        );
     }
 
     #[test]
     fn test_resample_preserves_amplitude() {
-        let input = sine(1_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let input = sine(REFERENCE_TONE_HZ, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
         let input_rms = rms(&input);
         let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
         let output_rms = rms(steady_state(&output));
 
         assert!(
-            (output_rms - input_rms).abs() < 0.05,
+            (output_rms - input_rms).abs() < RMS_TOLERANCE,
             "amplitude changed: {input_rms} in, {output_rms} out"
         );
     }

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -122,6 +122,152 @@ fn estimate_output_len(input_len: usize, from_rate: u32, to_rate: u32) -> usize 
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::f32::consts::PI;
+
+    /// Sample rate of the test signals, matching the common capture rate.
+    const TEST_RATE_HIGH: u32 = 48_000;
+    /// Target rate used by the downsample tests, matching the `BirdNET` input rate.
+    const TEST_RATE_LOW: u32 = 32_000;
+    /// Length of the generated test signals, one second at the higher rate.
+    const TEST_SIGNAL_LEN: usize = 48_000;
+    /// A tone in the middle of the range most bird vocalisations occupy.
+    const BIRD_BAND_HZ: f32 = 6_000.0;
+    /// How far the measured tone may sit below the strongest competing band.
+    const DOMINANCE_RATIO: f32 = 100.0;
+
+    /// Generate a pure sine wave.
+    #[allow(clippy::cast_precision_loss)]
+    fn sine(freq_hz: f32, rate: u32, len: usize) -> Vec<f32> {
+        (0..len)
+            .map(|i| (2.0 * PI * freq_hz * i as f32 / rate as f32).sin())
+            .collect()
+    }
+
+    /// Power of a single frequency, via the Goertzel algorithm.
+    ///
+    /// Used instead of comparing samples directly because the resampler delays
+    /// its output by half the FFT block, so the signal comes back phase shifted.
+    /// Measuring in the frequency domain ignores that shift.
+    #[allow(clippy::cast_precision_loss)]
+    fn tone_power(samples: &[f32], rate: u32, freq_hz: f32) -> f32 {
+        let n = samples.len() as f32;
+        let k = (n * freq_hz / rate as f32).round();
+        let w = 2.0 * PI * k / n;
+        let coeff = 2.0 * w.cos();
+        let (mut s1, mut s2) = (0.0f32, 0.0f32);
+        for &x in samples {
+            let s0 = coeff.mul_add(s1, x) - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        // Goertzel magnitude: s1^2 + s2^2 - coeff*s1*s2.
+        (coeff * s1).mul_add(-s2, s1.mul_add(s1, s2 * s2)).max(0.0) / n
+    }
+
+    /// Root mean square of a signal.
+    #[allow(clippy::cast_precision_loss)]
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|x| x * x).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    /// Drop the head and tail of a resampled signal.
+    ///
+    /// The resampler ramps up over its delay and the last chunk is zero padded,
+    /// so both ends are unrepresentative. The middle is the steady state.
+    fn steady_state(samples: &[f32]) -> &[f32] {
+        let margin = samples.len() / 8;
+        &samples[margin..samples.len() - margin]
+    }
+
+    #[test]
+    fn test_resample_preserves_tone_frequency() {
+        let input = sine(1_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
+        let body = steady_state(&output);
+
+        let at_tone = tone_power(body, TEST_RATE_LOW, 1_000.0);
+        // A resampler that shifted the pitch would move the energy to a
+        // different bin, so check the neighbours are quiet rather than just
+        // checking the tone is present.
+        for other in [500.0, 2_000.0, 4_000.0] {
+            let at_other = tone_power(body, TEST_RATE_LOW, other);
+            assert!(
+                at_tone > at_other * DOMINANCE_RATIO,
+                "1 kHz tone did not dominate {other} Hz: {at_tone} vs {at_other}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resample_preserves_bird_band_content() {
+        // Guards the anti-aliasing cutoff. 6 kHz is well under the 16 kHz
+        // Nyquist limit of the 32 kHz output, so it must survive intact. A
+        // resampler configured with too small an FFT block lowers the cutoff
+        // and quietly attenuates exactly this band, which is where most bird
+        // song lives.
+        let input = sine(BIRD_BAND_HZ, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
+        let body = steady_state(&output);
+
+        let at_tone = tone_power(body, TEST_RATE_LOW, BIRD_BAND_HZ);
+        for other in [3_000.0, 9_000.0, 12_000.0] {
+            let at_other = tone_power(body, TEST_RATE_LOW, other);
+            assert!(
+                at_tone > at_other * DOMINANCE_RATIO,
+                "6 kHz tone did not dominate {other} Hz: {at_tone} vs {at_other}"
+            );
+        }
+
+        // The tone must also survive at close to full amplitude. Dominance
+        // alone would still pass if everything were attenuated together.
+        let level = rms(body);
+        assert!(
+            level > 0.6,
+            "6 kHz tone was attenuated by resampling: rms {level}, expected about 0.707"
+        );
+    }
+
+    #[test]
+    fn test_resample_filters_content_above_output_nyquist() {
+        // The one test here that can tell a real resampler from a naive one.
+        //
+        // 20 kHz fits under the 24 kHz Nyquist limit of the 48 kHz input but
+        // not under the 16 kHz limit of the 32 kHz output. A resampler with a
+        // working anti-aliasing filter removes it. One without folds it back to
+        // |20000 - 32000| = 12 kHz, inventing a tone that was never played.
+        //
+        // In-band tones cannot catch this: they stay dominant either way, which
+        // is why the other tests here pass even against nearest-neighbour
+        // decimation.
+        let input = sine(20_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
+        let body = steady_state(&output);
+
+        let alias = tone_power(body, TEST_RATE_LOW, 12_000.0);
+        assert!(
+            alias < 1e-3,
+            "20 kHz folded back to 12 kHz, anti-aliasing filter is not working: power {alias}"
+        );
+
+        let level = rms(body);
+        assert!(
+            level < 0.1,
+            "content above the output Nyquist limit survived resampling: rms {level}"
+        );
+    }
+
+    #[test]
+    fn test_resample_preserves_amplitude() {
+        let input = sine(1_000.0, TEST_RATE_HIGH, TEST_SIGNAL_LEN);
+        let input_rms = rms(&input);
+        let output = resample(input, TEST_RATE_HIGH, TEST_RATE_LOW).unwrap();
+        let output_rms = rms(steady_state(&output));
+
+        assert!(
+            (output_rms - input_rms).abs() < 0.05,
+            "amplitude changed: {input_rms} in, {output_rms} out"
+        );
+    }
 
     #[test]
     fn test_resample_same_rate_returns_input() {

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -14,14 +14,12 @@ pub fn resample(samples: Vec<f32>, from_rate: u32, to_rate: u32) -> Result<Vec<f
 
     // Create FFT-based synchronous resampler with fixed input/output sizes
     let chunk_size = 1024;
-    let sub_chunks = 1;
     let channels = 1;
 
     let mut resampler = Fft::<f32>::new(
         from_rate as usize,
         to_rate as usize,
         chunk_size,
-        sub_chunks,
         channels,
         FixedSync::Both,
     )
@@ -44,12 +42,11 @@ pub fn resample(samples: Vec<f32>, from_rate: u32, to_rate: u32) -> Result<Vec<f
                 }
             })?;
 
-        let resampled =
-            resampler
-                .process(&input_adapter, 0, None)
-                .map_err(|e| Error::Resample {
-                    reason: e.to_string(),
-                })?;
+        let resampled = resampler
+            .process(&input_adapter, None)
+            .map_err(|e| Error::Resample {
+                reason: e.to_string(),
+            })?;
 
         // Extract samples from the interleaved output
         let output_data = resampled.take_data();
@@ -70,12 +67,11 @@ pub fn resample(samples: Vec<f32>, from_rate: u32, to_rate: u32) -> Result<Vec<f
                 }
             })?;
 
-        let resampled =
-            resampler
-                .process(&input_adapter, 0, None)
-                .map_err(|e| Error::Resample {
-                    reason: e.to_string(),
-                })?;
+        let resampled = resampler
+            .process(&input_adapter, None)
+            .map_err(|e| Error::Resample {
+                reason: e.to_string(),
+            })?;
 
         // Only take proportional amount of output
         #[allow(


### PR DESCRIPTION
Closes #271. Lifts the `audioadapter-buffers` semver-major pin added in #252.

## Why this is unblocked now

`.github/dependabot.yml` named its own exit condition: *"Remove this ignore once rubato moves to audioadapter 4.x."* Verified against the crates.io API that this has happened:

| | audioadapter | audioadapter-buffers |
|---|---|---|
| rubato 3.0.0 | `^3.0` | `^3.0` |
| rubato 4.0.0 | `^4.0` | `^4.0` |

Both crates move together here. Bumping either alone puts two majors in the graph and breaks the resampler, which is exactly why the standalone Dependabot bump (#262) could never go green. The graph now resolves to a single version of each: `rubato 4.0.0`, `audioadapter 4.0.0`, `audioadapter-buffers 4.0.0`, `audioadapter-sample 4.0.0`.

## The API changes, and why they are behaviour preserving

rubato 4 changed two signatures. Neither is a like-for-like rename, so I read the rubato sources rather than pattern-match the nearest new signature.

**`Fft::new` drops `sub_chunks`.** We passed `1`. rubato 4 derives it instead:

```rust
// rubato-4.0.0/src/synchro.rs:220
let sub_chunks = (chunk_size / 256).max(1);     // = 4 for our chunk_size of 1024
```

That looked alarming, because rubato documents `sub_chunks` as affecting quality: *"a smaller FFT block also lowers the cutoff frequency of the anti-aliasing filter, which may affect quality at high frequencies"* — and bird song lives mostly in 2-10 kHz, so a lowered cutoff would quietly degrade detection.

It turns out not to bite here. We use `FixedSync::Both`, and that match arm ignores `sub_chunks` in **both** versions, identically:

```rust
FixedSync::Both => {
    let min_chunk_in = sample_rate_input / gcd;
    (chunk_size as f32 / min_chunk_in as f32).ceil() as usize   // no wanted_subsize
}
```

The window matches too: rubato 3 hard-codes `WindowFunction::BlackmanHarris2` inside `FftResampler::new`, and rubato 4's `Fft::new` passes exactly `BlackmanHarris2`.

**`Resampler::process` folds `input_offset` and `active_channels_mask` into `Option<&Indexing>`.** Our `(&adapter, 0, None)` becomes `(&adapter, None)`, which builds the identical struct: `get_offsets(&None)` returns `(0, 0)`, `get_partial_len(&None)` returns `None`, and the mask stays `None`.

`SequentialSlice::new(buf, channels, frames)` is unchanged between audioadapter-buffers 3 and 4.

## Verification: the output is bit-identical

Reasoning about equivalence is not proof, so I measured it. Resampling a 1234 Hz tone from 48 kHz to 32 kHz on each version:

| | rubato 3 | rubato 4 |
|---|---|---|
| len | 32000 | 32000 |
| sum | 3.028585383 | 3.028585383 |
| abssum | 20154.178050801 | 20154.178050801 |
| first / mid samples | identical | identical |

Byte for byte the same across all 32000 samples.

## The tests this needed first

#271 flagged that the existing tests only assert output **length**, so a migration that silently produced wrong samples would pass CI. The first commit here fixes that **before** the migration, so there is a real baseline.

The test with teeth is the anti-aliasing one. A 20 kHz tone fits under the 48 kHz input Nyquist limit but not the 16 kHz output limit, so a working filter removes it while a naive resampler folds it back to 12 kHz as a tone that was never played.

I proved it fails when it should, by swapping in nearest-neighbour decimation:

| Implementation | Anti-aliasing test |
|---|---|
| Real resampler (rubato 3 and rubato 4) | passes |
| Nearest-neighbour decimation | **fails**: 12 kHz alias power 3776 against a 1e-3 threshold |

Being straight about the rest: the pitch and amplitude tests **also pass** against that naive decimator, because an in-band tone stays dominant either way. They guard against pitch shift and gain change, not filter quality. Only the Nyquist test distinguishes a real resampler from a bad one, and the comments say so.

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --no-default-features -- -D warnings` (0 warnings)
- [x] `cargo test --no-default-features --no-fail-fast`: **329 passed, 0 failed**
- [x] Single major of each audioadapter crate in the lockfile
- [x] Fidelity tests pass on rubato 3 (baseline) and still pass on rubato 4
- [x] Anti-aliasing test verified to fail against a deliberately broken resampler
- [x] Output bit-identical across rubato 3 and 4
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio resampling accuracy, preserving target tone frequencies and steadier output amplitude.
  * Strengthened anti-aliasing behavior when content exceeds the output Nyquist limit.
  * Better handling for resampling between common rates, including correct behavior when input and output sample rates match.

* **Chores**
  * Updated Rust audio-related dependencies to newer major versions.
  * Adjusted update monitoring so major releases for audio buffer support are no longer excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->