### PR TITLE
fix: make the geomodel reachable from the commands that manage it

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -126,13 +126,14 @@ pub enum ConfigAction {
     Set {
         /// Configuration key (dotted path, e.g., "defaults.model").
         key: String,
-        /// Value to set.
-        ///
-        /// `allow_hyphen_values` because plenty of legitimate values start with
-        /// a minus. Without it clap reads `birda config set defaults.latitude
-        /// -33.9` as an unknown short flag and fails with "unexpected argument
-        /// '-3' found", which put every southern and western hemisphere
-        /// coordinate out of reach of this command.
+        // `allow_hyphen_values` because plenty of legitimate values start with a
+        // minus. Without it clap reads `birda config set defaults.latitude
+        // -33.9` as an unknown short flag and fails with "unexpected argument
+        // '-3' found", which put every southern and western hemisphere
+        // coordinate out of reach of this command. Kept as a `//` comment: clap
+        // renders `///` into `--help`, and this is implementation rationale.
+        /// Value to set. Use `--` before a value that begins with a hyphen and
+        /// could be mistaken for a flag.
         #[arg(allow_hyphen_values = true)]
         value: String,
     },
@@ -223,10 +224,11 @@ pub struct AnalyzeArgs {
     #[arg(long, env = "BIRDA_META_MODEL_PATH", hide = true)]
     pub meta_model_path: Option<PathBuf>,
 
+    // Global so `birda species` reaches the same field as `birda analyze`. See
+    // the note on `yes` for why these are not duplicated per subcommand. Kept
+    // as a `//` comment: clap renders `///` into `--help`.
     /// Path to the `BirdNET` Geomodel v3.0.2 ONNX file (overrides config).
-    ///
-    /// Global so `birda species` reaches the same field as `birda analyze`.
-    /// See the note on `yes` for why these are not duplicated per subcommand.
+    /// Must be given together with --geomodel-labels-path.
     #[arg(
         long,
         global = true,
@@ -235,9 +237,9 @@ pub struct AnalyzeArgs {
     )]
     pub geomodel_path: Option<PathBuf>,
 
+    // Global for the same reason as the model path above.
     /// Path to the `BirdNET` Geomodel v3.0.2 labels file (overrides config).
-    ///
-    /// Global for the same reason as `geomodel_path`.
+    /// Must be given together with --geomodel-path.
     #[arg(
         long,
         global = true,
@@ -396,14 +398,22 @@ pub struct AnalyzeArgs {
     #[arg(long, value_enum, env = "BIRDA_RANGE_UNMATCHED")]
     pub range_unmatched: Option<crate::config::UnmatchedPolicy>,
 
-    /// Assume yes for prompts, including the geomodel download offer.
-    ///
-    /// Global so that every spelling reaches this one field. `AnalyzeArgs` is
-    /// flattened onto the root, so without `global` a subcommand could only see
-    /// this flag by declaring its own copy, and the two copies would populate
-    /// different fields: `birda --yes species` would set the root field while
-    /// `species` read its own, still-false one. That is the defect in #286, and
-    /// duplicating the flag would have moved it rather than fixed it.
+    // Global so that every spelling reaches this one field. `AnalyzeArgs` is
+    // flattened onto the root, so without `global` a subcommand could only see
+    // this flag by declaring its own copy, and the two copies would populate
+    // different fields: `birda --yes species` would set the root field while
+    // `species` read its own, still-false one. That is the defect in #286, and
+    // duplicating the flag would have moved it rather than fixed it.
+    //
+    // Kept as a `//` comment on purpose: clap renders `///` into `--help`, and
+    // because this flag is global the text would appear under every subcommand.
+    // Rationale belongs to the code, not to the user.
+    //
+    // Every prompt this flag can reach must read it. See `handle_models_install`
+    // and `handle_models_remove`: a prompt that ignores `--yes`, or answers it
+    // backwards, is the same defect as a flag that does not reach the command.
+    /// Assume yes for prompts: the geomodel download offer, licence acceptance,
+    /// setting an installed model as default, and `models remove --purge`.
     #[arg(short = 'y', long, global = true)]
     pub yes: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -132,8 +132,8 @@ pub enum ConfigAction {
         // '-3' found", which put every southern and western hemisphere
         // coordinate out of reach of this command. Kept as a `//` comment: clap
         // renders `///` into `--help`, and this is implementation rationale.
-        /// Value to set. Use `--` before a value that begins with a hyphen and
-        /// could be mistaken for a flag.
+        /// Value to set. Values beginning with a hyphen are accepted, so
+        /// coordinates such as -33.9 need no escaping.
         #[arg(allow_hyphen_values = true)]
         value: String,
     },

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -127,6 +127,13 @@ pub enum ConfigAction {
         /// Configuration key (dotted path, e.g., "defaults.model").
         key: String,
         /// Value to set.
+        ///
+        /// `allow_hyphen_values` because plenty of legitimate values start with
+        /// a minus. Without it clap reads `birda config set defaults.latitude
+        /// -33.9` as an unknown short flag and fails with "unexpected argument
+        /// '-3' found", which put every southern and western hemisphere
+        /// coordinate out of reach of this command.
+        #[arg(allow_hyphen_values = true)]
         value: String,
     },
 }
@@ -217,11 +224,26 @@ pub struct AnalyzeArgs {
     pub meta_model_path: Option<PathBuf>,
 
     /// Path to the `BirdNET` Geomodel v3.0.2 ONNX file (overrides config).
-    #[arg(long, env = "BIRDA_GEOMODEL_PATH", requires = "geomodel_labels_path")]
+    ///
+    /// Global so `birda species` reaches the same field as `birda analyze`.
+    /// See the note on `yes` for why these are not duplicated per subcommand.
+    #[arg(
+        long,
+        global = true,
+        env = "BIRDA_GEOMODEL_PATH",
+        requires = "geomodel_labels_path"
+    )]
     pub geomodel_path: Option<PathBuf>,
 
     /// Path to the `BirdNET` Geomodel v3.0.2 labels file (overrides config).
-    #[arg(long, env = "BIRDA_GEOMODEL_LABELS_PATH", requires = "geomodel_path")]
+    ///
+    /// Global for the same reason as `geomodel_path`.
+    #[arg(
+        long,
+        global = true,
+        env = "BIRDA_GEOMODEL_LABELS_PATH",
+        requires = "geomodel_path"
+    )]
     pub geomodel_labels_path: Option<PathBuf>,
 
     /// Enable bat detection with a regional classifier.
@@ -375,7 +397,14 @@ pub struct AnalyzeArgs {
     pub range_unmatched: Option<crate::config::UnmatchedPolicy>,
 
     /// Assume yes for prompts, including the geomodel download offer.
-    #[arg(short = 'y', long)]
+    ///
+    /// Global so that every spelling reaches this one field. `AnalyzeArgs` is
+    /// flattened onto the root, so without `global` a subcommand could only see
+    /// this flag by declaring its own copy, and the two copies would populate
+    /// different fields: `birda --yes species` would set the root field while
+    /// `species` read its own, still-false one. That is the defect in #286, and
+    /// duplicating the flag would have moved it rather than fixed it.
+    #[arg(short = 'y', long, global = true)]
     pub yes: bool,
 
     /// Path to species list file.
@@ -393,13 +422,38 @@ pub struct AnalyzeArgs {
     pub stdout: bool,
 }
 
+impl AnalyzeArgs {
+    /// The subset of these arguments that geomodel resolution actually reads.
+    ///
+    /// All three source fields are `global = true`, so this returns the same
+    /// values whether the flags were given before the subcommand or after it.
+    /// That is what lets `birda species` share one resolver with `analyze`
+    /// instead of fabricating an `AnalyzeArgs` of its own, which is how #286
+    /// arose.
+    #[must_use]
+    pub fn geomodel_request(&self) -> crate::config::GeomodelRequest<'_> {
+        crate::config::GeomodelRequest {
+            model_path: self.geomodel_path.as_deref(),
+            labels_path: self.geomodel_labels_path.as_deref(),
+            assume_yes: self.yes,
+        }
+    }
+}
+
 // Re-use shared validators
 use super::validators::{parse_batch_size, parse_confidence, parse_latitude, parse_longitude};
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
+// Test setup code: panicking on an unexpected parse shape is how these assert.
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn test_cli_parse_simple() {
@@ -753,5 +807,161 @@ mod tests {
     fn test_cli_stdout_conflicts_with_format() {
         let cli = Cli::try_parse_from(["birda", "--stdout", "--format", "csv", "test.wav"]);
         assert!(cli.is_err());
+    }
+
+    // ---- geomodel flag reach (#286) ----
+    //
+    // The defect was not that `--yes` was missing, but that the value never
+    // reached the resolver. These assert on the resolved
+    // `GeomodelRequest`, which is what the resolver actually consumes, rather
+    // than on a struct field that might again be read by nobody.
+
+    /// `species` requires a time argument, so every case below carries one.
+    /// Without it clap fails with `MissingRequiredArgument` for `--week`, which
+    /// would make the negative test below pass for entirely the wrong reason.
+    fn species_argv(extra: &[&str]) -> Vec<String> {
+        let mut argv: Vec<String> = [
+            "birda", "species", "--lat", "60.2", "--lon", "24.9", "--week", "24",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+        argv.extend(extra.iter().map(|s| (*s).to_string()));
+        argv
+    }
+
+    fn request_from(argv: &[String]) -> crate::config::GeomodelRequest<'static> {
+        // Leaked so the returned request can borrow for 'static, keeping these
+        // tests to a single expression each. Test-only, and bounded by the
+        // number of test cases.
+        let cli = Box::leak(Box::new(
+            Cli::try_parse_from(argv).expect("argv should parse"),
+        ));
+        cli.analyze.geomodel_request()
+    }
+
+    #[test]
+    fn test_species_accepts_yes_after_the_subcommand() {
+        // Rejected by clap before the fix, because `--yes` lived only on the
+        // root and `species` had no such argument.
+        let request = request_from(&species_argv(&["--yes"]));
+
+        assert!(request.assume_yes);
+    }
+
+    #[test]
+    fn test_species_accepts_short_yes_after_the_subcommand() {
+        let request = request_from(&species_argv(&["-y"]));
+
+        assert!(request.assume_yes);
+    }
+
+    #[test]
+    fn test_species_sees_yes_given_before_the_subcommand() {
+        // The regression guard for the shape of the fix. This spelling always
+        // parsed, and always discarded the flag. An implementation that gave
+        // `Species` its own `--yes` would leave this case broken, because the
+        // two flags would populate different fields; `global = true` is what
+        // makes both spellings land on the one field the resolver reads.
+        let argv = [
+            "birda", "--yes", "species", "--lat", "60.2", "--lon", "24.9", "--week", "24",
+        ]
+        .map(String::from);
+        let request = request_from(&argv);
+
+        assert!(
+            request.assume_yes,
+            "root --yes must reach the resolver for `birda --yes species`"
+        );
+    }
+
+    #[test]
+    fn test_species_accepts_the_geomodel_path_pair() {
+        let request = request_from(&species_argv(&[
+            "--geomodel-path",
+            "/opt/g.onnx",
+            "--geomodel-labels-path",
+            "/opt/g.txt",
+        ]));
+
+        assert_eq!(request.model_path, Some(Path::new("/opt/g.onnx")));
+        assert_eq!(request.labels_path, Some(Path::new("/opt/g.txt")));
+    }
+
+    #[test]
+    fn test_species_rejects_a_half_specified_geomodel_pair() {
+        // Making the flags global must not drop the `requires` pairing:
+        // a new model with the previous version's labels fails the label count
+        // check with a confusing message, so it is rejected at parse time.
+        let err = Cli::try_parse_from(species_argv(&["--geomodel-path", "/opt/g.onnx"]))
+            .expect_err("a lone --geomodel-path must be rejected");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        // Assert it failed for the RIGHT missing argument. Without this the
+        // test would also pass if `species` rejected the argv for an unrelated
+        // reason, such as the missing time argument this helper supplies.
+        assert!(
+            err.to_string().contains("--geomodel-labels-path"),
+            "must fail on the missing labels path, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_config_set_accepts_negative_values() {
+        // `birda config set defaults.latitude -33.9` failed with "unexpected
+        // argument '-3' found", because clap read the value as a short flag
+        // group. That put every southern hemisphere latitude and western
+        // hemisphere longitude out of reach of this command.
+        let cli = Cli::try_parse_from(["birda", "config", "set", "defaults.latitude", "-33.9"])
+            .expect("a negative value must be accepted");
+
+        let Some(Command::Config {
+            action: ConfigAction::Set { key, value },
+        }) = cli.command
+        else {
+            panic!("expected a config set command");
+        };
+
+        assert_eq!(key, "defaults.latitude");
+        assert_eq!(value, "-33.9");
+    }
+
+    #[test]
+    fn test_config_set_accepts_negative_longitude() {
+        let cli = Cli::try_parse_from(["birda", "config", "set", "defaults.longitude", "-74.006"])
+            .expect("a negative longitude must be accepted");
+
+        let Some(Command::Config {
+            action: ConfigAction::Set { value, .. },
+        }) = cli.command
+        else {
+            panic!("expected a config set command");
+        };
+
+        assert_eq!(value, "-74.006");
+    }
+
+    #[test]
+    fn test_models_install_accepts_yes() {
+        // `--yes` became reachable here when it was made global. It must parse
+        // AND be read; the reading is asserted by the resolver-side tests
+        // above sharing the one field this populates.
+        let cli = Cli::try_parse_from(["birda", "models", "install", "birdnet-v24", "--yes"])
+            .expect("models install must accept --yes");
+
+        assert!(
+            cli.analyze.yes,
+            "--yes must reach the one field that is read"
+        );
+    }
+
+    #[test]
+    fn test_analyze_request_defaults_to_no_flags() {
+        let argv = ["birda", "test.wav"].map(String::from);
+        let request = request_from(&argv);
+
+        assert!(!request.assume_yes);
+        assert_eq!(request.model_path, None);
+        assert_eq!(request.labels_path, None);
     }
 }

--- a/src/cli/species.rs
+++ b/src/cli/species.rs
@@ -47,6 +47,7 @@ pub fn generate_species_list(
     sort: SortOrder,
     model: Option<String>,
     output_mode: OutputMode,
+    geomodel_request: crate::config::GeomodelRequest<'_>,
 ) -> Result<()> {
     // Load configuration
     let config = load_default_config()?;
@@ -66,13 +67,8 @@ pub fn generate_species_list(
     // a species list is the entire purpose of this command, so there is nothing
     // useful to fall back to.
     let registry = crate::registry::load_registry()?;
-    let geomodel_args = crate::cli::AnalyzeArgs {
-        lat: Some(lat),
-        lon: Some(lon),
-        ..crate::cli::AnalyzeArgs::default()
-    };
     let geomodel =
-        match crate::config::resolve_geomodel(&geomodel_args, &config, &registry, output_mode)? {
+        match crate::config::resolve_geomodel(geomodel_request, &config, &registry, output_mode)? {
             crate::config::GeomodelResolution::Ready(paths) => paths,
             crate::config::GeomodelResolution::Unavailable(hint) => {
                 return Err(Error::GeomodelNotInstalled { hint });

--- a/src/config/geomodel.rs
+++ b/src/config/geomodel.rs
@@ -4,12 +4,32 @@
 //! be absent when a user upgrades from a birda that used the `BirdNET` v2.4
 //! meta model. This module finds it, and offers to fetch it when it is missing.
 
-use crate::cli::AnalyzeArgs;
 use crate::config::types::Config;
 use crate::error::{Error, Result};
 use crate::registry::{InstalledRangeFilter, Registry};
 use std::io::{IsTerminal, Write};
+use std::path::Path;
 use tracing::warn;
+
+/// What geomodel resolution needs from the invoking command.
+///
+/// This exists so the resolver takes exactly what it reads. It previously took
+/// `&AnalyzeArgs` while reading three of its fields, which let `birda species`
+/// build a throwaway `AnalyzeArgs` that set two fields the resolver never reads
+/// and left unset the three it does. That compiled, and shipped as #286.
+///
+/// Deliberately does NOT derive `Default`. `..Default::default()` is exactly
+/// what let the under-specified call typecheck; requiring every field to be
+/// named is the point of this type.
+#[derive(Debug, Clone, Copy)]
+pub struct GeomodelRequest<'a> {
+    /// `--geomodel-path`, if given.
+    pub model_path: Option<&'a Path>,
+    /// `--geomodel-labels-path`, if given.
+    pub labels_path: Option<&'a Path>,
+    /// `--yes`: download without prompting.
+    pub assume_yes: bool,
+}
 
 /// Outcome of looking for the geomodel.
 #[derive(Debug, Clone)]
@@ -28,17 +48,14 @@ pub enum GeomodelResolution {
 /// pairing a new model with the previous version's labels would fail the label
 /// count check with a confusing message, so it is rejected up front.
 pub fn configured_paths(
-    args: &AnalyzeArgs,
+    request: GeomodelRequest<'_>,
     config: &Config,
 ) -> Result<Option<InstalledRangeFilter>> {
-    match (
-        args.geomodel_path.as_ref(),
-        args.geomodel_labels_path.as_ref(),
-    ) {
+    match (request.model_path, request.labels_path) {
         (Some(model), Some(labels)) => {
             return Ok(Some(InstalledRangeFilter {
-                model: model.clone(),
-                labels: labels.clone(),
+                model: model.to_path_buf(),
+                labels: labels.to_path_buf(),
             }));
         }
         (Some(_), None) => {
@@ -77,7 +94,7 @@ pub fn configured_paths(
 /// Resolution order is CLI flags, then the config file, then the path the
 /// registry says the asset installs to.
 pub fn resolve_geomodel(
-    args: &AnalyzeArgs,
+    request: GeomodelRequest<'_>,
     config: &Config,
     registry: &Registry,
     output_mode: crate::config::OutputMode,
@@ -88,7 +105,7 @@ pub fn resolve_geomodel(
         .ok_or(Error::RangeFilterAssetMissing)?;
 
     let registry_paths = crate::registry::geomodel_paths(asset)?;
-    let paths = configured_paths(args, config)?.unwrap_or_else(|| registry_paths.clone());
+    let paths = configured_paths(request, config)?.unwrap_or_else(|| registry_paths.clone());
 
     // "Ours to verify" is decided by which file this is, not by how the path
     // was reached: `birda models install geomodel` records its own install path
@@ -129,7 +146,7 @@ pub fn resolve_geomodel(
     }
 
     let interactive = std::io::stdin().is_terminal() && !output_mode.is_structured();
-    acquire(asset, interactive, args.yes)
+    acquire(asset, interactive, request.assume_yes)
 }
 
 /// Acquire a geomodel that is not on disk.
@@ -247,7 +264,7 @@ fn host_of(url: &str) -> String {
 /// Returns "unknown size" when the registry does not declare one, rather than
 /// printing a misleading zero.
 #[allow(clippy::cast_precision_loss)]
-fn human_size(bytes: Option<u64>) -> String {
+pub(crate) fn human_size(bytes: Option<u64>) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = 1024.0 * 1024.0;
 
@@ -264,22 +281,29 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn args_with_paths(model: Option<&str>, labels: Option<&str>) -> AnalyzeArgs {
-        AnalyzeArgs {
-            geomodel_path: model.map(PathBuf::from),
-            geomodel_labels_path: labels.map(PathBuf::from),
-            ..AnalyzeArgs::default()
+    /// Build a request the way a command line would.
+    ///
+    /// The explicit lifetime is required: with two borrowed parameters, elision
+    /// cannot pick which one the returned `GeomodelRequest` borrows from.
+    fn request_with_paths<'a>(
+        model: Option<&'a str>,
+        labels: Option<&'a str>,
+    ) -> GeomodelRequest<'a> {
+        GeomodelRequest {
+            model_path: model.map(Path::new),
+            labels_path: labels.map(Path::new),
+            assume_yes: false,
         }
     }
 
     #[test]
     fn test_cli_paths_take_precedence_over_config() {
-        let args = args_with_paths(Some("/cli/m.onnx"), Some("/cli/l.txt"));
+        let args = request_with_paths(Some("/cli/m.onnx"), Some("/cli/l.txt"));
         let mut config = Config::default();
         config.defaults.geomodel = Some(PathBuf::from("/cfg/m.onnx"));
         config.defaults.geomodel_labels = Some(PathBuf::from("/cfg/l.txt"));
 
-        let paths = configured_paths(&args, &config).unwrap().unwrap();
+        let paths = configured_paths(args, &config).unwrap().unwrap();
 
         assert_eq!(paths.model, PathBuf::from("/cli/m.onnx"));
         assert_eq!(paths.labels, PathBuf::from("/cli/l.txt"));
@@ -287,19 +311,19 @@ mod tests {
 
     #[test]
     fn test_config_paths_used_when_cli_absent() {
-        let args = args_with_paths(None, None);
+        let args = request_with_paths(None, None);
         let mut config = Config::default();
         config.defaults.geomodel = Some(PathBuf::from("/cfg/m.onnx"));
         config.defaults.geomodel_labels = Some(PathBuf::from("/cfg/l.txt"));
 
-        let paths = configured_paths(&args, &config).unwrap().unwrap();
+        let paths = configured_paths(args, &config).unwrap().unwrap();
 
         assert_eq!(paths.model, PathBuf::from("/cfg/m.onnx"));
     }
 
     #[test]
     fn test_no_configured_paths_yields_none() {
-        let paths = configured_paths(&args_with_paths(None, None), &Config::default()).unwrap();
+        let paths = configured_paths(request_with_paths(None, None), &Config::default()).unwrap();
 
         assert!(paths.is_none(), "falls back to the registry install path");
     }
@@ -308,18 +332,18 @@ mod tests {
     fn test_partial_cli_paths_are_rejected() {
         // Pairing a new model with the previous version's labels would fail the
         // label count check with a confusing message, so reject it up front.
-        let args = args_with_paths(Some("/cli/m.onnx"), None);
+        let args = request_with_paths(Some("/cli/m.onnx"), None);
 
-        let err = configured_paths(&args, &Config::default()).unwrap_err();
+        let err = configured_paths(args, &Config::default()).unwrap_err();
 
         assert!(matches!(err, Error::GeomodelPathsIncomplete { .. }));
     }
 
     #[test]
     fn test_partial_cli_labels_path_is_rejected() {
-        let args = args_with_paths(None, Some("/cli/l.txt"));
+        let args = request_with_paths(None, Some("/cli/l.txt"));
 
-        let err = configured_paths(&args, &Config::default()).unwrap_err();
+        let err = configured_paths(args, &Config::default()).unwrap_err();
 
         assert!(matches!(err, Error::GeomodelPathsIncomplete { .. }));
     }
@@ -329,7 +353,7 @@ mod tests {
         let mut config = Config::default();
         config.defaults.geomodel = Some(PathBuf::from("/cfg/m.onnx"));
 
-        let err = configured_paths(&args_with_paths(None, None), &config).unwrap_err();
+        let err = configured_paths(request_with_paths(None, None), &config).unwrap_err();
 
         assert!(matches!(err, Error::GeomodelPathsIncomplete { .. }));
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ mod validate;
 
 pub use bat::{BatConfig, BatRegion};
 pub use file::{load_config_file, load_default_config, save_config, save_default_config};
-pub use geomodel::{GeomodelResolution, resolve_geomodel};
+pub use geomodel::{GeomodelRequest, GeomodelResolution, resolve_geomodel};
 pub use paths::{config_dir, config_file_path, tensorrt_cache_dir};
 pub use types::{
     Config, CsvColumnsConfig, DefaultsConfig, InferenceConfig, InferenceDevice, ModelConfig,

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -8,7 +8,8 @@
 
 use crate::cli::AnalyzeArgs;
 use crate::config::types::{Config, ModelConfig, ModelType};
-use crate::error::Result;
+use crate::constants::confidence;
+use crate::error::{Error, Result};
 use crate::inference::RangeFilterConfig;
 use crate::registry::InstalledRangeFilter;
 use crate::utils::date::{date_to_week, day_of_year_to_date, week_to_start_day};
@@ -94,6 +95,22 @@ pub fn build_range_filter_config(
     let threshold = args
         .range_threshold
         .unwrap_or(config.defaults.range_threshold);
+
+    // Bounds-check here, at the point of use, and not only in
+    // `validate_range_filter`. `validate_config` has exactly one caller,
+    // `handle_config_set`, so nothing validates a config that was hand-edited
+    // rather than written through the CLI. That hand-edited case is the one the
+    // bug report describes: a negative threshold makes filtering a silent
+    // no-op while the JSON envelope still reports it active, and NaN drops
+    // every mapped species because `score >= NaN` is false for every score.
+    // Validating only where configs are written would have left the path the
+    // defect actually travels wide open.
+    //
+    // The CLI flag reaches here already bounded by `parse_confidence`, so this
+    // fires only for a config-file value.
+    if !(confidence::MIN..=confidence::MAX).contains(&threshold) {
+        return Err(Error::InvalidRangeThreshold { value: threshold });
+    }
     let unmatched = args
         .range_unmatched
         .unwrap_or(config.defaults.range_unmatched);
@@ -143,6 +160,64 @@ mod tests {
             lon: Some(24.9384),
             week: Some(24),
             ..AnalyzeArgs::default()
+        }
+    }
+
+    /// A config as a hand-edit would leave it: coordinates set so range
+    /// filtering is wanted, and a threshold nothing on this path validated.
+    fn config_with_threshold(threshold: f32) -> Config {
+        let mut config = Config::default();
+        config.defaults.range_threshold = threshold;
+        config
+    }
+
+    fn build_with(config: &Config) -> crate::error::Result<Option<RangeFilterConfig>> {
+        build_range_filter_config(
+            &args_at_helsinki_week_24(),
+            config,
+            &model_of(ModelType::BirdnetV24),
+            &geomodel(),
+        )
+    }
+
+    #[test]
+    fn test_hand_edited_nan_threshold_is_rejected_on_the_analyze_path() {
+        // The reported defect in full. `validate_config` has one caller,
+        // `handle_config_set`, so a threshold typed into config.toml by hand
+        // reached analysis unchecked: `score >= NaN` is false for every score,
+        // so every mapped species was dropped and the only symptom was an info
+        // log reading "0 species in range".
+        //
+        // Guarding only `validate_range_filter` would leave this green while
+        // the bug stayed live, because nothing on this path calls it.
+        let err = build_with(&config_with_threshold(f32::NAN)).unwrap_err();
+
+        assert!(
+            matches!(err, crate::error::Error::InvalidRangeThreshold { value } if value.is_nan()),
+            "expected InvalidRangeThreshold(NaN), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_hand_edited_negative_threshold_is_rejected_on_the_analyze_path() {
+        // The sibling half: a negative threshold made filtering a silent no-op
+        // while the JSON envelope still reported it active.
+        let err = build_with(&config_with_threshold(-1.0)).unwrap_err();
+
+        assert!(
+            matches!(err, crate::error::Error::InvalidRangeThreshold { .. }),
+            "expected InvalidRangeThreshold, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_valid_thresholds_still_build_on_the_analyze_path() {
+        // The normal case must be untouched, including both inclusive bounds.
+        for threshold in [0.0, 0.01, 0.5, 1.0] {
+            assert!(
+                build_with(&config_with_threshold(threshold)).is_ok(),
+                "threshold {threshold} must be accepted"
+            );
         }
     }
 

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -34,6 +34,35 @@ pub fn supports_range_filter(args: &AnalyzeArgs, model_type: ModelType) -> bool 
     }
 }
 
+/// Reject a range threshold that the config file put out of bounds.
+///
+/// Separate from `build_range_filter_config` so it can run BEFORE the geomodel
+/// is resolved. Resolution may prompt for and download roughly 15 MB, and
+/// aborting after that spends the user's bandwidth to report something knowable
+/// up front.
+///
+/// Bounds-checked here rather than only in `validate_range_filter` because
+/// `validate_config` has exactly one caller, `handle_config_set`, so nothing
+/// validates a config that was hand-edited rather than written through the CLI.
+/// The hand-edited case is the one the bug report describes: a negative
+/// threshold makes filtering a silent no-op while the JSON envelope still
+/// reports it active, and NaN drops every mapped species because `score >= NaN`
+/// is false for every score.
+///
+/// The CLI flag arrives already bounded by `parse_confidence`, so in practice
+/// this fires only for a config-file value.
+pub fn validate_threshold(args: &AnalyzeArgs, config: &Config) -> Result<()> {
+    let threshold = args
+        .range_threshold
+        .unwrap_or(config.defaults.range_threshold);
+
+    if !(confidence::MIN..=confidence::MAX).contains(&threshold) {
+        return Err(Error::InvalidRangeThreshold { value: threshold });
+    }
+
+    Ok(())
+}
+
 /// Whether range filtering is wanted at all, before the geomodel is resolved.
 ///
 /// Checked ahead of acquisition so birda never prompts for, downloads, or
@@ -96,21 +125,10 @@ pub fn build_range_filter_config(
         .range_threshold
         .unwrap_or(config.defaults.range_threshold);
 
-    // Bounds-check here, at the point of use, and not only in
-    // `validate_range_filter`. `validate_config` has exactly one caller,
-    // `handle_config_set`, so nothing validates a config that was hand-edited
-    // rather than written through the CLI. That hand-edited case is the one the
-    // bug report describes: a negative threshold makes filtering a silent
-    // no-op while the JSON envelope still reports it active, and NaN drops
-    // every mapped species because `score >= NaN` is false for every score.
-    // Validating only where configs are written would have left the path the
-    // defect actually travels wide open.
-    //
-    // The CLI flag reaches here already bounded by `parse_confidence`, so this
-    // fires only for a config-file value.
-    if !(confidence::MIN..=confidence::MAX).contains(&threshold) {
-        return Err(Error::InvalidRangeThreshold { value: threshold });
-    }
+    // Belt and braces: `analyze_files` checks this before resolving the
+    // geomodel so a bad value fails without spending a download, but the check
+    // also belongs at the point of use so no future caller can bypass it.
+    validate_threshold(args, config)?;
     let unmatched = args
         .range_unmatched
         .unwrap_or(config.defaults.range_unmatched);

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -119,6 +119,21 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
         return Err(Error::InvalidLongitude { value: lon });
     }
 
+    // `--range-threshold` is bounds-checked by `parse_confidence`, but nothing
+    // checked the config-file path, so a hand-edited value went straight
+    // through. Two states were silently wrong rather than rejected: a negative
+    // threshold made range filtering a no-op while the JSON envelope still
+    // reported it active, and NaN dropped every mapped species because
+    // `score >= NaN` is false, leaving only the unmatched non-species labels.
+    //
+    // `contains` handles NaN without a special case: every NaN comparison is
+    // false, so the range does not contain it and the negation rejects it. A
+    // hand-rolled `threshold < 0.0` test would let NaN straight through.
+    let threshold = config.defaults.range_threshold;
+    if !(0.0..=1.0).contains(&threshold) {
+        return Err(Error::InvalidRangeThreshold { value: threshold });
+    }
+
     // The geomodel is resolved and acquired at analysis time rather than
     // validated here: it is a shared asset that birda can offer to download,
     // so a missing file is not a configuration error.
@@ -127,6 +142,11 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
 }
 
 #[cfg(test)]
+// Test setup code: unwrapping a known-Err result is how these assert, and the
+// float comparisons check that a literal passed in came back unchanged, so an
+// epsilon would weaken them. Matches the convention used by the other test
+// modules in this crate.
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 
@@ -196,5 +216,72 @@ mod tests {
 
         let result = validate_range_filter(&config);
         assert!(result.is_ok());
+    }
+
+    /// Build a config carrying nothing but the threshold under test, so a
+    /// failure can only be attributed to the threshold.
+    fn config_with_threshold(threshold: f32) -> Config {
+        let mut config = Config::default();
+        config.defaults.range_threshold = threshold;
+        config
+    }
+
+    #[test]
+    fn test_validate_range_filter_rejects_negative_threshold() {
+        // Silently disabled range filtering while the JSON envelope still
+        // reported it as active.
+        let err = validate_range_filter(&config_with_threshold(-1.0)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::InvalidRangeThreshold { value } if value == -1.0),
+            "expected InvalidRangeThreshold(-1.0), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_range_filter_rejects_threshold_above_one() {
+        let err = validate_range_filter(&config_with_threshold(1.5)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::InvalidRangeThreshold { value } if value == 1.5),
+            "expected InvalidRangeThreshold(1.5), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_range_filter_rejects_nan_threshold() {
+        // The regression guard. NaN dropped every mapped species, because
+        // `score >= NaN` is false for every score, and the only symptom was an
+        // info log reading "0 species in range". It is caught here because
+        // `(0.0..=1.0).contains(&NaN)` is false, not by an explicit is_nan test,
+        // so this asserts the idiom keeps working.
+        let err = validate_range_filter(&config_with_threshold(f32::NAN)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::InvalidRangeThreshold { value } if value.is_nan()),
+            "expected InvalidRangeThreshold(NaN), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_range_filter_accepts_threshold_boundaries() {
+        // The range is inclusive at both ends; pin that so a later refactor to
+        // an exclusive comparison is caught.
+        assert!(validate_range_filter(&config_with_threshold(0.0)).is_ok());
+        assert!(validate_range_filter(&config_with_threshold(1.0)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_rejects_bad_threshold() {
+        // `handle_config_set` calls `validate_config`, not `validate_range_filter`
+        // directly, so the chain has to hold for `birda config set
+        // defaults.range_threshold -1` to be rejected. Without this, the unit
+        // tests above could pass while the CLI path stayed broken.
+        let err = validate_config(&config_with_threshold(-1.0)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::InvalidRangeThreshold { .. }),
+            "validate_config must reach validate_range_filter, got {err:?}"
+        );
     }
 }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -130,7 +130,7 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
     // false, so the range does not contain it and the negation rejects it. A
     // hand-rolled `threshold < 0.0` test would let NaN straight through.
     let threshold = config.defaults.range_threshold;
-    if !(0.0..=1.0).contains(&threshold) {
+    if !(confidence::MIN..=confidence::MAX).contains(&threshold) {
         return Err(Error::InvalidRangeThreshold { value: threshold });
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -349,6 +349,13 @@ pub enum Error {
         value: f64,
     },
 
+    /// Invalid range filter threshold.
+    #[error("invalid range threshold: {value} (must be 0.0 to 1.0)")]
+    InvalidRangeThreshold {
+        /// Invalid threshold value.
+        value: f32,
+    },
+
     /// Failed to read species list file.
     #[error("failed to read species list file '{path}'")]
     SpeciesListRead {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1279,8 +1279,9 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
             };
         }
         // The three keys below are siblings of range_threshold above. They were
-        // missed when the geomodel landed, so users and the GUI had to
-        // hand-edit config.toml to reach them.
+        // missed when the geomodel landed, so reaching them meant hand-editing
+        // config.toml. (Only users: the GUI has no config write path at all, it
+        // shells out to `config show` and `config path` only.)
         "defaults.geomodel" => {
             config.defaults.geomodel = if value.is_empty() {
                 None
@@ -1301,12 +1302,23 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
             } else {
                 // Parsed through clap's ValueEnum so `config set` accepts
                 // exactly the spellings `--range-unmatched` accepts, rather
-                // than a second, drifting list.
+                // than a second, drifting list. The error message derives its
+                // list the same way, so adding a variant cannot leave the two
+                // out of step.
                 <config::UnmatchedPolicy as clap::ValueEnum>::from_str(value, false).map_err(
-                    |_| Error::ConfigValidation {
-                        message: format!(
-                            "invalid value for '{key}': {value} (expected 'keep' or 'drop')"
-                        ),
+                    |_| {
+                        let accepted =
+                            <config::UnmatchedPolicy as clap::ValueEnum>::value_variants()
+                                .iter()
+                                .filter_map(clap::ValueEnum::to_possible_value)
+                                .map(|v| format!("'{}'", v.get_name()))
+                                .collect::<Vec<_>>()
+                                .join(" or ");
+                        Error::ConfigValidation {
+                            message: format!(
+                                "invalid value for '{key}': {value} (expected {accepted})"
+                            ),
+                        }
                     },
                 )?
             };
@@ -1456,9 +1468,18 @@ fn handle_models_command(
             // birdnet-geomodel-v3` worked while `models install
             // birdnet-geomodel-v3` did not, which is a worse answer than a
             // single canonical handle.
-            if let Some(asset) = registry.range_filter.as_ref()
-                && id == registry::GEOMODEL_INSTALL_ID
-            {
+            // Match the id FIRST, then require the asset. Testing the asset
+            // first meant that a registry predating the geomodel fell through
+            // to `find_model` and died in `config::get_model` with "model
+            // 'geomodel' not found in configuration" -- exactly the message
+            // this branch exists to prevent. `handle_models_install` already
+            // orders it this way and reports `RangeFilterAssetMissing`, so the
+            // two commands disagreed on the same registry state.
+            if id == registry::GEOMODEL_INSTALL_ID {
+                let asset = registry
+                    .range_filter
+                    .as_ref()
+                    .ok_or(Error::RangeFilterAssetMissing)?;
                 if output_mode.is_structured() {
                     let payload = ModelInfoPayload {
                         result_type: ResultType::ModelInfo,
@@ -1542,7 +1563,9 @@ fn handle_models_command(
             }
             Ok(())
         }
-        ModelsAction::Remove { name, purge } => handle_models_remove(&name, purge, output_mode),
+        ModelsAction::Remove { name, purge } => {
+            handle_models_remove(&name, purge, output_mode, assume_yes)
+        }
         ModelsAction::Install {
             id,
             language,
@@ -1660,14 +1683,23 @@ fn referenced_model_paths(config: &Config) -> std::collections::HashSet<PathBuf>
 }
 
 /// Handle the `models remove` command.
-fn handle_models_remove(name: &str, purge: bool, output_mode: OutputMode) -> Result<()> {
+fn handle_models_remove(
+    name: &str,
+    purge: bool,
+    output_mode: OutputMode,
+    assume_yes: bool,
+) -> Result<()> {
     use std::io::Write;
 
     // Load config and verify model exists
     let mut config = load_default_config()?;
 
-    // If purge, confirm before deleting files (skip in structured mode)
-    if purge && !output_mode.is_structured() {
+    // If purge, confirm before deleting files (skip in structured mode).
+    //
+    // `--yes` is honoured here because the flag is global and therefore appears
+    // in this command's `--help`. A prompt that advertises the flag and then
+    // ignores it is the same defect as a flag that never reaches the command.
+    if purge && !output_mode.is_structured() && !assume_yes {
         print!("This will delete model files for '{name}' from disk. Continue? [y/N]: ");
         std::io::stdout().flush()?;
         let mut input = String::new();
@@ -1772,14 +1804,15 @@ fn handle_models_install(
 ) -> Result<()> {
     use std::io::{IsTerminal, Write};
 
-    // `--yes` is documented as "assume yes for prompts", so it has to reach the
-    // prompts. It became reachable here when the flag was made global for
-    // `birda species`; leaving it unread would have made `models install --yes`
-    // parse and do nothing, which is the same defect this change set exists to
-    // remove. Note this grants no new licence exemption: acceptance already
-    // auto-succeeds for any non-interactive run, such as a pipe or JSON mode,
-    // and `--yes` simply lets a user at a terminal opt into the same thing.
-    let interactive = std::io::stdin().is_terminal() && !output_mode.is_structured() && !assume_yes;
+    // `interactive` means "a human is present and can be asked", nothing more.
+    //
+    // `assume_yes` is deliberately NOT folded in here. Doing so collapses three
+    // states (cannot ask / pre-answered yes / must ask) into two, and the two
+    // collapsed states need OPPOSITE answers at the "Set as default model?"
+    // prompt below, whose interactive default is yes: `--yes` would have
+    // answered no. Each prompt reads `assume_yes` for itself, the way
+    // `config::geomodel::acquire` already does.
+    let interactive = std::io::stdin().is_terminal() && !output_mode.is_structured();
 
     // Load registry
     let registry = registry::load_registry()?;
@@ -1787,7 +1820,7 @@ fn handle_models_install(
     // The shared range filter asset is installable under its own id, since it
     // is used by every classifier rather than belonging to any one of them.
     if id == registry::GEOMODEL_INSTALL_ID {
-        return handle_geomodel_install(&registry, interactive, output_mode);
+        return handle_geomodel_install(&registry, interactive, assume_yes, output_mode);
     }
 
     let model = registry::find_model(&registry, id)
@@ -1800,7 +1833,7 @@ fn handle_models_install(
         version: &model.version,
         license: &model.license,
     };
-    if !registry::prompt_license_acceptance(asset, interactive)? {
+    if !registry::prompt_license_acceptance(asset, interactive, assume_yes)? {
         if !output_mode.is_structured() {
             println!("Installation cancelled.");
         }
@@ -1845,8 +1878,13 @@ fn handle_models_install(
         println!();
     }
 
-    // Prompt to set as default
-    let should_set_default = if set_default {
+    // Prompt to set as default.
+    //
+    // `assume_yes` answers yes, matching this prompt's own interactive default
+    // ([Y/n], bare Enter means yes). Folding `--yes` into `interactive` instead
+    // would drop through to the `else` and answer NO, so the flag would mean
+    // "accept" at the licence prompt and "decline" here, inside one command.
+    let should_set_default = if set_default || assume_yes {
         true
     } else if interactive {
         print!("Set as default model? [Y/n]: ");
@@ -1966,6 +2004,7 @@ fn report_geomodel_status(info: &output::GeomodelInfo) {
 fn handle_geomodel_install(
     registry: &registry::Registry,
     interactive: bool,
+    assume_yes: bool,
     output_mode: OutputMode,
 ) -> Result<()> {
     let asset = registry
@@ -1979,7 +2018,7 @@ fn handle_geomodel_install(
         version: &asset.version,
         license: &asset.license,
     };
-    if !registry::prompt_license_acceptance(licensed, interactive)? {
+    if !registry::prompt_license_acceptance(licensed, interactive, assume_yes)? {
         if !output_mode.is_structured() {
             println!("Installation cancelled.");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,6 +776,24 @@ fn analyze_files(
     // Resolve device from command-line flags or config
     let device = resolve_device(args, config);
 
+    // Reject a malformed threshold BEFORE resolving the geomodel, because
+    // resolution may prompt for and download roughly 15 MB and aborting after
+    // that spends the user's bandwidth to report something knowable up front.
+    //
+    // This is a hard error, unlike the availability failures described below,
+    // and the distinction is deliberate. Those are transient (a network blip, a
+    // stale cached registry, a checksum mismatch) and degrade to unfiltered
+    // analysis so a pipeline survives them. A threshold outside 0.0-1.0 is
+    // neither transient nor safe to continue past: continuing is precisely the
+    // reported bug, where a negative value silently disabled filtering while
+    // the JSON envelope still called it active, and NaN dropped every species.
+    //
+    // Gated on `wants_range_filter` so a stale threshold in a config that is
+    // not doing range filtering at all cannot fail an unrelated run.
+    if config::range_filter::wants_range_filter(args, config, model_config.model_type) {
+        config::range_filter::validate_threshold(args, config)?;
+    }
+
     // Build range filter config, resolving the shared geomodel first.
     //
     // A geomodel that cannot be found or fetched disables range filtering with
@@ -1884,7 +1902,12 @@ fn handle_models_install(
     // ([Y/n], bare Enter means yes). Folding `--yes` into `interactive` instead
     // would drop through to the `else` and answer NO, so the flag would mean
     // "accept" at the licence prompt and "decline" here, inside one command.
-    let should_set_default = if set_default || assume_yes {
+    // `assume_yes && interactive`, not `assume_yes` alone: where no prompt is
+    // printed there is nothing to assume. In a pipe or under --output-mode json
+    // this prompt never appears, so answering it "yes" would silently seize
+    // `defaults.model` from a provisioning script that passed --yes only to
+    // clear the licence gate. That stays at its prior `false`.
+    let should_set_default = if set_default || (assume_yes && interactive) {
         true
     } else if interactive {
         print!("Set as default model? [Y/n]: ");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,13 +168,14 @@ fn resolve_range_filter_geomodel(
     // or a checksum failure, which is exactly the pipeline break this function
     // exists to prevent. Only `birda species`, where the species list IS the
     // output, treats an unavailable geomodel as fatal.
-    let resolution = match config::resolve_geomodel(args, config, &registry, output_mode) {
-        Ok(resolution) => resolution,
-        Err(e) => {
-            warn!("Range filtering disabled: {e}");
-            return None;
-        }
-    };
+    let resolution =
+        match config::resolve_geomodel(args.geomodel_request(), config, &registry, output_mode) {
+            Ok(resolution) => resolution,
+            Err(e) => {
+                warn!("Range filtering disabled: {e}");
+                return None;
+            }
+        };
 
     match resolution {
         config::GeomodelResolution::Ready(geomodel) => Some(geomodel),
@@ -323,9 +324,15 @@ pub fn run() -> Result<()> {
         inference::ensure_runtime_available()?;
     }
 
-    // Handle subcommands
+    // Handle subcommands.
+    //
+    // The geomodel request is read from the flattened root args rather than
+    // from the subcommand, because the three flags it carries are `global`.
+    // A subcommand that needs the geomodel therefore sees the user's flags
+    // whichever side of the subcommand name they were written on.
     if let Some(command) = cli.command {
-        return handle_command(command, &config, output_mode, &reporter);
+        let geomodel_request = cli.analyze.geomodel_request();
+        return handle_command(command, &config, output_mode, &reporter, geomodel_request);
     }
 
     // Default: analyze files
@@ -937,10 +944,13 @@ fn handle_command(
     config: &config::Config,
     output_mode: OutputMode,
     _reporter: &Arc<dyn ProgressReporter>,
+    geomodel_request: config::GeomodelRequest<'_>,
 ) -> Result<()> {
     match command {
         Command::Config { action } => handle_config_command(action, output_mode),
-        Command::Models { action } => handle_models_command(action, config, output_mode),
+        Command::Models { action } => {
+            handle_models_command(action, config, output_mode, geomodel_request.assume_yes)
+        }
         Command::Providers => {
             handle_providers_command(output_mode);
             Ok(())
@@ -966,6 +976,7 @@ fn handle_command(
             sort,
             model,
             output_mode,
+            geomodel_request,
         ),
         Command::Clip(args) => clipper::command::execute(&args, output_mode),
         Command::Update { check } => handle_update_command(check, output_mode),
@@ -1267,6 +1278,39 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
                 })?
             };
         }
+        // The three keys below are siblings of range_threshold above. They were
+        // missed when the geomodel landed, so users and the GUI had to
+        // hand-edit config.toml to reach them.
+        "defaults.geomodel" => {
+            config.defaults.geomodel = if value.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(value))
+            };
+        }
+        "defaults.geomodel_labels" => {
+            config.defaults.geomodel_labels = if value.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(value))
+            };
+        }
+        "defaults.range_unmatched" => {
+            config.defaults.range_unmatched = if value.is_empty() {
+                config::DefaultsConfig::default().range_unmatched
+            } else {
+                // Parsed through clap's ValueEnum so `config set` accepts
+                // exactly the spellings `--range-unmatched` accepts, rather
+                // than a second, drifting list.
+                <config::UnmatchedPolicy as clap::ValueEnum>::from_str(value, false).map_err(
+                    |_| Error::ConfigValidation {
+                        message: format!(
+                            "invalid value for '{key}': {value} (expected 'keep' or 'drop')"
+                        ),
+                    },
+                )?
+            };
+        }
         _ => {
             return Err(Error::InvalidConfigKey {
                 key: key.to_string(),
@@ -1299,6 +1343,7 @@ fn handle_models_command(
     action: cli::ModelsAction,
     config: &config::Config,
     output_mode: OutputMode,
+    assume_yes: bool,
 ) -> Result<()> {
     use cli::ModelsAction;
 
@@ -1397,6 +1442,54 @@ fn handle_models_command(
         ModelsAction::Info { id, languages } => {
             // Try registry first
             let registry = registry::load_registry()?;
+
+            // The geomodel lives in `registry.range_filter`, not
+            // `registry.models`, so `find_model` below can never match it and
+            // the fallback would die in `config::get_model` with "model not
+            // found" for the exact id every error message and doc page tells
+            // users to install. Handle it before the lookup, not inside
+            // `show_info`, which that lookup would never reach.
+            // Only the install handle, deliberately not `asset.id`. That is the
+            // id `models install` accepts, the one every error message and doc
+            // page names, and the one this command's own JSON reports. Taking
+            // the registry's internal id here as well would mean `models info
+            // birdnet-geomodel-v3` worked while `models install
+            // birdnet-geomodel-v3` did not, which is a worse answer than a
+            // single canonical handle.
+            if let Some(asset) = registry.range_filter.as_ref()
+                && id == registry::GEOMODEL_INSTALL_ID
+            {
+                if output_mode.is_structured() {
+                    let payload = ModelInfoPayload {
+                        result_type: ResultType::ModelInfo,
+                        model: ModelDetails {
+                            id: registry::GEOMODEL_INSTALL_ID.to_string(),
+                            // Distinguishes the shared range filter from a
+                            // classifier, which is what a consumer needs in
+                            // order not to offer it as a selectable model.
+                            model_type: "range-filter".to_string(),
+                            path: None,
+                            labels_path: None,
+                            source: "registry".to_string(),
+                        },
+                    };
+                    emit_json_result(&payload);
+                } else if languages {
+                    // The geomodel ships one English labels file and has no
+                    // language variants, so report that rather than rendering
+                    // an empty language list that looks like a lookup failure.
+                    println!("Range filter: {}", asset.name);
+                    println!();
+                    println!(
+                        "The range filter has no label language variants. Species names in \
+                         output come from the active classifier's own labels."
+                    );
+                } else {
+                    registry::show_range_filter_info(asset);
+                }
+                return Ok(());
+            }
+
             if let Some(reg_model) = registry::find_model(&registry, &id) {
                 // JSON/NDJSON output for registry model
                 if output_mode.is_structured() {
@@ -1454,7 +1547,7 @@ fn handle_models_command(
             id,
             language,
             default,
-        } => handle_models_install(&id, language.as_deref(), default, output_mode),
+        } => handle_models_install(&id, language.as_deref(), default, output_mode, assume_yes),
     }
 }
 
@@ -1675,10 +1768,18 @@ fn handle_models_install(
     language: Option<&str>,
     set_default: bool,
     output_mode: OutputMode,
+    assume_yes: bool,
 ) -> Result<()> {
     use std::io::{IsTerminal, Write};
 
-    let interactive = std::io::stdin().is_terminal() && !output_mode.is_structured();
+    // `--yes` is documented as "assume yes for prompts", so it has to reach the
+    // prompts. It became reachable here when the flag was made global for
+    // `birda species`; leaving it unread would have made `models install --yes`
+    // parse and do nothing, which is the same defect this change set exists to
+    // remove. Note this grants no new licence exemption: acceptance already
+    // auto-succeeds for any non-interactive run, such as a pipe or JSON mode,
+    // and `--yes` simply lets a user at a terminal opt into the same thing.
+    let interactive = std::io::stdin().is_terminal() && !output_mode.is_structured() && !assume_yes;
 
     // Load registry
     let registry = registry::load_registry()?;

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -498,9 +498,11 @@ pub struct AvailableModelsPayload {
     /// Named `available_range_filter` rather than `range_filter` because
     /// `DetectionsPayload` already has a `range_filter` field carrying a
     /// completely different shape (`RangeFilterInfo`: per-run coverage counts).
-    /// Two disjoint types under one field name collide for any consumer that
-    /// derives one type per field name, which is how the GUI's `types.ts` is
-    /// written.
+    /// Distinct names keep the two readable side by side in a schema, a doc
+    /// table or a generated client, where one name over two disjoint shapes
+    /// invites the wrong one being reached for. This is a naming-clarity call,
+    /// not a fix for a known consumer: TypeScript scopes field names to their
+    /// interface, so nothing in birda-gui collides today.
     ///
     /// `None` when the registry predates the geomodel.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -495,9 +495,16 @@ pub struct AvailableModelsPayload {
     /// would otherwise offer an entry that fails on use. This also keeps the
     /// change additive, so existing consumers of `models` are unaffected.
     ///
+    /// Named `available_range_filter` rather than `range_filter` because
+    /// `DetectionsPayload` already has a `range_filter` field carrying a
+    /// completely different shape (`RangeFilterInfo`: per-run coverage counts).
+    /// Two disjoint types under one field name collide for any consumer that
+    /// derives one type per field name, which is how the GUI's `types.ts` is
+    /// written.
+    ///
     /// `None` when the registry predates the geomodel.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub range_filter: Option<AvailableRangeFilterEntry>,
+    pub available_range_filter: Option<AvailableRangeFilterEntry>,
 }
 
 /// The shared range filter asset, as offered by `birda models list-available`.
@@ -524,9 +531,9 @@ pub struct AvailableRangeFilterEntry {
     pub species_count: usize,
     /// Combined download size of the model and labels files, in bytes.
     ///
-    /// `None` when the registry declares no size for either file, rather than
-    /// reporting a misleading zero. Both files are required, so a size is only
-    /// meaningful when both are known.
+    /// `None` unless both files declare a size and their sum fits in `u64`.
+    /// Both files are required for the range filter to work, so a partial total
+    /// would read as the whole download and understate it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_bytes: Option<u64>,
 }
@@ -894,7 +901,7 @@ mod tests {
                 license: "CC-BY-NC-SA-4.0".to_string(),
                 commercial_use: false,
             }],
-            range_filter: None,
+            available_range_filter: None,
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
@@ -1149,9 +1156,21 @@ mod tests {
 
     #[test]
     fn test_spec_version_is_bumped_for_the_geomodel_envelope() {
+        // 1.1 is the version in which `DetectionsPayload.range_filter` became
+        // `RangeFilterInfo` (geomodel coverage counts), replacing the
+        // cross-model fields. This is a change-detector on that constant, not
+        // evidence that any later change was accompanied by a bump: it can only
+        // fire when someone edits the literal.
+        //
+        // Purely additive optional fields do NOT move it. That is why
+        // `AvailableModelsPayload::available_range_filter` was added under 1.1:
+        // it carries `#[serde(default, skip_serializing_if)]`, so old consumers
+        // deserialize unchanged and the emitted bytes are identical when the
+        // registry has no range filter.
         assert_eq!(
             SPEC_VERSION, "1.1",
-            "range_filter changed shape, so consumers need the bump"
+            "changing this constant is a wire-contract decision; update the \
+             reasoning above along with it"
         );
     }
 

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -488,6 +488,47 @@ pub struct AvailableModelsPayload {
     pub result_type: ResultType,
     /// List of available models from registry.
     pub models: Vec<AvailableModelEntry>,
+    /// The shared range filter asset, which is not one of `models`.
+    ///
+    /// Kept in its own field rather than folded into `models` because it is not
+    /// selectable with `-m`: a consumer building a model picker from `models`
+    /// would otherwise offer an entry that fails on use. This also keeps the
+    /// change additive, so existing consumers of `models` are unaffected.
+    ///
+    /// `None` when the registry predates the geomodel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_filter: Option<AvailableRangeFilterEntry>,
+}
+
+/// The shared range filter asset, as offered by `birda models list-available`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableRangeFilterEntry {
+    /// The id to pass to `birda models install` and `birda models info`.
+    ///
+    /// This is the install handle ("geomodel"), not the registry asset id
+    /// ("birdnet-geomodel-v3"), because it is the string a user can type.
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Asset version.
+    pub version: String,
+    /// Organization/author.
+    pub vendor: String,
+    /// License type (SPDX identifier).
+    pub license: String,
+    /// Whether commercial use is allowed.
+    pub commercial_use: bool,
+    /// Whether derivatives must be shared under the same license.
+    pub share_alike: bool,
+    /// Number of species the model scores.
+    pub species_count: usize,
+    /// Combined download size of the model and labels files, in bytes.
+    ///
+    /// `None` when the registry declares no size for either file, rather than
+    /// reporting a misleading zero. Both files are required, so a size is only
+    /// meaningful when both are known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
 }
 
 /// A single available model from the registry.
@@ -853,6 +894,7 @@ mod tests {
                 license: "CC-BY-NC-SA-4.0".to_string(),
                 commercial_use: false,
             }],
+            range_filter: None,
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,15 +16,15 @@ pub use audacity::AudacityWriter;
 pub use csv::CsvWriter;
 pub use json::JsonResultWriter;
 pub use json_envelope::{
-    AvailableModelEntry, AvailableModelsPayload, BatchProgress, BsgMetadata, CancelReason,
-    CancelledPayload, ClipExtractionEntry, ClipExtractionPayload, ConfigPathPayload, ConfigPayload,
-    DetectionInfo, DetectionsPayload, DownloadProgress, ErrorPayload, ErrorSeverity, EventType,
-    ExecutionProviderInfo, FileCompletedPayload, FileErrorInfo, FileProgress, FileStartedPayload,
-    FileStatus, GeomodelInfo, JsonEnvelope, ModelCheckEntry, ModelCheckPayload, ModelDetails,
-    ModelEntry, ModelInfoPayload, ModelInstalledPayload, ModelListPayload, ModelRemovedPayload,
-    PipelineCompletedPayload, PipelineStartedPayload, PipelineStatus, ProgressPayload,
-    ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry,
-    SpeciesListPayload, VersionPayload,
+    AvailableModelEntry, AvailableModelsPayload, AvailableRangeFilterEntry, BatchProgress,
+    BsgMetadata, CancelReason, CancelledPayload, ClipExtractionEntry, ClipExtractionPayload,
+    ConfigPathPayload, ConfigPayload, DetectionInfo, DetectionsPayload, DownloadProgress,
+    ErrorPayload, ErrorSeverity, EventType, ExecutionProviderInfo, FileCompletedPayload,
+    FileErrorInfo, FileProgress, FileStartedPayload, FileStatus, GeomodelInfo, JsonEnvelope,
+    ModelCheckEntry, ModelCheckPayload, ModelDetails, ModelEntry, ModelInfoPayload,
+    ModelInstalledPayload, ModelListPayload, ModelRemovedPayload, PipelineCompletedPayload,
+    PipelineStartedPayload, PipelineStatus, ProgressPayload, ProviderInfo, ProvidersPayload,
+    RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry, SpeciesListPayload, VersionPayload,
 };
 pub use kaleidoscope::KaleidoscopeWriter;
 pub use parquet::{ParquetWriter, combine_parquet_files};

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -435,6 +435,45 @@ mod tests {
     }
 
     #[test]
+    fn test_verify_rejects_wrong_labels_with_a_correct_model() {
+        // The sibling test above pairs a wrong model with right labels, so the
+        // labels-side checksum block could be deleted outright and every verify
+        // test would still pass. A birda that downloaded the labels and never
+        // checked them would then ship with a green suite. This is the only
+        // test that pins the labels side, so the pair has to stay asymmetric.
+        let dir = tempfile::tempdir().unwrap();
+        let model = dir.path().join("m.onnx");
+        let labels = dir.path().join("l.txt");
+        std::fs::write(&model, b"right").unwrap();
+        std::fs::write(&labels, b"wrong").unwrap();
+        let paths = InstalledRangeFilter { model, labels };
+
+        assert!(
+            paths.verify(&test_asset()).is_err(),
+            "a correct model must not excuse corrupt labels"
+        );
+    }
+
+    #[test]
+    fn test_is_installed_requires_the_model_too() {
+        // The sibling test covers a present model with absent labels. Without
+        // this direction the model-existence check could be dropped and both
+        // would still pass.
+        let dir = tempfile::tempdir().unwrap();
+        let labels = dir.path().join("l.txt");
+        std::fs::write(&labels, b"present").unwrap();
+        let paths = InstalledRangeFilter {
+            model: dir.path().join("absent.onnx"),
+            labels,
+        };
+
+        assert!(
+            !paths.is_installed(),
+            "a missing model must count as not installed"
+        );
+    }
+
+    #[test]
     fn test_verify_skips_files_without_a_declared_checksum() {
         let dir = tempfile::tempdir().unwrap();
         let model = dir.path().join("m.onnx");

--- a/src/registry/license.rs
+++ b/src/registry/license.rs
@@ -24,15 +24,22 @@ pub struct LicensedAsset<'a> {
 
 /// Display license information and prompt for acceptance.
 ///
-/// When `interactive` is `false`, skips the user prompt and returns `Ok(true)`
-/// (auto-accept). This is used for non-TTY or structured output modes.
+/// `interactive` is checked first and dominates. When it is `false` this
+/// returns `Ok(true)` immediately, printing nothing at all: that is the non-TTY
+/// and structured-output path, where no human is present to read the terms and
+/// blocking on a prompt would hang a pipeline.
 ///
-/// When `assume_yes` is set the terms are still DISPLAYED and only the question
-/// is skipped. Suppressing the display as well would mean a user at a terminal
-/// accepts a licence they were never shown, which is worse than the non-TTY
-/// case where no human is present to read it. The classifiers are CC BY-NC-SA
-/// (non-commercial) and the geomodel is CC BY-SA (share-alike), so what is
-/// being agreed to differs by asset and is worth printing.
+/// `assume_yes` therefore only has an effect when `interactive` is `true`, and
+/// there it skips the QUESTION while still displaying the terms. Suppressing
+/// the display as well would mean a user at a terminal accepts a licence they
+/// were never shown, which is worse than the non-TTY case above because someone
+/// is there to read it. The classifiers are CC BY-NC-SA (non-commercial) and
+/// the geomodel is CC BY-SA (share-alike), so what is being agreed to differs
+/// by asset and is worth printing.
+///
+/// In short: `!interactive` shows nothing and accepts; `interactive &&
+/// assume_yes` shows the terms and accepts; `interactive && !assume_yes` shows
+/// the terms and asks.
 ///
 /// Returns `Ok(true)` if user accepts, `Ok(false)` if user declines.
 pub fn prompt_license_acceptance(

--- a/src/registry/license.rs
+++ b/src/registry/license.rs
@@ -52,8 +52,24 @@ pub fn prompt_license_acceptance(asset: LicensedAsset<'_>, interactive: bool) ->
 
 /// Display license summary with key restrictions.
 fn display_license_summary(license: &LicenseInfo, vendor: &str) {
-    println!("License: {}", license.r#type);
-    println!(
+    print!("{}", license_summary(license, vendor));
+}
+
+/// Render the license summary.
+///
+/// Split from the printing so it can be asserted on. The tests for this
+/// previously called the printing version and asserted nothing, which meant a
+/// summary that silently dropped the share-alike obligation would still have
+/// passed a green suite (#291).
+fn license_summary(license: &LicenseInfo, vendor: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let yes_no = |flag: bool| if flag { "Yes" } else { "No" };
+
+    let _ = writeln!(out, "License: {}", license.r#type);
+    let _ = writeln!(
+        out,
         "  Commercial use: {}",
         if license.commercial_use {
             "Allowed"
@@ -61,44 +77,45 @@ fn display_license_summary(license: &LicenseInfo, vendor: &str) {
             "Not allowed"
         }
     );
-    println!(
+    let _ = writeln!(
+        out,
         "  Attribution required: {}",
-        if license.attribution_required {
-            "Yes"
-        } else {
-            "No"
-        }
+        yes_no(license.attribution_required)
     );
-    println!(
+    let _ = writeln!(
+        out,
         "  Share-alike required: {}",
-        if license.share_alike { "Yes" } else { "No" }
+        yes_no(license.share_alike)
     );
-    println!();
-    println!("Full license text:");
-    println!("{}", license.url);
-    println!();
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Full license text:");
+    let _ = writeln!(out, "{}", license.url);
+    let _ = writeln!(out);
 
     // Display key obligations
     if !license.commercial_use || license.attribution_required || license.share_alike {
-        println!("By using this model, you agree to:");
+        let _ = writeln!(out, "By using this model, you agree to:");
 
         if !license.commercial_use {
-            println!("  • Use for non-commercial purposes only");
+            let _ = writeln!(out, "  • Use for non-commercial purposes only");
         }
 
         if license.attribution_required {
-            println!("  • Provide attribution to {vendor}");
+            let _ = writeln!(out, "  • Provide attribution to {vendor}");
         }
 
         if license.share_alike {
-            println!(
+            let _ = writeln!(
+                out,
                 "  • Share derivatives under the same license ({})",
                 license.r#type
             );
         }
 
-        println!();
+        let _ = writeln!(out);
     }
+
+    out
 }
 
 #[cfg(test)]
@@ -130,14 +147,30 @@ mod tests {
     }
 
     #[test]
-    fn test_display_license_summary_share_alike() {
+    fn test_license_summary_states_the_share_alike_obligation() {
         // The geomodel is CC BY-SA, unlike the CC BY-NC-SA classifier models,
-        // so the share-alike obligation must render.
-        display_license_summary(&geomodel_license(), "Cornell Lab of Ornithology");
+        // so the share-alike obligation must render. This previously called the
+        // printing function and asserted nothing, so a summary that dropped the
+        // obligation entirely would still have passed.
+        let summary = license_summary(&geomodel_license(), "Cornell Lab of Ornithology");
+
+        assert!(
+            summary.contains("Share-alike required: Yes"),
+            "must state the obligation, got:\n{summary}"
+        );
+        assert!(
+            summary.contains("Share derivatives under the same license (CC-BY-SA-4.0)"),
+            "must name the licence in the obligation list, got:\n{summary}"
+        );
+        assert!(
+            summary.contains("Commercial use: Allowed"),
+            "CC BY-SA permits commercial use, unlike the classifiers, and \
+             conflating the two would misinform a commercial user, got:\n{summary}"
+        );
     }
 
     #[test]
-    fn test_display_license_summary_noncommercial() {
+    fn test_license_summary_states_the_non_commercial_restriction() {
         let license = LicenseInfo {
             r#type: "CC-BY-NC-SA-4.0".into(),
             url: "https://creativecommons.org/licenses/by-nc-sa/4.0/".into(),
@@ -146,27 +179,24 @@ mod tests {
             share_alike: true,
         };
 
-        // This test verifies the function exists and can be called
-        // We can't easily capture stdout in unit tests, so we just verify compilation
-        display_license_summary(&license, "Test Vendor");
+        let summary = license_summary(&license, "Test Vendor");
+
+        assert!(
+            summary.contains("Commercial use: Not allowed"),
+            "got:\n{summary}"
+        );
+        assert!(
+            summary.contains("Use for non-commercial purposes only"),
+            "the restriction must appear in the obligation list, got:\n{summary}"
+        );
+        assert!(
+            summary.contains("Provide attribution to Test Vendor"),
+            "got:\n{summary}"
+        );
     }
 
     #[test]
-    fn test_display_license_summary_commercial() {
-        let license = LicenseInfo {
-            r#type: "Apache-2.0".into(),
-            url: "https://www.apache.org/licenses/LICENSE-2.0".into(),
-            commercial_use: true,
-            attribution_required: true,
-            share_alike: false,
-        };
-
-        // Verify function can be called
-        display_license_summary(&license, "Test Vendor");
-    }
-
-    #[test]
-    fn test_display_license_summary_permissive() {
+    fn test_license_summary_reports_a_permissive_licence_without_obligations() {
         let license = LicenseInfo {
             r#type: "MIT".into(),
             url: "https://opensource.org/licenses/MIT".into(),
@@ -175,7 +205,28 @@ mod tests {
             share_alike: false,
         };
 
-        // Verify function can be called
-        display_license_summary(&license, "Test Vendor");
+        let summary = license_summary(&license, "Test Vendor");
+
+        assert!(
+            summary.contains("Commercial use: Allowed"),
+            "got:\n{summary}"
+        );
+        assert!(
+            !summary.contains("By using this model, you agree to:"),
+            "a licence with no obligations must not print an empty obligation \
+             list, got:\n{summary}"
+        );
+    }
+
+    #[test]
+    fn test_license_summary_always_includes_the_full_text_url() {
+        // The summary is a summary; the URL is the only route to the actual
+        // terms, so it must survive regardless of which flags are set.
+        let summary = license_summary(&geomodel_license(), "Cornell Lab of Ornithology");
+
+        assert!(
+            summary.contains("https://creativecommons.org/licenses/by-sa/4.0/"),
+            "got:\n{summary}"
+        );
     }
 }

--- a/src/registry/license.rs
+++ b/src/registry/license.rs
@@ -27,8 +27,19 @@ pub struct LicensedAsset<'a> {
 /// When `interactive` is `false`, skips the user prompt and returns `Ok(true)`
 /// (auto-accept). This is used for non-TTY or structured output modes.
 ///
+/// When `assume_yes` is set the terms are still DISPLAYED and only the question
+/// is skipped. Suppressing the display as well would mean a user at a terminal
+/// accepts a licence they were never shown, which is worse than the non-TTY
+/// case where no human is present to read it. The classifiers are CC BY-NC-SA
+/// (non-commercial) and the geomodel is CC BY-SA (share-alike), so what is
+/// being agreed to differs by asset and is worth printing.
+///
 /// Returns `Ok(true)` if user accepts, `Ok(false)` if user declines.
-pub fn prompt_license_acceptance(asset: LicensedAsset<'_>, interactive: bool) -> Result<bool> {
+pub fn prompt_license_acceptance(
+    asset: LicensedAsset<'_>,
+    interactive: bool,
+    assume_yes: bool,
+) -> Result<bool> {
     if !interactive {
         return Ok(true);
     }
@@ -39,6 +50,11 @@ pub fn prompt_license_acceptance(asset: LicensedAsset<'_>, interactive: bool) ->
     println!();
 
     display_license_summary(asset.license, asset.vendor);
+
+    if assume_yes {
+        println!("Accepted via --yes.");
+        return Ok(true);
+    }
 
     println!();
     print!("Type 'accept' to continue, or anything else to cancel: ");
@@ -143,7 +159,7 @@ mod tests {
             license: &license,
         };
 
-        assert!(prompt_license_acceptance(asset, false).unwrap());
+        assert!(prompt_license_acceptance(asset, false, false).unwrap());
     }
 
     #[test]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -47,7 +47,7 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         let payload = AvailableModelsPayload {
             result_type: ResultType::AvailableModels,
             models,
-            range_filter: registry.range_filter.as_ref().map(available_range_filter),
+            available_range_filter: registry.range_filter.as_ref().map(available_range_filter),
         };
         emit_json_result(&payload);
         return;
@@ -67,12 +67,7 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         println!("    {} - {}", model.name, model.description);
         println!("    Vendor: {}", model.vendor);
 
-        let license_note = if model.license.commercial_use {
-            &model.license.r#type
-        } else {
-            &format!("{} (non-commercial)", model.license.r#type)
-        };
-        println!("    License: {license_note}");
+        println!("    License: {}", license_line(&model.license));
         println!();
     }
 
@@ -88,17 +83,36 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         // used above.
         println!("    {}", asset.name);
         println!("    Vendor: {}", asset.vendor);
-        let share_alike = if asset.license.share_alike {
-            " (share-alike)"
-        } else {
-            ""
-        };
-        println!("    License: {}{share_alike}", asset.license.r#type);
+        println!("    License: {}", license_line(&asset.license));
         println!("    Covers {} species", asset.species_count);
         println!();
     }
 
     println!("Run 'birda models info <id>' for details.");
+}
+
+/// Render a licence identifier with the restrictions that apply to it.
+///
+/// One renderer for classifiers and the range filter alike. Listing them
+/// separately taught a falsehood: the classifier loop showed only
+/// `(non-commercial)` and the range filter showed only `(share-alike)`, so
+/// `birdnet-v24` and `bsg-fi-v44` listed without a share-alike note even though
+/// both carry that obligation. Whichever restrictions apply are now named on
+/// every entry.
+fn license_line(license: &LicenseInfo) -> String {
+    let mut notes = Vec::new();
+    if !license.commercial_use {
+        notes.push("non-commercial");
+    }
+    if license.share_alike {
+        notes.push("share-alike");
+    }
+
+    if notes.is_empty() {
+        license.r#type.clone()
+    } else {
+        format!("{} ({})", license.r#type, notes.join(", "))
+    }
 }
 
 /// Project the shared range filter asset into its structured-output shape.
@@ -131,8 +145,12 @@ fn total_download_size(asset: &RangeFilterAsset) -> Option<u64> {
 /// Render the shared range filter asset for `birda models info geomodel`.
 ///
 /// Separate from [`show_info`] because the geomodel is not a [`ModelEntry`]:
-/// it has no per-language labels and no model type, and it carries a species
-/// count and a share-alike obligation that no classifier does.
+/// it has no per-language labels, no model type and no description, and it
+/// carries a species count and a download size that no classifier entry does.
+///
+/// Note that share-alike is NOT what distinguishes it: `birdnet-v24`
+/// (CC BY-NC-SA) and `bsg-fi-v44` (BSG-NC) are share-alike too. What differs is
+/// commercial use, which the geomodel permits and those two do not.
 pub fn show_range_filter_info(asset: &RangeFilterAsset) {
     println!("Range filter: {}", asset.name);
     println!("ID: {GEOMODEL_INSTALL_ID}");
@@ -255,6 +273,49 @@ pub fn show_info(registry: &Registry, id: &str) -> Result<()> {
     println!("To install: birda models install {}", model.id);
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
+mod tests {
+    use super::*;
+
+    fn license(commercial_use: bool, share_alike: bool) -> LicenseInfo {
+        LicenseInfo {
+            r#type: "TEST-1.0".into(),
+            url: "https://example.com/licence".into(),
+            commercial_use,
+            attribution_required: true,
+            share_alike,
+        }
+    }
+
+    #[test]
+    fn test_license_line_names_every_restriction_that_applies() {
+        // The defect this replaced: the classifier loop showed only
+        // "(non-commercial)" and the range filter only "(share-alike)", so
+        // birdnet-v24 and bsg-fi-v44 listed with no share-alike note despite
+        // carrying that obligation. Both restrictions must show together.
+        let line = license_line(&license(false, true));
+
+        assert!(line.contains("non-commercial"), "got: {line}");
+        assert!(line.contains("share-alike"), "got: {line}");
+    }
+
+    #[test]
+    fn test_license_line_names_share_alike_on_a_commercial_licence() {
+        // The geomodel's shape: CC BY-SA permits commercial use but still binds
+        // share-alike, so the note must not be suppressed by commercial_use.
+        let line = license_line(&license(true, true));
+
+        assert!(!line.contains("non-commercial"), "got: {line}");
+        assert!(line.contains("share-alike"), "got: {line}");
+    }
+
+    #[test]
+    fn test_license_line_adds_nothing_for_an_unrestricted_licence() {
+        assert_eq!(license_line(&license(true, false)), "TEST-1.0");
+    }
 }
 
 /// Show available languages for a model.

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -47,6 +47,7 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         let payload = AvailableModelsPayload {
             result_type: ResultType::AvailableModels,
             models,
+            range_filter: registry.range_filter.as_ref().map(available_range_filter),
         };
         emit_json_result(&payload);
         return;
@@ -75,7 +76,117 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         println!();
     }
 
+    // The geomodel lives in `registry.range_filter`, not `registry.models`, so
+    // every loop over `models` skips it. Listing it here is what makes the
+    // asset every error message tells users to install actually discoverable.
+    if let Some(asset) = registry.range_filter.as_ref() {
+        println!("Range filter (shared by all classifiers):");
+        println!();
+        println!("  {GEOMODEL_INSTALL_ID}");
+        // RangeFilterAsset has no `description` field, unlike ModelEntry, so
+        // this shows the name alone rather than the "name - description" pair
+        // used above.
+        println!("    {}", asset.name);
+        println!("    Vendor: {}", asset.vendor);
+        let share_alike = if asset.license.share_alike {
+            " (share-alike)"
+        } else {
+            ""
+        };
+        println!("    License: {}{share_alike}", asset.license.r#type);
+        println!("    Covers {} species", asset.species_count);
+        println!();
+    }
+
     println!("Run 'birda models info <id>' for details.");
+}
+
+/// Project the shared range filter asset into its structured-output shape.
+fn available_range_filter(asset: &RangeFilterAsset) -> crate::output::AvailableRangeFilterEntry {
+    crate::output::AvailableRangeFilterEntry {
+        // The install handle, not `asset.id`: this is the string a user types.
+        id: GEOMODEL_INSTALL_ID.to_string(),
+        name: asset.name.clone(),
+        version: asset.version.clone(),
+        vendor: asset.vendor.clone(),
+        license: asset.license.r#type.clone(),
+        commercial_use: asset.license.commercial_use,
+        share_alike: asset.license.share_alike,
+        species_count: asset.species_count,
+        size_bytes: total_download_size(asset),
+    }
+}
+
+/// Combined download size of the geomodel's two files.
+///
+/// Both files are required, so the number a user weighing the download cares
+/// about is the total. Returns `None` unless both sizes are declared, rather
+/// than reporting a half-total that reads as the whole.
+fn total_download_size(asset: &RangeFilterAsset) -> Option<u64> {
+    let model = asset.model.size_bytes?;
+    let labels = asset.labels.size_bytes?;
+    model.checked_add(labels)
+}
+
+/// Render the shared range filter asset for `birda models info geomodel`.
+///
+/// Separate from [`show_info`] because the geomodel is not a [`ModelEntry`]:
+/// it has no per-language labels and no model type, and it carries a species
+/// count and a share-alike obligation that no classifier does.
+pub fn show_range_filter_info(asset: &RangeFilterAsset) {
+    println!("Range filter: {}", asset.name);
+    println!("ID: {GEOMODEL_INSTALL_ID}");
+    println!("Version: {}", asset.version);
+    println!("Vendor: {}", asset.vendor);
+    println!();
+
+    println!("Description:");
+    println!(
+        "  Scores {} species by location and time of year. Shared by every",
+        asset.species_count
+    );
+    println!("  classifier; it is not selectable with -m.");
+    println!();
+
+    println!("License:");
+    println!("  Type: {}", asset.license.r#type);
+    println!("  URL: {}", asset.license.url);
+    println!(
+        "  Commercial use: {}",
+        if asset.license.commercial_use {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    println!(
+        "  Attribution required: {}",
+        if asset.license.attribution_required {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    println!(
+        "  Share-alike required: {}",
+        if asset.license.share_alike {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    println!();
+
+    println!("Files:");
+    println!("  Model: {}", asset.model.url);
+    println!("  Labels: {}", asset.labels.url);
+    println!(
+        "  Download size: {}",
+        crate::config::geomodel::human_size(total_download_size(asset))
+    );
+    println!();
+
+    println!("To install: birda models install {GEOMODEL_INSTALL_ID}");
 }
 
 /// Show detailed information about a specific model.

--- a/tests/geomodel_discoverability.rs
+++ b/tests/geomodel_discoverability.rs
@@ -1,0 +1,185 @@
+//! Integration tests for geomodel discoverability (#287).
+//!
+//! These drive the real binary rather than calling `registry::show_info`
+//! directly, and that is the point. `models info <id>` dispatches on
+//! `registry::find_model`, which only searches `registry.models`; the geomodel
+//! lives in `registry.range_filter`. A unit test calling `show_info` with the
+//! geomodel id would therefore pass while `birda models info geomodel` still
+//! failed, because the dispatch never reaches `show_info` for that id.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+
+/// Registry commands are local, but `load_registry` can rewrite the cached
+/// registry, so keep them bounded.
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run birda against an isolated HOME.
+///
+/// `load_registry` writes an updated registry cache into the user's data
+/// directory. Without this the suite would mutate the developer's real config.
+fn run(args: &[&str]) -> std::process::Output {
+    let home = tempfile::tempdir().expect("create temp home");
+
+    let mut cmd = cargo_bin_cmd!("birda");
+    cmd.env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join("config"))
+        .env("XDG_DATA_HOME", home.path().join("data"))
+        .timeout(COMMAND_TIMEOUT);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    cmd.output().expect("birda should run")
+}
+
+fn stdout_of(args: &[&str]) -> String {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "`birda {}` failed with {:?}\nstderr: {}",
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn test_models_info_geomodel_succeeds() {
+    // Before the fix this exited non-zero with "model 'geomodel' not found",
+    // despite every error message and doc page telling users to install it.
+    let stdout = stdout_of(&["models", "info", "geomodel"]);
+
+    assert!(
+        stdout.contains("BirdNET Geomodel"),
+        "should name the asset, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_models_info_geomodel_shows_the_licence_terms() {
+    // This is the "what am I about to download?" step, and the only place the
+    // CC BY-SA terms surface before the user commits to the download. The
+    // geomodel's share-alike obligation differs from the classifiers'
+    // CC BY-NC-SA, so it has to be visible here specifically.
+    let stdout = stdout_of(&["models", "info", "geomodel"]);
+
+    assert!(
+        stdout.contains("CC-BY-SA-4.0"),
+        "should show the licence id, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Share-alike required: Yes"),
+        "should spell out the share-alike obligation, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_models_info_geomodel_shows_coverage_and_size() {
+    let stdout = stdout_of(&["models", "info", "geomodel"]);
+
+    assert!(
+        stdout.contains("12012"),
+        "should report the species count, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Download size"),
+        "should report the download size, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_models_info_geomodel_languages_flag_is_handled() {
+    // `--languages` routes to `show_languages`, which is a second consumer
+    // behind the same dispatch. The geomodel has no language variants, so this
+    // must explain that rather than fail or print an empty list.
+    let stdout = stdout_of(&["models", "info", "geomodel", "--languages"]);
+
+    assert!(
+        stdout.contains("no label language variants"),
+        "should explain the absence of language variants, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_models_info_still_rejects_an_unknown_id() {
+    // The geomodel branch must not swallow genuinely unknown ids.
+    let output = run(&["models", "info", "definitely-not-a-model"]);
+
+    assert!(
+        !output.status.success(),
+        "an unknown id must still be an error"
+    );
+}
+
+#[test]
+fn test_models_info_uses_one_canonical_geomodel_handle() {
+    // `models install` accepts only the install handle. If `models info` also
+    // took the registry's internal asset id, `birda models info
+    // birdnet-geomodel-v3` would succeed and then tell the user to run an
+    // install command that rejects that id. One handle, or the two commands
+    // disagree.
+    let output = run(&["models", "info", "birdnet-geomodel-v3"]);
+
+    assert!(
+        !output.status.success(),
+        "the registry asset id must not be a second accepted handle"
+    );
+}
+
+#[test]
+fn test_list_available_mentions_the_range_filter() {
+    let stdout = stdout_of(&["models", "list-available"]);
+
+    assert!(
+        stdout.contains("Range filter"),
+        "should carry a range filter section, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("geomodel"),
+        "should name the install id, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_list_available_json_exposes_range_filter_as_a_sibling_field() {
+    let stdout = stdout_of(&["--output-mode", "json", "models", "list-available"]);
+    let value: Value = serde_json::from_str(&stdout).expect("valid JSON envelope");
+    let payload = &value["payload"];
+
+    let range_filter = &payload["range_filter"];
+    assert!(
+        !range_filter.is_null(),
+        "range_filter must be present, got: {payload}"
+    );
+
+    // The install handle, not the registry asset id: this is what a user types.
+    assert_eq!(range_filter["id"], "geomodel");
+    assert_eq!(range_filter["share_alike"], true);
+    assert_eq!(range_filter["species_count"], 12012);
+}
+
+#[test]
+fn test_list_available_json_keeps_models_classifier_only() {
+    // The additive claim. The geomodel is not selectable with `-m`, so a
+    // consumer building a model picker from `models` must not see it; if it
+    // ever leaks in, that picker offers an entry that fails on use.
+    let stdout = stdout_of(&["--output-mode", "json", "models", "list-available"]);
+    let value: Value = serde_json::from_str(&stdout).expect("valid JSON envelope");
+
+    let models = value["payload"]["models"]
+        .as_array()
+        .expect("models is an array");
+
+    assert!(
+        !models
+            .iter()
+            .any(|m| m["id"] == "geomodel" || m["id"] == "birdnet-geomodel-v3"),
+        "the geomodel must not appear in `models`, got: {models:?}"
+    );
+}

--- a/tests/geomodel_discoverability.rs
+++ b/tests/geomodel_discoverability.rs
@@ -26,11 +26,17 @@ const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 /// directory. Without this the suite would mutate the developer's real config.
 fn run(args: &[&str]) -> std::process::Output {
     let home = tempfile::tempdir().expect("create temp home");
+    run_in(home.path(), args)
+}
 
+/// Run birda against a caller-supplied HOME, so several invocations can share
+/// one config directory. Needed to seed a registry file and then observe how a
+/// later command reacts to it.
+fn run_in(home: &std::path::Path, args: &[&str]) -> std::process::Output {
     let mut cmd = cargo_bin_cmd!("birda");
-    cmd.env("HOME", home.path())
-        .env("XDG_CONFIG_HOME", home.path().join("config"))
-        .env("XDG_DATA_HOME", home.path().join("data"))
+    cmd.env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("XDG_DATA_HOME", home.join("data"))
         // `--output-mode` reads BIRDA_OUTPUT_MODE. A developer with that
         // exported turns every human-output assertion below into a failure, so
         // the isolation has to cover the environment, not just the filesystem.
@@ -130,6 +136,7 @@ fn test_models_info_geomodel_languages_flag_is_handled() {
 fn assert_rejected_naming(args: &[&str], id: &str) {
     let output = run(args);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert_eq!(
         output.status.code(),
@@ -141,9 +148,14 @@ fn assert_rejected_naming(args: &[&str], id: &str) {
         stderr.contains(id),
         "the error must name the rejected id '{id}', got: {stderr}"
     );
+    // Against STDOUT, not stderr. `show_range_filter_info` prints with
+    // `println!` while errors go to stderr via `eprintln!`, so asserting this
+    // on stderr checked a stream the string can never reach: it passed for an
+    // unrelated reason and would have kept passing if the range filter really
+    // had been rendered for a rejected id.
     assert!(
-        !stderr.contains("Range filter:"),
-        "must not have rendered the range filter for a rejected id, got: {stderr}"
+        !stdout.contains("Range filter:"),
+        "must not have rendered the range filter for a rejected id, got: {stdout}"
     );
 }
 
@@ -190,9 +202,8 @@ fn test_list_available_json_exposes_range_filter_as_a_sibling_field() {
     let payload = &value["payload"];
 
     // Named `available_range_filter`, not `range_filter`: `DetectionsPayload`
-    // already uses `range_filter` for a different shape, and one field name
-    // over two disjoint types collides for a consumer that derives one type per
-    // name.
+    // already uses `range_filter` for a per-run coverage shape, and distinct
+    // names keep the two readable side by side.
     let range_filter = &payload["available_range_filter"];
     assert!(
         !range_filter.is_null(),
@@ -234,5 +245,60 @@ fn test_list_available_json_keeps_models_classifier_only() {
             .iter()
             .any(|m| m["id"] == "geomodel" || m["id"] == "birdnet-geomodel-v3"),
         "the geomodel must not appear in `models`, got: {models:?}"
+    );
+}
+
+#[test]
+fn test_models_info_geomodel_on_a_registry_without_the_asset() {
+    // The case fix 4 exists for, and the only one that can distinguish it.
+    //
+    // The dispatch used to read `if let Some(asset) = registry.range_filter
+    // && id == GEOMODEL_INSTALL_ID`, testing the asset BEFORE the id. With no
+    // asset it fell through to `find_model` (never matches) and then
+    // `config::get_model`, producing "model 'geomodel' not found in
+    // configuration" -- the exact message the branch was written to prevent.
+    // `models install geomodel` already ordered it the other way and reported
+    // the accurate `RangeFilterAssetMissing`, so the two commands disagreed on
+    // one registry state.
+    //
+    // Every other test here passes with the fix reverted, because for any id
+    // that is not the install handle both orderings take the same path. This
+    // one needs a registry that has no `range_filter` at all.
+    let home = tempfile::tempdir().expect("create temp home");
+
+    // Learn where this platform puts the config, rather than assuming a layout.
+    let config_path = String::from_utf8_lossy(&run_in(home.path(), &["config", "path"]).stdout)
+        .trim()
+        .to_string();
+    let config_dir = std::path::Path::new(&config_path)
+        .parent()
+        .expect("config path has a parent")
+        .to_path_buf();
+
+    // `load_registry` keeps the cached copy whenever its `registry_version` is
+    // at least the bundled one, so a high version pins this stripped registry.
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(
+        config_dir.join("registry.json"),
+        r#"{"schema_version":"1.0","registry_version":9999,"models":[]}"#,
+    )
+    .expect("seed a registry with no range_filter");
+
+    let output = run_in(home.path(), &["models", "info", "geomodel"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "a registry with no range filter cannot describe the geomodel"
+    );
+    assert!(
+        !stderr.contains("not found in configuration"),
+        "must not claim the id is an unknown configured model; that is the \
+         misleading fallback this branch exists to avoid. stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("range filter"),
+        "must report the missing range filter asset, matching what \
+         `models install geomodel` reports for the same state. stderr: {stderr}"
     );
 }

--- a/tests/geomodel_discoverability.rs
+++ b/tests/geomodel_discoverability.rs
@@ -1,11 +1,13 @@
 //! Integration tests for geomodel discoverability (#287).
 //!
-//! These drive the real binary rather than calling `registry::show_info`
-//! directly, and that is the point. `models info <id>` dispatches on
+//! These drive the real binary rather than calling into `registry` directly,
+//! and that is the point. `models info <id>` dispatches on
 //! `registry::find_model`, which only searches `registry.models`; the geomodel
-//! lives in `registry.range_filter`. A unit test calling `show_info` with the
-//! geomodel id would therefore pass while `birda models info geomodel` still
-//! failed, because the dispatch never reaches `show_info` for that id.
+//! lives in `registry.range_filter`. A unit test calling
+//! `show_range_filter_info(asset)` would pass while `birda models info
+//! geomodel` still failed, because that function takes the asset directly and
+//! the dispatch never reaches it for this id. Only driving the binary exercises
+//! the dispatch, which is where the defect lived.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -29,6 +31,10 @@ fn run(args: &[&str]) -> std::process::Output {
     cmd.env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join("config"))
         .env("XDG_DATA_HOME", home.path().join("data"))
+        // `--output-mode` reads BIRDA_OUTPUT_MODE. A developer with that
+        // exported turns every human-output assertion below into a failure, so
+        // the isolation has to cover the environment, not just the filesystem.
+        .env_remove("BIRDA_OUTPUT_MODE")
         .timeout(COMMAND_TIMEOUT);
     for arg in args {
         cmd.arg(arg);
@@ -91,6 +97,14 @@ fn test_models_info_geomodel_shows_coverage_and_size() {
         stdout.contains("Download size"),
         "should report the download size, got: {stdout}"
     );
+    // The label alone proves nothing: `total_download_size` returns None when
+    // either file lacks a declared size, and `human_size(None)` renders
+    // "unknown size" under that same label. Mutation testing confirmed a
+    // always-None mutant survived the label-only assertion.
+    assert!(
+        !stdout.contains("unknown size"),
+        "the size must actually resolve, not fall back to 'unknown size': {stdout}"
+    );
 }
 
 #[test]
@@ -106,14 +120,39 @@ fn test_models_info_geomodel_languages_flag_is_handled() {
     );
 }
 
+/// Assert a command was rejected BY THE APPLICATION, naming the offending id.
+///
+/// `!status.success()` alone is not a verdict: it is equally true of a clap
+/// parse error (exit 2), a panic (exit 101) and a timeout kill (no code at
+/// all). Mutation testing confirmed it -- making the fallback panic left both
+/// negative tests below green. Pinning exit code 1 plus the id in stderr is
+/// what makes them observe the rejection they claim to.
+fn assert_rejected_naming(args: &[&str], id: &str) {
+    let output = run(args);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected a clean application error (exit 1), not a parse error, panic \
+         or kill. stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(id),
+        "the error must name the rejected id '{id}', got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Range filter:"),
+        "must not have rendered the range filter for a rejected id, got: {stderr}"
+    );
+}
+
 #[test]
 fn test_models_info_still_rejects_an_unknown_id() {
     // The geomodel branch must not swallow genuinely unknown ids.
-    let output = run(&["models", "info", "definitely-not-a-model"]);
-
-    assert!(
-        !output.status.success(),
-        "an unknown id must still be an error"
+    assert_rejected_naming(
+        &["models", "info", "definitely-not-a-model"],
+        "definitely-not-a-model",
     );
 }
 
@@ -124,11 +163,9 @@ fn test_models_info_uses_one_canonical_geomodel_handle() {
     // birdnet-geomodel-v3` would succeed and then tell the user to run an
     // install command that rejects that id. One handle, or the two commands
     // disagree.
-    let output = run(&["models", "info", "birdnet-geomodel-v3"]);
-
-    assert!(
-        !output.status.success(),
-        "the registry asset id must not be a second accepted handle"
+    assert_rejected_naming(
+        &["models", "info", "birdnet-geomodel-v3"],
+        "birdnet-geomodel-v3",
     );
 }
 
@@ -152,16 +189,24 @@ fn test_list_available_json_exposes_range_filter_as_a_sibling_field() {
     let value: Value = serde_json::from_str(&stdout).expect("valid JSON envelope");
     let payload = &value["payload"];
 
-    let range_filter = &payload["range_filter"];
+    // Named `available_range_filter`, not `range_filter`: `DetectionsPayload`
+    // already uses `range_filter` for a different shape, and one field name
+    // over two disjoint types collides for a consumer that derives one type per
+    // name.
+    let range_filter = &payload["available_range_filter"];
     assert!(
         !range_filter.is_null(),
-        "range_filter must be present, got: {payload}"
+        "available_range_filter must be present, got: {payload}"
     );
 
     // The install handle, not the registry asset id: this is what a user types.
     assert_eq!(range_filter["id"], "geomodel");
     assert_eq!(range_filter["share_alike"], true);
     assert_eq!(range_filter["species_count"], 12012);
+    assert!(
+        range_filter["size_bytes"].as_u64().is_some_and(|n| n > 0),
+        "size_bytes must resolve to a real total, got: {range_filter}"
+    );
 }
 
 #[test]
@@ -175,6 +220,14 @@ fn test_list_available_json_keeps_models_classifier_only() {
     let models = value["payload"]["models"]
         .as_array()
         .expect("models is an array");
+
+    // Prove the precondition before asserting an absence. Mutation testing
+    // confirmed the `any()` check below passes vacuously on an empty array.
+    assert!(
+        !models.is_empty(),
+        "the classifier list must be populated for this absence check to mean \
+         anything, got: {models:?}"
+    );
 
     assert!(
         !models


### PR DESCRIPTION
Closes #286. Closes #287.

The geomodel landed in 1.10.0 as a shared asset, `Registry.range_filter`, a sibling of `Registry.models` rather than an entry in it. That is the right shape, since one geomodel serves every classifier, but every code path that enumerates `registry.models` silently skips it. Three reported defects turn out to be that one omission wearing different hats.

| | Before | After |
| --- | --- | --- |
| `birda species --yes` | clap error | works |
| `birda --yes species` | parsed, flag discarded | works, same field |
| `birda models info geomodel` | "model not found" | full licence terms, 12,012 species, size |
| `birda config set defaults.geomodel` | unknown key | works |
| `birda config set defaults.latitude -33.9` | "unexpected argument -3" | works |
| `range_threshold = nan` in config.toml | drops every species silently | rejected |

**#286.** `birda species` built a throwaway `AnalyzeArgs` to call `resolve_geomodel`, setting `lat`/`lon`, which the resolver never reads, and leaving unset the three fields it does. That compiled because the parameter type was far wider than the function needed. `resolve_geomodel` now takes a `GeomodelRequest` holding exactly the three values it consumes, and that type deliberately does not derive `Default`, because `..Default::default()` is what let the under-specified call typecheck.

The three flags become `global` rather than being duplicated onto `Species`. Duplicating would have moved the bug: root and subcommand flags populate separate fields, so `birda --yes species` would have gone on discarding it. Measured against clap directly before choosing.

**#287, enumeration only.** `models info geomodel` failed with the id every error message tells users to run. The fix belongs at the `ModelsAction::Info` dispatch, not inside `show_info`: dispatch branches on `find_model`, which searches `models` only, so a fix inside `show_info` would have been dead code for this id. `models list-available` now lists the asset, and the structured output carries it as an `available_range_filter` sibling field rather than inside `models`, since it is not selectable with `-m` and a consumer building a model picker must not be offered an entry that fails on use. `config set` learns `defaults.geomodel`, `defaults.geomodel_labels` and `defaults.range_unmatched`.

**#288 item 1.** `--range-threshold` goes through `parse_confidence`, but the config-file path had no equivalent, so a negative value made range filtering a silent no-op while the JSON envelope still reported it active, and NaN dropped every mapped species. Validated both where configs are written and where the value is used.

**Folded in, found while testing the above:** `birda config set` could not accept any value beginning with a minus, so every southern and western hemisphere coordinate was out of reach of the command. Two test-quality fixes from #291: four licence tests that asserted nothing, and the missing right-model/wrong-labels case for `InstalledRangeFilter::verify`, whose absence meant the labels checksum block could be deleted with the suite still green.

## Review

Twelve independent reviewers plus a Gemini cross-check ran over the first three commits. They found seven hazards, all in code this PR wrote, and the fourth commit closes them. The most serious: the threshold guard was on the config-write path only, so the hand-edited case the bug report actually describes was still live; and `--yes` answered *no* to "Set as default model? [Y/n]" while answering *yes* to the licence prompt, because folding it into `interactive` collapsed three states into two. Also fixed: `--yes` suppressed the licence *text* rather than only the question, implementation rationale was being rendered into `--help` on every subcommand, and a doc comment plus the `list-available` output both claimed the geomodel is the only share-alike asset when two of three classifiers are.

Two mutation checks were run rather than trusting green tests: disabling the `models info` dispatch fails exactly the four tests that guard it, and deleting the labels checksum block fails only the new test, with all six pre-existing ones still green.

**Gate status: round 2 did not complete.** The fix wave was reviewed by the author and verified against the built binary and the suite, but the independent round-2 pass was still running when this was pushed. Treat the fourth commit as the least-reviewed code here.

Verified: 434 tests pass, up from a 403 baseline. `cargo clippy -- -D warnings` clean, `--all-targets` 302 against a 303 baseline.

## Deferred, with issues

#294 licence disclosure asymmetry, #295 config is never validated on load (the general form of the threshold defect, affecting six other keys), #296 remaining geomodel surface gaps, #297 batched low-severity findings. Doc and GUI drift appended to #290.