### PR TITLE
fix: validate the configuration file on load, not only on 'config set'

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,24 @@ device = "auto"  # auto, gpu, or cpu
 combined_prefix = "BirdNET"
 ```
 
+### Configuration Validation
+
+The configuration file is validated when it is loaded, so a bad value is reported once, up front, instead of turning into odd behaviour later in a run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
+
+```
+$ birda analyze recording.wav
+error: invalid latitude: 200 (must be -90.0 to 90.0)
+```
+
+The `config` commands are deliberately exempt, because they are how you fix the problem. `birda config show` still prints a config that fails validation, so you can see which value is wrong, and `birda config set` still repairs it:
+
+```
+$ birda config show                          # works, shows the bad value
+$ birda config set defaults.latitude 60.17   # repairs it
+```
+
+Writing is validated too. `birda config set` and the `birda models` commands all refuse to save a configuration that would not load, and they refuse before touching the file, so a rejected write leaves the existing configuration intact.
+
 ### Environment Variables
 
 All options can be set via environment variables:

--- a/README.md
+++ b/README.md
@@ -364,21 +364,23 @@ combined_prefix = "BirdNET"
 
 ### Configuration Validation
 
-The configuration file is validated when it is loaded, so a bad value is reported once, up front, instead of turning into odd behaviour later in a run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
+An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
 
 ```
-$ birda analyze recording.wav
+$ birda recording.wav
 error: invalid latitude: 200 (must be -90.0 to 90.0)
 ```
 
-The `config` commands are deliberately exempt, because they are how you fix the problem. `birda config show` still prints a config that fails validation, so you can see which value is wrong, and `birda config set` still repairs it:
+Only analysis is gated, because it is the only command that turns the whole of `[defaults]` into a result. Everything else keeps working, which matters because those are the commands you need in order to fix the file. `config show` prints a config that fails validation so you can see which value is wrong, `config set` rewrites it, and `models install` still works when `defaults.model` names a model you no longer have.
 
 ```
 $ birda config show                          # works, shows the bad value
-$ birda config set defaults.latitude 60.17   # repairs it
+$ birda config set defaults.latitude 60.17   # rewrites it
 ```
 
-Writing is validated too. `birda config set` and the `birda models` commands all refuse to save a configuration that would not load, and they refuse before touching the file, so a rejected write leaves the existing configuration intact.
+One limitation worth knowing: `config set` validates the whole file before saving, so it cannot repair a config with two independent bad values one key at a time. Each write is rejected by the other fault. Fix those by editing `config.toml` directly.
+
+Writing is validated too. `config init`, `config set` and the `models` commands all refuse to save a configuration that would not load, and they refuse before touching the file, so a rejected write leaves the existing configuration intact.
 
 ### Environment Variables
 
@@ -424,13 +426,13 @@ Apache Parquet columnar format for efficient data storage and analysis. Provides
 
 ```bash
 # Single format
-birda analyze -f parquet recording.wav
+birda -f parquet recording.wav
 
 # Multiple formats
-birda analyze -f csv,parquet recording.wav
+birda -f csv,parquet recording.wav
 
 # With metadata columns
-birda analyze -f parquet --lat 45.0 --lon -73.0 --week 24 recording.wav
+birda -f parquet --lat 45.0 --lon -73.0 --week 24 recording.wav
 ```
 
 **Column Schema:**
@@ -552,11 +554,11 @@ Bat echolocation calls are ultrasonic (20-120 kHz). BattyBirdNET exploits a "slo
 
 ```bash
 # Analyze bat recordings with the Bavaria classifier
-birda analyze -m birdnet-v24-embeddings --bat bavaria bat_recording.wav
+birda -m birdnet-v24-embeddings --bat bavaria bat_recording.wav
 
 # Other available regions
-birda analyze -m birdnet-v24-embeddings --bat uk bat_recording.wav
-birda analyze -m birdnet-v24-embeddings --bat eu bat_recording.wav
+birda -m birdnet-v24-embeddings --bat uk bat_recording.wav
+birda -m birdnet-v24-embeddings --bat eu bat_recording.wav
 ```
 
 ### Available Regions

--- a/README.md
+++ b/README.md
@@ -366,16 +366,16 @@ combined_prefix = "BirdNET"
 
 An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
 
-```
+```text
 $ birda recording.wav
 error: invalid latitude: 200 (must be -90.0 to 90.0)
 ```
 
 Only analysis is gated, because it is the only command that turns the whole of `[defaults]` into a result. Everything else keeps working, which matters because those are the commands you need in order to fix the file. `config show` prints a config that fails validation so you can see which value is wrong, `config set` rewrites it, and `models install` still works when `defaults.model` names a model you no longer have.
 
-```
-$ birda config show                          # works, shows the bad value
-$ birda config set defaults.latitude 60.17   # rewrites it
+```bash
+birda config show                          # works, shows the bad value
+birda config set defaults.latitude 60.17   # rewrites it
 ```
 
 One limitation worth knowing: `config set` validates the whole file before saving, so it cannot repair a config with two independent bad values one key at a time. Each write is rejected by the other fault. Fix those by editing `config.toml` directly.

--- a/docs/clip-extraction.md
+++ b/docs/clip-extraction.md
@@ -143,7 +143,7 @@ birda clip results.csv -a /recordings/2024-06-15_dawn.flac
 
 ```bash
 # Analyze recordings, then extract best clips
-birda analyze recordings/ -o detections/
+birda recordings/ -o detections/
 birda clip detections/*.csv -c 0.85 -o best_clips/
 ```
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -59,7 +59,18 @@ pub fn load_default_config() -> Result<Config> {
 }
 
 /// Save configuration to a TOML file.
+///
+/// The configuration is validated first, so no writer can persist a value that
+/// `config set` would have rejected. Several callers build a config by mutating
+/// a loaded one (`models add`, `models install`, `models remove`, the geomodel
+/// install) and reached this function without validating.
+///
+/// Validating before the write also matters because this function truncates and
+/// rewrites the whole file: refusing early means a bad config cannot destroy a
+/// good one on disk.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
+    super::validate_config(config)?;
+
     // Create parent directories if they don't exist
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| Error::ConfigWrite {
@@ -78,6 +89,8 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
 }
 
 /// Save configuration to the default platform-specific path.
+///
+/// Validates before writing; see [`save_config`].
 pub fn save_default_config(config: &Config) -> Result<std::path::PathBuf> {
     let path = super::config_file_path()?;
     save_config(config, &path)?;
@@ -131,5 +144,83 @@ min_confidence = 0.25
 
         let config = load_config_file(file.path());
         assert!(config.is_err());
+    }
+
+    /// A config that `config set` would reject, for the save-path tests.
+    ///
+    /// `min_confidence` is used because `validate_defaults` checks it first, so
+    /// these assert the whole chain runs and not just the range-filter half.
+    fn invalid_config() -> Config {
+        let mut config = Config::default();
+        config.defaults.min_confidence = 1.5;
+        config
+    }
+
+    #[test]
+    fn test_save_config_rejects_an_invalid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let err = save_config(&invalid_config(), &path).unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConfigValidation { .. }),
+            "expected ConfigValidation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_save_config_writes_nothing_when_validation_fails() {
+        // `models add`, `models install`, `models remove` and the geomodel
+        // install all mutate a loaded config and save it without validating, so
+        // rejecting has to happen before the file is touched, not after.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        assert!(save_config(&invalid_config(), &path).is_err());
+        assert!(
+            !path.exists(),
+            "a rejected save must not leave a config file behind"
+        );
+    }
+
+    #[test]
+    fn test_save_config_does_not_truncate_an_existing_config() {
+        // The regression guard that matters most. This function truncates and
+        // rewrites the whole file, and a half-written config parses as
+        // all-defaults, silently losing every model the user had. Validating
+        // before the write is what stops a bad config destroying a good one.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let mut good = Config::default();
+        good.defaults.min_confidence = 0.25;
+        save_config(&good, &path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        assert!(save_config(&invalid_config(), &path).is_err());
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "the existing config must survive untouched");
+        assert_eq!(
+            load_config_file(&path).unwrap().defaults.min_confidence,
+            0.25
+        );
+    }
+
+    #[test]
+    fn test_save_config_still_writes_a_valid_config() {
+        // The happy path, so the guard above cannot pass by rejecting everything.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("config.toml");
+
+        let mut config = Config::default();
+        config.defaults.latitude = Some(60.17);
+        config.defaults.longitude = Some(24.94);
+        save_config(&config, &path).unwrap();
+
+        let loaded = load_config_file(&path).unwrap();
+        assert_eq!(loaded.defaults.latitude, Some(60.17));
+        assert_eq!(loaded.defaults.longitude, Some(24.94));
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -66,8 +66,11 @@ pub fn load_default_config() -> Result<Config> {
 /// install) and reached this function without validating.
 ///
 /// Validating before the write also matters because this function truncates and
-/// rewrites the whole file: refusing early means a bad config cannot destroy a
-/// good one on disk.
+/// rewrites the whole file: refusing early means an invalid config cannot
+/// destroy a good one on disk. That covers the validation failure mode only.
+/// The write itself is not atomic, so an interrupted or short write can still
+/// leave a truncated config.toml, which parses as all-defaults and loses every
+/// configured model.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
     super::validate_config(config)?;
 

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -41,16 +41,18 @@ pub fn supports_range_filter(args: &AnalyzeArgs, model_type: ModelType) -> bool 
 /// aborting after that spends the user's bandwidth to report something knowable
 /// up front.
 ///
-/// Bounds-checked here rather than only in `validate_range_filter` because
-/// `validate_config` has exactly one caller, `handle_config_set`, so nothing
-/// validates a config that was hand-edited rather than written through the CLI.
-/// The hand-edited case is the one the bug report describes: a negative
-/// threshold makes filtering a silent no-op while the JSON envelope still
-/// reports it active, and NaN drops every mapped species because `score >= NaN`
-/// is false for every score.
+/// Kept as a point-of-use check even though both of its inputs are now bounded
+/// before they arrive: the CLI flag by `parse_confidence`, and the config value
+/// by the load-time `validate_config` in `run()`. It exists so a future caller
+/// of this module cannot reach the threshold without one.
 ///
-/// The CLI flag arrives already bounded by `parse_confidence`, so in practice
-/// this fires only for a config-file value.
+/// The original reason was narrower and no longer holds. `validate_config` used
+/// to have exactly one caller, `handle_config_set`, so a threshold hand-edited
+/// into config.toml reached analysis unchecked: a negative value made filtering
+/// a silent no-op while the JSON envelope still reported it active, and NaN
+/// dropped every mapped species because `score >= NaN` is false for every
+/// score. #295 wired validation into the load path, which closed that hole at
+/// the source.
 pub fn validate_threshold(args: &AnalyzeArgs, config: &Config) -> Result<()> {
     let threshold = args
         .range_threshold
@@ -200,14 +202,15 @@ mod tests {
 
     #[test]
     fn test_hand_edited_nan_threshold_is_rejected_on_the_analyze_path() {
-        // The reported defect in full. `validate_config` has one caller,
+        // The reported defect in full. `validate_config` had one caller,
         // `handle_config_set`, so a threshold typed into config.toml by hand
         // reached analysis unchecked: `score >= NaN` is false for every score,
         // so every mapped species was dropped and the only symptom was an info
         // log reading "0 species in range".
         //
-        // Guarding only `validate_range_filter` would leave this green while
-        // the bug stayed live, because nothing on this path calls it.
+        // #295 closed that at the load path, so this now guards the same value
+        // one layer further in. Kept because it asserts the property this
+        // module depends on rather than the wiring that currently supplies it.
         let err = build_with(&config_with_threshold(f32::NAN)).unwrap_err();
 
         assert!(

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -29,18 +29,26 @@ fn validate_defaults(config: &Config) -> Result<()> {
 
     // Validate overlap is a finite, non-negative number.
     //
-    // The `is_finite` half is not decoration. A bare `overlap < 0.0` is the
-    // hand-rolled comparison `validate_range_filter` warns against below, and it
-    // let two values through with the same silent-wrong-result signature as the
-    // reported bug. `overlap * sample_rate` is cast to `usize`, and Rust
-    // saturates that cast rather than trapping: NaN becomes 0, so the setting
-    // was silently ignored, and infinity becomes `usize::MAX`, so
-    // `chunk_samples.saturating_sub(overlap_samples)` gave a step of 0 and
-    // `chunk_audio` returned no chunks at all. Neither reported anything.
+    // The `is_finite` half is what catches NaN, and NaN is the case that
+    // matters: a bare `overlap < 0.0` is the hand-rolled comparison
+    // `validate_range_filter` warns against below, and `NaN < 0.0` is false, so
+    // it was accepted. `overlap * sample_rate` is then cast to `usize`, and Rust
+    // saturates that cast rather than trapping, so NaN became 0 and the setting
+    // was silently ignored. That is the reported bug's signature exactly: a
+    // configured value that changes nothing and says nothing.
     //
-    // No upper bound is imposed here. One belongs with the chunk duration
-    // rather than in a rule that cannot see it, and adding it would be a new
-    // policy rather than a fix.
+    // Infinity is also caught, but it was never silent, so the gain there is
+    // only that it now fails as a config error up front instead of as an
+    // `Error::Internal` from `AudioDecoder::next_segment`, which rejects an
+    // overlap at or above the segment length. That reject still catches an
+    // oversized *finite* overlap, which this rule deliberately does not: 5.0
+    // and 1e15 are both finite and both fail there, the latter because the same
+    // saturating cast sends it to `usize::MAX`.
+    //
+    // So no upper bound is imposed here. One belongs with the segment length
+    // rather than in a rule that cannot see it, and adding it would be new
+    // policy rather than a fix. Tracked in #306 along with the matching hole on
+    // the `--overlap` flag, which carries no value parser at all.
     if !defaults.overlap.is_finite() || defaults.overlap < 0.0 {
         return Err(Error::ConfigValidation {
             message: format!(
@@ -203,11 +211,15 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_infinite_overlap() {
-        // The worse of the two. `inf as usize` saturates to `usize::MAX`, so
-        // `chunk_samples.saturating_sub(overlap_samples)` produced a step of 0
-        // and `chunk_audio` returned an empty vector: a run that finds nothing
-        // and says nothing about why.
+        // Positive infinity is the case `is_finite` adds here. It was already
+        // caught deeper in, by `AudioDecoder::next_segment` rejecting an overlap
+        // at or above the segment length, so this only moves the failure to load
+        // time where it reads as a config error rather than an internal one.
         assert!(validate_config(&config_with_overlap(f32::INFINITY)).is_err());
+
+        // Negative infinity was already rejected by the old `overlap < 0.0`,
+        // which is true for it. Asserted so the tightened rule is not assumed to
+        // have changed this case.
         assert!(validate_config(&config_with_overlap(f32::NEG_INFINITY)).is_err());
     }
 

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -27,10 +27,26 @@ fn validate_defaults(config: &Config) -> Result<()> {
         });
     }
 
-    // Validate overlap is non-negative
-    if defaults.overlap < 0.0 {
+    // Validate overlap is a finite, non-negative number.
+    //
+    // The `is_finite` half is not decoration. A bare `overlap < 0.0` is the
+    // hand-rolled comparison `validate_range_filter` warns against below, and it
+    // let two values through with the same silent-wrong-result signature as the
+    // reported bug. `overlap * sample_rate` is cast to `usize`, and Rust
+    // saturates that cast rather than trapping: NaN becomes 0, so the setting
+    // was silently ignored, and infinity becomes `usize::MAX`, so
+    // `chunk_samples.saturating_sub(overlap_samples)` gave a step of 0 and
+    // `chunk_audio` returned no chunks at all. Neither reported anything.
+    //
+    // No upper bound is imposed here. One belongs with the chunk duration
+    // rather than in a rule that cannot see it, and adding it would be a new
+    // policy rather than a fix.
+    if !defaults.overlap.is_finite() || defaults.overlap < 0.0 {
         return Err(Error::ConfigValidation {
-            message: format!("overlap must be non-negative, got {}", defaults.overlap),
+            message: format!(
+                "overlap must be a finite non-negative number, got {}",
+                defaults.overlap
+            ),
         });
     }
 
@@ -170,6 +186,39 @@ mod tests {
         assert!(validate_config(&config).is_err());
     }
 
+    /// Build a config carrying nothing but the overlap under test.
+    fn config_with_overlap(overlap: f32) -> Config {
+        let mut config = Config::default();
+        config.defaults.overlap = overlap;
+        config
+    }
+
+    #[test]
+    fn test_validate_rejects_nan_overlap() {
+        // `NaN < 0.0` is false, so the previous bare comparison accepted this.
+        // The cast to `usize` then saturated NaN to 0 and the setting was
+        // silently ignored, which is the same shape as the range-threshold bug.
+        assert!(validate_config(&config_with_overlap(f32::NAN)).is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_infinite_overlap() {
+        // The worse of the two. `inf as usize` saturates to `usize::MAX`, so
+        // `chunk_samples.saturating_sub(overlap_samples)` produced a step of 0
+        // and `chunk_audio` returned an empty vector: a run that finds nothing
+        // and says nothing about why.
+        assert!(validate_config(&config_with_overlap(f32::INFINITY)).is_err());
+        assert!(validate_config(&config_with_overlap(f32::NEG_INFINITY)).is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_ordinary_overlap() {
+        // The control: the tightened rule must not start rejecting the values
+        // it is meant to allow, including the zero default.
+        assert!(validate_config(&config_with_overlap(0.0)).is_ok());
+        assert!(validate_config(&config_with_overlap(1.5)).is_ok());
+    }
+
     #[test]
     fn test_validate_zero_batch_size() {
         let mut config = Config::default();
@@ -273,10 +322,12 @@ mod tests {
 
     #[test]
     fn test_validate_config_rejects_bad_threshold() {
-        // `handle_config_set` calls `validate_config`, not `validate_range_filter`
-        // directly, so the chain has to hold for `birda config set
-        // defaults.range_threshold -1` to be rejected. Without this, the unit
-        // tests above could pass while the CLI path stayed broken.
+        // Every caller reaches this through `validate_config` rather than
+        // calling `validate_range_filter` directly: the load gate in `run()`,
+        // and `save_config` on behalf of every writer. So the chain has to hold
+        // for `birda config set defaults.range_threshold -1` to be rejected.
+        // Without this, the unit tests above could pass while the CLI path
+        // stayed broken.
         let err = validate_config(&config_with_threshold(-1.0)).unwrap_err();
 
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,15 @@ pub fn run() -> Result<()> {
     // Load configuration
     let config = load_default_config()?;
 
+    // `load_config_file` only parses TOML and reports deprecated keys, so until
+    // this call every rule in `config::validate` guarded `config set` alone.
+    // That is the path where clap's value parsers have usually already checked
+    // the value, and it left the hand-edited file, where a wrong value is most
+    // likely, entirely unchecked.
+    if command_requires_valid_config(cli.command.as_ref(), cli.inputs.is_empty()) {
+        config::validate_config(&config)?;
+    }
+
     // Determine output mode (CLI flag takes precedence over config)
     // Auto-enable NDJSON mode for stdout
     let output_mode = if cli.analyze.stdout {
@@ -344,6 +353,27 @@ pub fn run() -> Result<()> {
 
     // Run analysis
     analyze_files(&cli.inputs, &cli.analyze, &config, output_mode, &reporter)
+}
+
+/// Whether a command must run against a configuration that passes validation.
+///
+/// Commands that consume the values in `config.toml` treat an invalid one as an
+/// error rather than something to carry on with. Two paths are exempt, and both
+/// are exempt for the same reason: they are how a user diagnoses a broken file,
+/// so failing them would leave hand-editing as the only way out of a state that
+/// hand-editing caused.
+///
+/// - `config`, which is where `show`, `path` and `set` live.
+/// - The bare invocation with no inputs, which prints help and exits.
+///
+/// The exemption widens what can be read, not what can be persisted: every
+/// writer still validates inside [`config::save_config`].
+fn command_requires_valid_config(command: Option<&Command>, has_no_inputs: bool) -> bool {
+    match command {
+        Some(Command::Config { .. }) => false,
+        None => !has_no_inputs,
+        Some(_) => true,
+    }
 }
 
 fn command_requires_runtime(command: Option<&Command>, has_no_inputs: bool) -> bool {
@@ -1348,7 +1378,8 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
         }
     }
 
-    config::validate_config(&config)?;
+    // Validation happens inside `save_default_config`, which every config writer
+    // goes through, so the mutated config is rejected before anything is written.
     save_default_config(&config)?;
 
     if output_mode.is_structured() {
@@ -2714,5 +2745,76 @@ mod tests {
         assert_eq!(model.path, PathBuf::from("/path/to/model.onnx"));
         assert_eq!(model.labels, PathBuf::from("/path/to/labels.txt"));
         assert_eq!(model.model_type, ModelType::BirdnetV24);
+    }
+
+    /// Which commands run against a validated config (#295).
+    ///
+    /// The predicate decides whether a hand-edited `config.toml` can reach a
+    /// command at all, so both answers need pinning: an exemption that spreads
+    /// silently reopens the bug, and one that shrinks locks a user out of the
+    /// commands that repair the file.
+    mod requires_valid_config {
+        use super::*;
+        use cli::{ConfigAction, ModelsAction};
+
+        /// Analysis with input files, the path that consumes every default.
+        const HAS_INPUTS: bool = false;
+        /// No input files, which is how the bare invocation reaches help.
+        const NO_INPUTS: bool = true;
+
+        #[test]
+        fn test_config_subcommand_is_exempt() {
+            // The repair surface. `config show` diagnoses the bad value and
+            // `config set` replaces it, so validating here would mean the only
+            // way out of a broken file is the hand-editing that broke it.
+            for action in [
+                ConfigAction::Show,
+                ConfigAction::Path,
+                ConfigAction::Init,
+                ConfigAction::Set {
+                    key: "defaults.latitude".to_string(),
+                    value: "60.1".to_string(),
+                },
+            ] {
+                let command = Command::Config { action };
+                assert!(
+                    !command_requires_valid_config(Some(&command), NO_INPUTS),
+                    "config subcommand must stay reachable with an invalid config"
+                );
+            }
+        }
+
+        #[test]
+        fn test_bare_invocation_without_inputs_is_exempt() {
+            // Falls through to `print_smart_help`. Refusing to print help
+            // because the config is wrong is the least useful moment to refuse.
+            assert!(!command_requires_valid_config(None, NO_INPUTS));
+        }
+
+        #[test]
+        fn test_analysis_requires_a_valid_config() {
+            // The reported case: `range_threshold = nan` dropped every mapped
+            // species and the only symptom was an info log reading "0 species
+            // in range".
+            assert!(command_requires_valid_config(None, HAS_INPUTS));
+        }
+
+        #[test]
+        fn test_other_subcommands_require_a_valid_config() {
+            let commands = [
+                Command::Models {
+                    action: ModelsAction::List,
+                },
+                Command::Providers,
+                Command::Update { check: true },
+            ];
+
+            for command in &commands {
+                assert!(
+                    command_requires_valid_config(Some(command), NO_INPUTS),
+                    "{command:?} reads config values and must validate them"
+                );
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,22 +357,51 @@ pub fn run() -> Result<()> {
 
 /// Whether a command must run against a configuration that passes validation.
 ///
-/// Commands that consume the values in `config.toml` treat an invalid one as an
-/// error rather than something to carry on with. Two paths are exempt, and both
-/// are exempt for the same reason: they are how a user diagnoses a broken file,
-/// so failing them would leave hand-editing as the only way out of a state that
-/// hand-editing caused.
+/// Only the commands that turn `config.toml` values into a result are gated,
+/// because those are the ones an invalid value corrupts. Everything else either
+/// reads no configuration at all or exists to inspect and repair the thing that
+/// is broken, and gating those would leave hand-editing as the only way out of
+/// a state that hand-editing caused.
 ///
-/// - `config`, which is where `show`, `path` and `set` live.
-/// - The bare invocation with no inputs, which prints help and exits.
+/// Enumerated rather than defaulted through a wildcard, deliberately and for
+/// the same reason as [`command_requires_runtime`] below: a new `Command` must
+/// not inherit an answer nobody chose. Adding a variant is a compile error here
+/// until someone decides which side it belongs on.
 ///
-/// The exemption widens what can be read, not what can be persisted: every
+/// The exemption widens what can be read, never what can be persisted: every
 /// writer still validates inside [`config::save_config`].
 fn command_requires_valid_config(command: Option<&Command>, has_no_inputs: bool) -> bool {
     match command {
-        Some(Command::Config { .. }) => false,
+        // Analysis is the only path that turns the whole of `[defaults]` into a
+        // result, and it is the path the reported bug ran down. With no inputs
+        // this falls through to help, which is the least useful moment to
+        // refuse.
         None => !has_no_inputs,
-        Some(_) => true,
+
+        // Every subcommand is exempt, and each for a stated reason.
+        //
+        // `config` and `models` are the repair surfaces: one edits the file,
+        // the other installs the model a dangling `defaults.model` names.
+        // Gating them would leave hand-editing as the only way out of a state
+        // that hand-editing caused, and `models install` is itself a repair.
+        //
+        // `providers`, `clip` and `update` receive no `Config` at all;
+        // `handle_providers_command`, `clipper::command::execute` and
+        // `handle_update_command` each take only an output mode. Refusing to
+        // run the updater over a config it never reads would block the route to
+        // a build that fixes the config handling.
+        //
+        // `species` takes `--lat` and `--lon` as required arguments, so it
+        // never reads the coordinate defaults. Failing it on a stale
+        // `defaults.latitude` would reject a run that could not have used it.
+        Some(
+            Command::Config { .. }
+            | Command::Models { .. }
+            | Command::Species { .. }
+            | Command::Providers
+            | Command::Clip(_)
+            | Command::Update { .. },
+        ) => false,
     }
 }
 
@@ -818,8 +847,13 @@ fn analyze_files(
     // reported bug, where a negative value silently disabled filtering while
     // the JSON envelope still called it active, and NaN dropped every species.
     //
-    // Gated on `wants_range_filter` so a stale threshold in a config that is
-    // not doing range filtering at all cannot fail an unrelated run.
+    // Gated on `wants_range_filter`, which no longer changes the outcome: since
+    // #295 the config-file value is rejected at load and the flag is bounded by
+    // `parse_confidence`, so a threshold reaching here is already in range. The
+    // gate's original promise, that a stale threshold in a config not doing
+    // range filtering cannot fail an unrelated run, does not survive that: an
+    // out-of-range value now fails the run regardless, which is the same answer
+    // `config set` has always given it.
     if config::range_filter::wants_range_filter(args, config, model_config.model_type) {
         config::range_filter::validate_threshold(args, config)?;
     }
@@ -1378,8 +1412,14 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
         }
     }
 
-    // Validation happens inside `save_default_config`, which every config writer
-    // goes through, so the mutated config is rejected before anything is written.
+    // Validation happens inside `save_config`, which `save_default_config`
+    // delegates to and every config writer reaches, so the mutated config is
+    // rejected before anything is written.
+    //
+    // Note this validates the whole config, not just the key being set, so a
+    // file carrying two independent faults cannot be repaired one key at a time
+    // here. That predates #295 and is tracked separately; the load gate is
+    // scoped to analysis so it does not turn that into a lockout.
     save_default_config(&config)?;
 
     if output_mode.is_structured() {
@@ -2750,71 +2790,107 @@ mod tests {
     /// Which commands run against a validated config (#295).
     ///
     /// The predicate decides whether a hand-edited `config.toml` can reach a
-    /// command at all, so both answers need pinning: an exemption that spreads
-    /// silently reopens the bug, and one that shrinks locks a user out of the
-    /// commands that repair the file.
+    /// command at all, so both answers need pinning. An exemption that shrinks
+    /// locks a user out of the commands that repair the file; one that spreads
+    /// starts rejecting runs over values they never read.
+    // A test command line that fails to parse is a broken test, not a runtime
+    // condition to handle, so `expect` is the right call here. Matches the
+    // convention the other test modules in this crate use.
+    #[allow(clippy::expect_used)]
     mod requires_valid_config {
         use super::*;
-        use cli::{ConfigAction, ModelsAction};
 
-        /// Analysis with input files, the path that consumes every default.
-        const HAS_INPUTS: bool = false;
-        /// No input files, which is how the bare invocation reaches help.
-        const NO_INPUTS: bool = true;
+        /// Answer the predicate for a real command line.
+        ///
+        /// Parsing through clap rather than building `Command` variants by hand
+        /// keeps the test honest about two things a hand-built variant hides:
+        /// which arguments are actually required on a subcommand, and that
+        /// `inputs` is empty whenever a subcommand is present, since clap routes
+        /// positionals to the subcommand.
+        fn gated(argv: &[&str]) -> bool {
+            let cli = Cli::try_parse_from(argv).expect("test command line should parse");
+            command_requires_valid_config(cli.command.as_ref(), cli.inputs.is_empty())
+        }
 
         #[test]
-        fn test_config_subcommand_is_exempt() {
-            // The repair surface. `config show` diagnoses the bad value and
-            // `config set` replaces it, so validating here would mean the only
-            // way out of a broken file is the hand-editing that broke it.
-            for action in [
-                ConfigAction::Show,
-                ConfigAction::Path,
-                ConfigAction::Init,
-                ConfigAction::Set {
-                    key: "defaults.latitude".to_string(),
-                    value: "60.1".to_string(),
-                },
-            ] {
-                let command = Command::Config { action };
-                assert!(
-                    !command_requires_valid_config(Some(&command), NO_INPUTS),
-                    "config subcommand must stay reachable with an invalid config"
-                );
-            }
+        fn test_analysis_requires_a_valid_config() {
+            // The reported case, and the only gated path. `range_threshold =
+            // nan` dropped every mapped species here and the only symptom was
+            // an info log reading "0 species in range".
+            assert!(gated(&["birda", "recording.wav"]));
         }
 
         #[test]
         fn test_bare_invocation_without_inputs_is_exempt() {
             // Falls through to `print_smart_help`. Refusing to print help
             // because the config is wrong is the least useful moment to refuse.
-            assert!(!command_requires_valid_config(None, NO_INPUTS));
+            assert!(!gated(&["birda"]));
         }
 
         #[test]
-        fn test_analysis_requires_a_valid_config() {
-            // The reported case: `range_threshold = nan` dropped every mapped
-            // species and the only symptom was an info log reading "0 species
-            // in range".
-            assert!(command_requires_valid_config(None, HAS_INPUTS));
-        }
-
-        #[test]
-        fn test_other_subcommands_require_a_valid_config() {
-            let commands = [
-                Command::Models {
-                    action: ModelsAction::List,
-                },
-                Command::Providers,
-                Command::Update { check: true },
-            ];
-
-            for command in &commands {
+        fn test_config_subcommand_is_exempt() {
+            // The repair surface. `config show` diagnoses the bad value and
+            // `config set` replaces it, so validating here would mean the only
+            // way out of a broken file is the hand-editing that broke it.
+            for argv in [
+                vec!["birda", "config", "show"],
+                vec!["birda", "config", "path"],
+                vec!["birda", "config", "init"],
+                vec!["birda", "config", "set", "defaults.latitude", "60.17"],
+            ] {
                 assert!(
-                    command_requires_valid_config(Some(command), NO_INPUTS),
-                    "{command:?} reads config values and must validate them"
+                    !gated(&argv),
+                    "{argv:?} must stay reachable with an invalid config"
                 );
             }
+        }
+
+        #[test]
+        fn test_models_subcommand_is_exempt() {
+            // `defaults.model` naming a model that is not in the file is the
+            // one fault `config set` cannot fix by setting the offending key,
+            // and `models install` is its natural repair. Gating this arm made
+            // that repair unreachable.
+            for argv in [
+                vec!["birda", "models", "list"],
+                vec!["birda", "models", "check"],
+                vec!["birda", "models", "install", "birdnet-v24"],
+                vec!["birda", "models", "remove", "birdnet-v24"],
+            ] {
+                assert!(
+                    !gated(&argv),
+                    "{argv:?} must stay reachable so a dangling default can be repaired"
+                );
+            }
+        }
+
+        #[test]
+        fn test_commands_that_receive_no_config_are_exempt() {
+            // `handle_providers_command`, `clipper::command::execute` and
+            // `handle_update_command` each take only an output mode, so an
+            // invalid value cannot reach them. `update` matters most: it is how
+            // a user installs a build that fixes the config handling, and
+            // gating it on the config would block that route.
+            for argv in [
+                vec!["birda", "providers"],
+                vec!["birda", "clip", "results.csv"],
+                vec!["birda", "update", "--check"],
+            ] {
+                assert!(
+                    !gated(&argv),
+                    "{argv:?} receives no Config and must not be gated on one"
+                );
+            }
+        }
+
+        #[test]
+        fn test_species_is_exempt_because_its_coordinates_are_required_args() {
+            // `--lat` and `--lon` are required here, so `species` never reads
+            // `defaults.latitude` or `defaults.longitude`. Failing it on a stale
+            // coordinate would reject a run that could not have used it.
+            assert!(!gated(&[
+                "birda", "species", "--lat", "60.17", "--lon", "24.94", "--week", "24"
+            ]));
         }
     }
 }

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -32,6 +32,38 @@ const OUT_OF_RANGE_LATITUDE: &str = "[defaults]\nlatitude = 200.0\n";
 /// "0 species in range".
 const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
 
+/// Every `BIRDA_*` variable clap binds to an argument.
+///
+/// All of them are cleared per run. These tests assert on what the config file
+/// produces, and each of these overrides a config value, so any one of them
+/// exported in a developer's shell would silently change what is being tested
+/// rather than failing outright. Enumerated rather than cleared wholesale
+/// because the child still needs `HOME`, `PATH` and the rest of its
+/// environment.
+///
+/// Kept in sync with `grep -rhoE 'env = "BIRDA_[A-Z_]+"' src/`.
+const BIRDA_ENV_VARS: [&str; 19] = [
+    "BIRDA_BATCH_SIZE",
+    "BIRDA_DAY_OF_YEAR",
+    "BIRDA_FORMAT",
+    "BIRDA_GEOMODEL_LABELS_PATH",
+    "BIRDA_GEOMODEL_PATH",
+    "BIRDA_LABELS_PATH",
+    "BIRDA_LATITUDE",
+    "BIRDA_LONGITUDE",
+    "BIRDA_META_MODEL_PATH",
+    "BIRDA_MIN_CONFIDENCE",
+    "BIRDA_MODEL",
+    "BIRDA_MODEL_PATH",
+    "BIRDA_MODEL_TYPE",
+    "BIRDA_OUTPUT_DIR",
+    "BIRDA_OUTPUT_MODE",
+    "BIRDA_OVERLAP",
+    "BIRDA_RANGE_THRESHOLD",
+    "BIRDA_RANGE_UNMATCHED",
+    "BIRDA_SPECIES_LIST",
+];
+
 /// Run birda against a caller-supplied HOME.
 ///
 /// `directories` resolves the config directory from `HOME` on macOS and from
@@ -39,16 +71,18 @@ const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
 /// this the suite would read and rewrite the developer's real config.toml.
 /// `seed_config` proves the redirection actually took effect before writing
 /// anything; see the comment there.
+///
+/// The isolation has to cover the environment as well as the filesystem, hence
+/// [`BIRDA_ENV_VARS`].
 fn run_in(home: &Path, args: &[&str]) -> std::process::Output {
     let mut cmd = cargo_bin_cmd!("birda");
     cmd.env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join("config"))
         .env("XDG_DATA_HOME", home.join("data"))
-        // `--output-mode` reads BIRDA_OUTPUT_MODE. A developer with that
-        // exported would turn the human-output assertions into failures, so the
-        // isolation has to cover the environment, not just the filesystem.
-        .env_remove("BIRDA_OUTPUT_MODE")
         .timeout(COMMAND_TIMEOUT);
+    for var in BIRDA_ENV_VARS {
+        cmd.env_remove(var);
+    }
     for arg in args {
         cmd.arg(arg);
     }
@@ -134,25 +168,40 @@ fn assert_analysis_rejected(home: &Path, expected: &str) {
     );
 }
 
-/// Assert an analyze run cleared config validation and failed further in.
-fn assert_analysis_passes_validation(home: &Path) {
+/// Assert config validation did not stop an analyze run.
+///
+/// Stated as the absence of every rule message rather than as a positive
+/// assertion on whatever comes next, because what comes next is not invariant.
+/// `run()` initialises the ONNX runtime after validation but before it resolves
+/// a model, so on a machine with the shared library present the run reaches "no
+/// model specified", and on one without it stops at the runtime instead. CI is
+/// the second kind, so pinning the later stage made this environment-dependent.
+///
+/// Absence is only safe here because each message is a shared constant that a
+/// rejection test asserts positively. A reword therefore fails loudly there
+/// instead of silently switching this check off, which is the trap an earlier
+/// revision fell into with a list nothing positively pinned.
+fn assert_validation_did_not_reject(home: &Path) {
     let input = dummy_input(home);
     let stderr = stderr_of(&run_in(home, &[input.to_str().unwrap()]));
 
-    assert!(
-        stderr.contains(PAST_VALIDATION_ERROR),
-        "analysis should have reached model resolution, meaning it cleared \
-         validation; expected {PAST_VALIDATION_ERROR:?}, got: {stderr}"
-    );
+    for message in [LATITUDE_VIOLATION, THRESHOLD_VIOLATION, OVERLAP_VIOLATION] {
+        assert!(
+            !stderr.contains(message),
+            "a valid config must not be rejected ({message}), got: {stderr}"
+        );
+    }
 }
 
-/// The error an analyze run reaches once it is past config validation.
+/// The rule messages this suite drives, exactly as the user sees them.
 ///
-/// These tests install no model, so this is where a run that cleared the gate
-/// lands. Asserting it positively is what makes the control meaningful: an
-/// assertion that merely failed to find a validation error would also pass if
-/// the binary died for any other reason, or if the error text drifted.
-const PAST_VALIDATION_ERROR: &str = "no model specified";
+/// Each is used twice: asserted positively by the rejection test for its rule,
+/// and asserted absent by the control. That pairing is what keeps the control
+/// honest, since a reworded message breaks its rejection test loudly rather
+/// than quietly ceasing to match.
+const LATITUDE_VIOLATION: &str = "invalid latitude";
+const THRESHOLD_VIOLATION: &str = "invalid range threshold";
+const OVERLAP_VIOLATION: &str = "overlap must be a finite non-negative number";
 
 /// The exit code birda uses for an application error, as opposed to a clap
 /// parse failure (2) or a panic (101). Pinned so a rejection test cannot be
@@ -183,7 +232,7 @@ fn test_out_of_range_latitude_is_rejected_on_load() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
 
-    assert_analysis_rejected(home.path(), "invalid latitude");
+    assert_analysis_rejected(home.path(), LATITUDE_VIOLATION);
 }
 
 #[test]
@@ -194,7 +243,7 @@ fn test_nan_range_threshold_is_rejected_on_load() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), NAN_RANGE_THRESHOLD);
 
-    assert_analysis_rejected(home.path(), "invalid range threshold");
+    assert_analysis_rejected(home.path(), THRESHOLD_VIOLATION);
 }
 
 #[test]
@@ -255,7 +304,7 @@ fn test_config_set_repairs_an_invalid_config() {
         "the repaired value should be the one that was set"
     );
 
-    assert_analysis_passes_validation(home.path());
+    assert_validation_did_not_reject(home.path());
 }
 
 #[test]
@@ -352,7 +401,7 @@ fn test_an_overlap_rule_violation_is_rejected_on_load() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), "[defaults]\noverlap = nan\n");
 
-    assert_analysis_rejected(home.path(), "overlap must be a finite non-negative number");
+    assert_analysis_rejected(home.path(), OVERLAP_VIOLATION);
 }
 
 #[test]
@@ -380,5 +429,5 @@ fn test_a_valid_config_still_loads() {
         "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n",
     );
 
-    assert_analysis_passes_validation(home.path());
+    assert_validation_did_not_reject(home.path());
 }

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -318,19 +318,45 @@ fn test_repair_and_diagnostic_commands_are_not_gated() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
 
+    // Only hermetic, local commands are driven here. Every exempt command
+    // shares the single gate call site in `run()`, so proving the wiring with
+    // one of them proves it for all; which commands are exempt is a table fact,
+    // covered by the unit tests over the predicate. `update --check` and `clip`
+    // were both in this loop briefly and neither belonged: `update --check`
+    // performs a real release lookup and exits 1 with no network, so it would
+    // fail for an offline developer and under GitHub API rate limiting on
+    // shared CI runners, and `clip` currently exits 0 for a file that does not
+    // exist, so asserting its success would pin a production oddity that ought
+    // to be fixed.
     for args in [
         vec!["models", "list"],
         vec!["models", "check"],
         vec!["config", "path"],
-        vec!["clip", "no-such-results.csv"],
-        vec!["update", "--check"],
+        vec!["config", "show"],
     ] {
         assert_command_succeeds(home.path(), &args);
     }
 }
 
 #[test]
-fn test_a_dangling_default_model_does_not_block_models_install() {
+fn test_an_overlap_rule_violation_is_rejected_on_load() {
+    // `validate_config` runs two halves and only `validate_range_filter` was
+    // reached end to end: swapping the gate call to `validate_range_filter`
+    // alone left the whole suite green. This drives a `validate_defaults` rule
+    // through the binary, so the gate is pinned to the full check rather than
+    // half of it.
+    //
+    // Overlap is the rule to use, because it is the one this branch tightened:
+    // `overlap < 0.0` accepted NaN, which the saturating cast to `usize` then
+    // turned into a silently ignored setting.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\noverlap = nan\n");
+
+    assert_analysis_rejected(home.path(), "overlap must be a finite non-negative number");
+}
+
+#[test]
+fn test_a_dangling_default_model_does_not_block_the_models_commands() {
     // The one fault `config set` cannot fix by correcting the offending key:
     // `defaults.model` names a model that is not in the file, and installing
     // that model is the natural repair. Gating `models` made the repair

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -112,13 +112,20 @@ fn stderr_of(output: &std::process::Output) -> String {
 }
 
 /// Assert the analyze path refused to start, naming the offending value.
+///
+/// The exit code is pinned rather than tested with `!success`, because a panic
+/// (101), a clap failure (2) or the timeout kill would all satisfy the looser
+/// form while proving nothing about validation. This follows the convention
+/// `tests/geomodel_discoverability.rs` already established for the same reason.
 fn assert_analysis_rejected(home: &Path, expected: &str) {
     let input = dummy_input(home);
     let output = run_in(home, &[input.to_str().unwrap()]);
 
-    assert!(
-        !output.status.success(),
-        "analysis must not run against an invalid config"
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "analysis must be rejected as an application error, got: {}",
+        stderr_of(&output)
     );
     let stderr = stderr_of(&output);
     assert!(
@@ -127,37 +134,46 @@ fn assert_analysis_rejected(home: &Path, expected: &str) {
     );
 }
 
-/// The message each rule in `validate_config` produces, as the user sees it.
-///
-/// Matched individually rather than on the shared `configuration validation
-/// failed:` prefix, because `Error::ConfigValidation` also carries errors that
-/// have nothing to do with the config file. "no model specified" is one, and it
-/// is the expected outcome of an analyze run in a HOME with no model installed,
-/// so keying on the prefix would make the control below assert its own failure.
-const RULE_VIOLATION_MESSAGES: [&str; 6] = [
-    "invalid latitude",
-    "invalid longitude",
-    "invalid range threshold",
-    "min_confidence must be between",
-    "overlap must be",
-    "batch_size must be at least",
-];
+/// Assert an analyze run cleared config validation and failed further in.
+fn assert_analysis_passes_validation(home: &Path) {
+    let input = dummy_input(home);
+    let stderr = stderr_of(&run_in(home, &[input.to_str().unwrap()]));
 
-/// Assert a command was not gated on the config.
+    assert!(
+        stderr.contains(PAST_VALIDATION_ERROR),
+        "analysis should have reached model resolution, meaning it cleared \
+         validation; expected {PAST_VALIDATION_ERROR:?}, got: {stderr}"
+    );
+}
+
+/// The error an analyze run reaches once it is past config validation.
 ///
-/// Checks the absence of a rule violation rather than success, because some
-/// exempt commands legitimately fail for their own reasons (a missing CSV, an
-/// unavailable ONNX runtime, no model installed). What must never appear is a
-/// complaint about a config value the command does not read.
-fn assert_not_gated_on_config(home: &Path, args: &[&str]) {
-    let stderr = stderr_of(&run_in(home, args));
-    for message in RULE_VIOLATION_MESSAGES {
-        assert!(
-            !stderr.contains(message),
-            "`birda {}` must not be blocked by config validation ({message}), got: {stderr}",
-            args.join(" ")
-        );
-    }
+/// These tests install no model, so this is where a run that cleared the gate
+/// lands. Asserting it positively is what makes the control meaningful: an
+/// assertion that merely failed to find a validation error would also pass if
+/// the binary died for any other reason, or if the error text drifted.
+const PAST_VALIDATION_ERROR: &str = "no model specified";
+
+/// The exit code birda uses for an application error, as opposed to a clap
+/// parse failure (2) or a panic (101). Pinned so a rejection test cannot be
+/// satisfied by the wrong kind of failure.
+const APPLICATION_ERROR: i32 = 1;
+
+/// Assert a command ran to completion, so it was not gated on the config.
+///
+/// A plain success assertion rather than the absence of a validation message.
+/// Absence fails open twice over: it passes when the command breaks for an
+/// unrelated reason, and it silently stops testing anything if the message it
+/// looks for is ever reworded.
+fn assert_command_succeeds(home: &Path, args: &[&str]) {
+    let output = run_in(home, args);
+    assert!(
+        output.status.success(),
+        "`birda {}` must run despite the invalid config, got {:?}: {}",
+        args.join(" "),
+        output.status.code(),
+        stderr_of(&output)
+    );
 }
 
 #[test]
@@ -188,17 +204,26 @@ fn test_config_show_still_works_with_an_invalid_config() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
 
-    let output = run_in(home.path(), &["config", "show"]);
+    // Asserted through the JSON envelope rather than the human output. The
+    // structured payload is what birda-gui reads, and it is the only route
+    // that shows a GUI user which value is wrong; the human form would pin the
+    // assertion to `{config:#?}` Debug formatting, so a cosmetic change to how
+    // floats print would break the test while the behaviour was intact.
+    let output = run_in(home.path(), &["config", "show", "--output-mode", "json"]);
 
     assert!(
         output.status.success(),
         "`config show` must survive an invalid config: {}",
         stderr_of(&output)
     );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("200.0"),
-        "`config show` should display the offending value so it can be found, got: {stdout}"
+    let envelope: serde_json::Value =
+        serde_json::from_str(&stdout).expect("`config show` must emit a parseable envelope");
+
+    assert_eq!(
+        envelope["payload"]["config"]["defaults"]["latitude"], 200.0,
+        "`config show` should report the offending value so it can be found, got: {stdout}"
     );
 }
 
@@ -219,7 +244,18 @@ fn test_config_set_repairs_an_invalid_config() {
         stderr_of(&repair)
     );
 
-    assert_not_gated_on_config(home.path(), &["models", "list"]);
+    // Pin that the requested value actually landed, not merely that the command
+    // exited 0. A `config set` that persisted defaults instead would clear the
+    // fault and satisfy every other assertion here.
+    let shown = run_in(home.path(), &["config", "show", "--output-mode", "json"]);
+    let envelope: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&shown.stdout))
+        .expect("`config show` must emit a parseable envelope");
+    assert_eq!(
+        envelope["payload"]["config"]["defaults"]["latitude"], 60.17,
+        "the repaired value should be the one that was set"
+    );
+
+    assert_analysis_passes_validation(home.path());
 }
 
 #[test]
@@ -233,9 +269,13 @@ fn test_config_set_refuses_to_persist_an_invalid_value() {
 
     let output = run_in(home.path(), &["config", "set", "defaults.latitude", "200"]);
 
-    assert!(
-        !output.status.success(),
-        "`config set` must reject an out-of-range latitude"
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "`config set` must reject an out-of-range latitude as an application \
+         error; a panic or a parse failure would satisfy a bare !success check \
+         while proving nothing, got: {}",
+        stderr_of(&output)
     );
     assert_eq!(
         std::fs::read_to_string(&path).unwrap(),
@@ -258,6 +298,14 @@ fn test_bare_invocation_prints_help_with_an_invalid_config() {
         "the bare invocation should still print help: {}",
         stderr_of(&output)
     );
+
+    // Exiting 0 is not the claim; printing the help is. Without this the test
+    // passes just as well against a `print_smart_help` that returns silently.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("birda models list-available"),
+        "help should still guide a user with no models configured, got: {stdout}"
+    );
 }
 
 #[test]
@@ -272,10 +320,12 @@ fn test_repair_and_diagnostic_commands_are_not_gated() {
 
     for args in [
         vec!["models", "list"],
+        vec!["models", "check"],
         vec!["config", "path"],
         vec!["clip", "no-such-results.csv"],
+        vec!["update", "--check"],
     ] {
-        assert_not_gated_on_config(home.path(), &args);
+        assert_command_succeeds(home.path(), &args);
     }
 }
 
@@ -288,13 +338,8 @@ fn test_a_dangling_default_model_does_not_block_models_install() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), "[defaults]\nmodel = \"gone-model\"\n");
 
-    assert_not_gated_on_config(home.path(), &["models", "list"]);
-
-    let stderr = stderr_of(&run_in(home.path(), &["models", "check"]));
-    assert!(
-        !stderr.contains("not found in configuration"),
-        "`models check` must not fail on the dangling default it exists to report, got: {stderr}"
-    );
+    assert_command_succeeds(home.path(), &["models", "list"]);
+    assert_command_succeeds(home.path(), &["models", "check"]);
 }
 
 #[test]
@@ -309,6 +354,5 @@ fn test_a_valid_config_still_loads() {
         "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n",
     );
 
-    let input = dummy_input(home.path());
-    assert_not_gated_on_config(home.path(), &[input.to_str().unwrap()]);
+    assert_analysis_passes_validation(home.path());
 }

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -37,6 +37,8 @@ const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
 /// `directories` resolves the config directory from `HOME` on macOS and from
 /// `XDG_CONFIG_HOME` (falling back to `HOME`) on Linux, so both are set. Without
 /// this the suite would read and rewrite the developer's real config.toml.
+/// `seed_config` proves the redirection actually took effect before writing
+/// anything; see the comment there.
 fn run_in(home: &Path, args: &[&str]) -> std::process::Output {
     let mut cmd = cargo_bin_cmd!("birda");
     cmd.env("HOME", home)
@@ -68,15 +70,94 @@ fn config_path_in(home: &Path) -> PathBuf {
 }
 
 /// Write `contents` to the config file the binary will actually load.
+///
+/// The assertion is load-bearing, not a sanity check. `HOME` and `XDG_*`
+/// redirect `directories` on macOS and Linux only: on Windows it resolves
+/// through `SHGetKnownFolderPath`, which consults no environment variable at
+/// all, so the path handed back would be the developer's real
+/// `%APPDATA%\birda\config.toml` and this function would overwrite it with a
+/// two-line stub, destroying every model they had configured. Refusing to write
+/// outside the temp HOME turns that from silent destruction into a failure that
+/// names its own cause, on any platform where the redirection stops working.
 fn seed_config(home: &Path, contents: &str) -> PathBuf {
     let path = config_path_in(home);
+    assert!(
+        path.starts_with(home),
+        "config path {} escaped the test HOME {}; refusing to write. \
+         The environment no longer redirects this platform's config directory, \
+         so writing here would clobber the real user config.",
+        path.display(),
+        home.display()
+    );
+
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, contents).unwrap();
     path
 }
 
+/// An input path that makes the run take the analyze branch.
+///
+/// Analysis is the only gated command, so every "must be rejected" assertion
+/// has to go through it. The file only has to exist: validation happens in
+/// `run()` before the runtime is initialised and long before anything tries to
+/// decode audio, so its contents are never read.
+fn dummy_input(home: &Path) -> PathBuf {
+    let path = home.join("input.wav");
+    std::fs::write(&path, b"not really audio").unwrap();
+    path
+}
+
 fn stderr_of(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Assert the analyze path refused to start, naming the offending value.
+fn assert_analysis_rejected(home: &Path, expected: &str) {
+    let input = dummy_input(home);
+    let output = run_in(home, &[input.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "analysis must not run against an invalid config"
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains(expected),
+        "the error should name the offending value ({expected}), got: {stderr}"
+    );
+}
+
+/// The message each rule in `validate_config` produces, as the user sees it.
+///
+/// Matched individually rather than on the shared `configuration validation
+/// failed:` prefix, because `Error::ConfigValidation` also carries errors that
+/// have nothing to do with the config file. "no model specified" is one, and it
+/// is the expected outcome of an analyze run in a HOME with no model installed,
+/// so keying on the prefix would make the control below assert its own failure.
+const RULE_VIOLATION_MESSAGES: [&str; 6] = [
+    "invalid latitude",
+    "invalid longitude",
+    "invalid range threshold",
+    "min_confidence must be between",
+    "overlap must be",
+    "batch_size must be at least",
+];
+
+/// Assert a command was not gated on the config.
+///
+/// Checks the absence of a rule violation rather than success, because some
+/// exempt commands legitimately fail for their own reasons (a missing CSV, an
+/// unavailable ONNX runtime, no model installed). What must never appear is a
+/// complaint about a config value the command does not read.
+fn assert_not_gated_on_config(home: &Path, args: &[&str]) {
+    let stderr = stderr_of(&run_in(home, args));
+    for message in RULE_VIOLATION_MESSAGES {
+        assert!(
+            !stderr.contains(message),
+            "`birda {}` must not be blocked by config validation ({message}), got: {stderr}",
+            args.join(" ")
+        );
+    }
 }
 
 #[test]
@@ -86,38 +167,18 @@ fn test_out_of_range_latitude_is_rejected_on_load() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
 
-    let output = run_in(home.path(), &["models", "list"]);
-
-    assert!(
-        !output.status.success(),
-        "an out-of-range latitude must not load clean"
-    );
-    let stderr = stderr_of(&output);
-    assert!(
-        stderr.contains("invalid latitude"),
-        "the error should name the offending value, got: {stderr}"
-    );
+    assert_analysis_rejected(home.path(), "invalid latitude");
 }
 
 #[test]
 fn test_nan_range_threshold_is_rejected_on_load() {
     // Reproduced in #295: `birda config show` printed `range_threshold: NaN`
-    // and exited 0, and `models check` reported OK, while an analyze run
-    // returned only the unmatched non-species labels.
+    // and exited 0, while an analyze run returned only the unmatched
+    // non-species labels.
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), NAN_RANGE_THRESHOLD);
 
-    let output = run_in(home.path(), &["models", "list"]);
-
-    assert!(
-        !output.status.success(),
-        "a NaN range threshold must not load clean"
-    );
-    let stderr = stderr_of(&output);
-    assert!(
-        stderr.contains("invalid range threshold"),
-        "the error should name the offending value, got: {stderr}"
-    );
+    assert_analysis_rejected(home.path(), "invalid range threshold");
 }
 
 #[test]
@@ -158,12 +219,7 @@ fn test_config_set_repairs_an_invalid_config() {
         stderr_of(&repair)
     );
 
-    let after = run_in(home.path(), &["models", "list"]);
-    assert!(
-        after.status.success(),
-        "the repaired config should load: {}",
-        stderr_of(&after)
-    );
+    assert_not_gated_on_config(home.path(), &["models", "list"]);
 }
 
 #[test]
@@ -205,20 +261,54 @@ fn test_bare_invocation_prints_help_with_an_invalid_config() {
 }
 
 #[test]
+fn test_repair_and_diagnostic_commands_are_not_gated() {
+    // The blast-radius guard. An earlier revision of this change gated every
+    // subcommand, which blocked `models install` (the repair for a
+    // `defaults.model` that names a missing model), and blocked `update`, the
+    // route to a build that would fix the config handling, over a config none
+    // of them reads.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+
+    for args in [
+        vec!["models", "list"],
+        vec!["config", "path"],
+        vec!["clip", "no-such-results.csv"],
+    ] {
+        assert_not_gated_on_config(home.path(), &args);
+    }
+}
+
+#[test]
+fn test_a_dangling_default_model_does_not_block_models_install() {
+    // The one fault `config set` cannot fix by correcting the offending key:
+    // `defaults.model` names a model that is not in the file, and installing
+    // that model is the natural repair. Gating `models` made the repair
+    // unreachable, so this pins it open.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nmodel = \"gone-model\"\n");
+
+    assert_not_gated_on_config(home.path(), &["models", "list"]);
+
+    let stderr = stderr_of(&run_in(home.path(), &["models", "check"]));
+    assert!(
+        !stderr.contains("not found in configuration"),
+        "`models check` must not fail on the dangling default it exists to report, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_a_valid_config_still_loads() {
     // The control. Without it every assertion above would pass just as well if
-    // the new check rejected every config it was handed.
+    // the new check rejected every config it was handed. Analysis may still
+    // fail further on (no model is configured here), so this asserts only that
+    // it got past validation.
     let home = tempfile::tempdir().unwrap();
     seed_config(
         home.path(),
         "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n",
     );
 
-    let output = run_in(home.path(), &["models", "list"]);
-
-    assert!(
-        output.status.success(),
-        "a valid config must still load: {}",
-        stderr_of(&output)
-    );
+    let input = dummy_input(home.path());
+    assert_not_gated_on_config(home.path(), &[input.to_str().unwrap()]);
 }

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -1,0 +1,224 @@
+//! Integration tests for configuration validation on load (#295).
+//!
+//! These drive the real binary rather than calling `validate_config` directly,
+//! and that is the point. Every rule in `src/config/validate.rs` already
+//! existed and every unit test over it already passed; the defect was that
+//! nothing on the load path ever called them. `validate_config` had exactly one
+//! non-test caller, `handle_config_set`, so a value typed through the CLI (where
+//! clap has usually already checked it) was validated and a value hand-edited
+//! into `config.toml` (where it is most likely to be wrong) was not.
+//!
+//! A unit test cannot tell those two states apart, because both call the same
+//! passing function. Only spawning the binary against a seeded `config.toml`
+//! exercises the wiring, which is where the defect lived.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+
+/// These commands are local (no network, no ONNX runtime), so they should be
+/// quick. Bound them anyway so a hang fails rather than stalls the suite.
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A config that fails validation for a reason unrelated to the range filter,
+/// so the tests do not all depend on one rule.
+const OUT_OF_RANGE_LATITUDE: &str = "[defaults]\nlatitude = 200.0\n";
+
+/// The reported case: NaN dropped every mapped species, because `score >= NaN`
+/// is false for every score, and the only symptom was an info log reading
+/// "0 species in range".
+const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
+
+/// Run birda against a caller-supplied HOME.
+///
+/// `directories` resolves the config directory from `HOME` on macOS and from
+/// `XDG_CONFIG_HOME` (falling back to `HOME`) on Linux, so both are set. Without
+/// this the suite would read and rewrite the developer's real config.toml.
+fn run_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = cargo_bin_cmd!("birda");
+    cmd.env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("XDG_DATA_HOME", home.join("data"))
+        // `--output-mode` reads BIRDA_OUTPUT_MODE. A developer with that
+        // exported would turn the human-output assertions into failures, so the
+        // isolation has to cover the environment, not just the filesystem.
+        .env_remove("BIRDA_OUTPUT_MODE")
+        .timeout(COMMAND_TIMEOUT);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    cmd.output().expect("birda should run")
+}
+
+/// Ask the binary where its config lives rather than recomputing the platform
+/// rules here. A test that hardcoded `~/.config/birda/config.toml` would seed a
+/// file the binary never reads on macOS and then pass vacuously.
+fn config_path_in(home: &Path) -> PathBuf {
+    let output = run_in(home, &["config", "path"]);
+    assert!(
+        output.status.success(),
+        "`config path` failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
+}
+
+/// Write `contents` to the config file the binary will actually load.
+fn seed_config(home: &Path, contents: &str) -> PathBuf {
+    let path = config_path_in(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+fn stderr_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn test_out_of_range_latitude_is_rejected_on_load() {
+    // Accepted on load before the fix. `validate_range_filter` has checked
+    // latitude since long before this change; nothing called it.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+
+    let output = run_in(home.path(), &["models", "list"]);
+
+    assert!(
+        !output.status.success(),
+        "an out-of-range latitude must not load clean"
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("invalid latitude"),
+        "the error should name the offending value, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_nan_range_threshold_is_rejected_on_load() {
+    // Reproduced in #295: `birda config show` printed `range_threshold: NaN`
+    // and exited 0, and `models check` reported OK, while an analyze run
+    // returned only the unmatched non-species labels.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), NAN_RANGE_THRESHOLD);
+
+    let output = run_in(home.path(), &["models", "list"]);
+
+    assert!(
+        !output.status.success(),
+        "a NaN range threshold must not load clean"
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("invalid range threshold"),
+        "the error should name the offending value, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_config_show_still_works_with_an_invalid_config() {
+    // The repair surface. Validating here would mean the only route out of a
+    // broken config is the hand-editing that broke it, so `config` is exempt.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+
+    let output = run_in(home.path(), &["config", "show"]);
+
+    assert!(
+        output.status.success(),
+        "`config show` must survive an invalid config: {}",
+        stderr_of(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("200.0"),
+        "`config show` should display the offending value so it can be found, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_config_set_repairs_an_invalid_config() {
+    // The escape hatch end to end: the exemption is only worth having if the
+    // exempt commands can actually get the user back to a loadable config.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+
+    let repair = run_in(
+        home.path(),
+        &["config", "set", "defaults.latitude", "60.17"],
+    );
+    assert!(
+        repair.status.success(),
+        "`config set` must be able to fix the value: {}",
+        stderr_of(&repair)
+    );
+
+    let after = run_in(home.path(), &["models", "list"]);
+    assert!(
+        after.status.success(),
+        "the repaired config should load: {}",
+        stderr_of(&after)
+    );
+}
+
+#[test]
+fn test_config_set_refuses_to_persist_an_invalid_value() {
+    // The save-side half of the change. `config set` validates through
+    // `save_config`, so a bad value is rejected before the file is rewritten
+    // and the previous contents survive.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), "[defaults]\nlatitude = 60.17\n");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(home.path(), &["config", "set", "defaults.latitude", "200"]);
+
+    assert!(
+        !output.status.success(),
+        "`config set` must reject an out-of-range latitude"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a rejected `config set` must leave the file untouched"
+    );
+}
+
+#[test]
+fn test_bare_invocation_prints_help_with_an_invalid_config() {
+    // Refusing to print help because the config is wrong is the least useful
+    // moment to refuse, so the no-command no-inputs path is exempt too.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+
+    let output = run_in(home.path(), &[]);
+
+    assert!(
+        output.status.success(),
+        "the bare invocation should still print help: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn test_a_valid_config_still_loads() {
+    // The control. Without it every assertion above would pass just as well if
+    // the new check rejected every config it was handed.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(
+        home.path(),
+        "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n",
+    );
+
+    let output = run_in(home.path(), &["models", "list"]);
+
+    assert!(
+        output.status.success(),
+        "a valid config must still load: {}",
+        stderr_of(&output)
+    );
+}


### PR DESCRIPTION
Closes #295.

`validate_config` had exactly one non-test caller, `handle_config_set`, while `load_default_config` had eight and none of them validated. Every rule in `src/config/validate.rs` therefore guarded the path where a value is least likely to be wrong, typed through the CLI where clap's value parsers have usually already checked it, and left the path where it is most likely to be wrong, hand-edited into `config.toml`, entirely unchecked.

The reported symptom was `range_threshold = nan`. It loaded clean, `config show` printed `range_threshold: NaN` and exited 0, and an analyze run then dropped every mapped species because `score >= NaN` is false for every score. The only hint was an info log reading "0 species in range". Nothing about that was specific to the threshold: an out-of-range latitude, a zero `batch_size` and a `defaults.model` naming a model that is not in the file were all accepted on load too.

## What changed

**Analysis validates the config before it starts.** That is the one path that turns the whole of `[defaults]` into a result, and the path the reported bug ran down.

**Every subcommand is exempt, each for a recorded reason.** `config` and `models` are the repair surfaces, and `models install` is the only fix for a `defaults.model` that names a missing model. `providers`, `clip` and `update` receive no `Config` at all. `species` takes `--lat` and `--lon` as required arguments, so it never reads the coordinate defaults. The match is exhaustive rather than wildcarded, so a new `Command` is a compile error until someone decides which side it belongs on.

**Writing validates too.** Moved into `save_config`, which every writer reaches, so `models add`, `models install`, `models remove` and the geomodel install can no longer re-persist a value `config set` would reject. Putting it there also matters because that function truncates and rewrites the whole file, so refusing before the write means an invalid config cannot destroy a good one. (It does not make the write atomic; that is #307.)

**`overlap` now has to be finite.** `validate_defaults` used `overlap < 0.0`, the hand-rolled comparison `validate_range_filter` warns against a hundred lines below it in the same file. `NaN < 0.0` is false, so NaN was accepted, and `(NaN * sample_rate) as usize` saturates to 0, discarding the setting with no message. That is the reported bug's signature exactly.

## Verification

Against the built binary, not only the suite. With `range_threshold = nan` seeded into an isolated config:

```
$ birda recording.wav
error: invalid range threshold: NaN (must be 0.0 to 1.0)     exit 1

$ birda models list / models check / clip / update --check / config show / birda      all exit 0

$ birda config set defaults.range_threshold 0.03             exit 0, repairs it
$ birda config set defaults.latitude 200
error: invalid latitude: 200 (must be -90.0 to 90.0)         exit 1, file byte-identical
```

`overlap = nan` and `overlap = inf` are now rejected where both previously ran.

458 tests across 18 suites, `cargo fmt --check` and `cargo clippy -- -D warnings` clean, no new warnings under `--all-targets` (which the repo does not yet enforce, #292), MSRV 1.92 builds with `--all-targets`.

Every behaviour is mutation-tested: disabling the load gate fails exactly the three rejection tests, halving it to `validate_range_filter` fails the overlap test, breaking `models list` fails two exemption tests, silencing `print_smart_help` fails the help test, and removing the save-path check fails four. The valid-config controls stay green throughout.

## Known behaviour changes

**A value is rejected even when the run overrides it.** `birda -c 0.5 recording.wav` fails on an out-of-range `min_confidence` in the file. Rejecting a value the file should not contain is what `config set` has always done.

**`config set` cannot repair a file with two independent faults**, since each write is rejected by the other. That predates this change and `main` has it too; it is documented in the README and filed as #305. The gate is scoped to analysis partly so this stays a limitation rather than becoming a lockout.

Release-note text is on #289.

## Review

Six review agents plus an independent Gemini pass over three rounds, each round reviewing the previous round's fixes. The first draft gated every subcommand and was wrong in ways the tests could not see, since it did exactly what I intended: it blocked `birda update`, the route to a build that would fix config handling, and blocked `models install`, the repair for the fault it was reporting. The integration test would also have overwritten a Windows developer's real `config.toml`, because `HOME` and `XDG_*` do not redirect `directories` there.

Filed rather than fixed, each too invasive for the severity it earned: #305 (`config set` multi-fault repair), #306 (`--overlap`/`BIRDA_OVERLAP` carry no value parser, plus the missing upper bound), #307 (non-atomic config write). Findings also added to #289, #290 and #297.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid configuration values are now rejected before analysis or configuration writes.
  - Non-finite overlap values, such as `NaN` and infinity, are correctly rejected.
  - Rejected configuration updates leave existing files unchanged.
  - Diagnostic and repair commands remain available even when configuration is invalid.

- **Documentation**
  - Updated configuration validation guidance and command examples.
  - Corrected examples for output formats, bat detection, and organized workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->