### PR TITLE
fix: write config.toml atomically, and validate --overlap like every sibling option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,15 @@ self-replace = "1"
 flate2 = "1"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
+# Promoted from dev-dependencies for the atomic config write in
+# `config::file::save_config`. Already in the tree either way, so this adds no
+# new crate to the dependency graph.
+tempfile = "3"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
-tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 serial_test = "3"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Options:
   -o, --output-dir <DIR>        Output directory (default: same as input)
   -c, --min-confidence <VALUE>  Minimum confidence threshold (0.0-1.0)
   -b, --batch-size <SIZE>       Inference batch size
-      --overlap <SECONDS>       Segment overlap in seconds
+      --overlap <SECONDS>       Segment overlap in seconds (finite, non-negative)
       --bat <REGION>            Enable bat detection with a regional classifier
       --gpu                     Enable CUDA GPU acceleration
       --cpu                     Force CPU inference
@@ -366,6 +366,8 @@ combined_prefix = "BirdNET"
 
 An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
 
+The same rules apply to the command-line flag and the environment variable for each of those settings, not just to the file. `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, so all three reject a negative, NaN or infinite value; previously only the file did, and the other two silently became zero overlap.
+
 ```text
 $ birda recording.wav
 error: invalid latitude: 200 (must be -90.0 to 90.0)
@@ -385,6 +387,14 @@ One limitation worth knowing: `config set` validates the whole file before savin
 
 Writing is validated too. `config init`, `config set` and the `models` commands all refuse to save a configuration that would not load, and they refuse before touching the file, so a rejected write leaves the existing configuration intact.
 
+Writes are also atomic. The new configuration goes to a temporary file beside `config.toml` and is renamed over it, so an interrupted write cannot leave a truncated file. That matters because a truncated `config.toml` still parses: an empty file is valid TOML and loads as all-defaults, which would silently drop every model you had configured. Three consequences:
+
+- A `config.toml` that is a **symlink** is followed, and the file it points at is the one rewritten, so keeping it in a dotfiles repository works.
+- A `config.toml` that is a **hardlink** is not, because a rename gives the path a new inode. The other name keeps the old contents and stops tracking.
+- If you run birda in a container, bind-mount the config **directory** rather than the `config.toml` file itself. Renaming over a bind-mounted file fails with `EBUSY`.
+
+A configuration file birda creates for the first time is readable only by you (mode 0600 on Unix). An existing file keeps whatever mode you gave it.
+
 ### Environment Variables
 
 All options can be set via environment variables:
@@ -397,7 +407,7 @@ All options can be set via environment variables:
 | `BIRDA_FORMAT` | Output formats (comma-separated) |
 | `BIRDA_OUTPUT_DIR` | Output directory |
 | `BIRDA_MIN_CONFIDENCE` | Minimum confidence threshold |
-| `BIRDA_OVERLAP` | Segment overlap in seconds |
+| `BIRDA_OVERLAP` | Segment overlap in seconds (finite, non-negative) |
 | `BIRDA_BATCH_SIZE` | Inference batch size |
 | `BIRDA_OUTPUT_MODE` | CLI output mode (human, json, ndjson) |
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ combined_prefix = "BirdNET"
 
 An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
 
-The same rules apply to the command-line flag and the environment variable for each of those settings, not just to the file. `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, so all three reject a negative, NaN or infinite value; previously only the file did, and the other two silently became zero overlap.
+For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude` and `longitude` agree across their routes too.
 
 ```text
 $ birda recording.wav
@@ -389,7 +389,7 @@ Writing is validated too. `config init`, `config set` and the `models` commands 
 
 Writes are also atomic. The new configuration goes to a temporary file beside `config.toml` and is renamed over it, so an interrupted write cannot leave a truncated file. That matters because a truncated `config.toml` still parses: an empty file is valid TOML and loads as all-defaults, which would silently drop every model you had configured. Three consequences:
 
-- A `config.toml` that is a **symlink** is followed, and the file it points at is the one rewritten, so keeping it in a dotfiles repository works.
+- A `config.toml` that is a **symlink** is followed, and the file it points at is the one rewritten, so keeping it in a dotfiles repository works. This holds whether or not the target exists yet, so you can create the link first and let birda create the file.
 - A `config.toml` that is a **hardlink** is not, because a rename gives the path a new inode. The other name keeps the old contents and stops tracking.
 - If you run birda in a container, bind-mount the config **directory** rather than the `config.toml` file itself. Renaming over a bind-mounted file fails with `EBUSY`.
 

--- a/docs/windows-guide.md
+++ b/docs/windows-guide.md
@@ -285,7 +285,7 @@ birda [OPTIONS] <FILES>
   -o, --output-dir <DIR>    # Output directory
   -c, --min-confidence <N>  # Confidence threshold (0.0-1.0)
   -b, --batch-size <N>      # Inference batch size
-      --overlap <SEC>       # Segment overlap in seconds
+      --overlap <SEC>       # Segment overlap in seconds (finite, non-negative)
       --combine             # Generate combined results file
       --force               # Reprocess existing files
       --fail-fast           # Stop on first error

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -270,8 +270,15 @@ pub struct AnalyzeArgs {
     /// `allow_hyphen_values` so a negative value reaches the parser and gets
     /// the real diagnostic. Without it clap reads the leading `-` as the start
     /// of another flag and reports "a value is required", which is a usage
-    /// error about the wrong thing. `--lat` and `--lon` carry it for the same
-    /// reason.
+    /// error about the wrong thing.
+    ///
+    /// `--lat` and `--lon` carry the same attribute for a stronger reason, not
+    /// the same one: a negative coordinate is *valid input*, so without it
+    /// every southern and western hemisphere position is unreachable. Here a
+    /// negative overlap is invalid either way and only the message improves.
+    /// The cost, shared with those two, is that `--overlap --cpu file.wav`
+    /// consumes `--cpu` as the value and reports that it is not a number
+    /// rather than that no value was supplied.
     #[arg(long, allow_hyphen_values = true, value_parser = parse_overlap, env = "BIRDA_OVERLAP")]
     pub overlap: Option<f32>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -266,7 +266,13 @@ pub struct AnalyzeArgs {
     pub min_confidence: Option<f32>,
 
     /// Segment overlap in seconds.
-    #[arg(long, env = "BIRDA_OVERLAP")]
+    ///
+    /// `allow_hyphen_values` so a negative value reaches the parser and gets
+    /// the real diagnostic. Without it clap reads the leading `-` as the start
+    /// of another flag and reports "a value is required", which is a usage
+    /// error about the wrong thing. `--lat` and `--lon` carry it for the same
+    /// reason.
+    #[arg(long, allow_hyphen_values = true, value_parser = parse_overlap, env = "BIRDA_OVERLAP")]
     pub overlap: Option<f32>,
 
     /// Inference batch size (must be at least 1).
@@ -451,7 +457,9 @@ impl AnalyzeArgs {
 }
 
 // Re-use shared validators
-use super::validators::{parse_batch_size, parse_confidence, parse_latitude, parse_longitude};
+use super::validators::{
+    parse_batch_size, parse_confidence, parse_latitude, parse_longitude, parse_overlap,
+};
 
 #[cfg(test)]
 // Test setup code: panicking on an unexpected parse shape is how these assert.

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -51,6 +51,46 @@ pub fn parse_longitude(s: &str) -> Result<f64, String> {
     parse_bounded_float(s, -180.0, 180.0, "longitude")
 }
 
+/// Parse and validate segment overlap in seconds (finite and non-negative).
+///
+/// The rule is deliberately identical to the config-file one in
+/// `validate_defaults`, wording included, because the two are the same setting
+/// reached by different routes: `--overlap` and `BIRDA_OVERLAP` both win over
+/// `defaults.overlap`, so a rule enforced on the file alone left the channels
+/// disagreeing. `overlap = -1` in config.toml was a hard error while
+/// `BIRDA_OVERLAP=-1` was accepted.
+///
+/// What each rejected value used to do, since none of them failed loudly:
+///
+/// - NaN and a negative value were both silently ignored. `overlap *
+///   sample_rate` is cast to `usize`, and Rust saturates that cast rather than
+///   trapping, so both became 0 and the run produced non-overlapping segments
+///   without a word.
+/// - Infinity changed the result instead. The same cast sends it to
+///   `usize::MAX`, `chunk_samples.saturating_sub(overlap_samples)` gives a step
+///   of 0, and the run yields no segments at all: exit 0, empty output.
+///
+/// No upper bound is imposed, matching the config side. An oversized but finite
+/// overlap is rejected by `AudioDecoder::next_segment`, which is the only place
+/// that knows the segment length to compare against.
+pub fn parse_overlap(s: &str) -> Result<f32, String> {
+    let value: f32 = s
+        .trim()
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+
+    // `is_finite` is what catches NaN, and it has to be spelled this way round:
+    // a bare `value < 0.0` test is false for NaN, which is exactly how NaN got
+    // through before.
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!(
+            "overlap must be a finite non-negative number, got {value}"
+        ));
+    }
+
+    Ok(value)
+}
+
 /// Parse and validate batch size (must be between 1 and `MAX_BATCH_SIZE`).
 pub fn parse_batch_size(s: &str) -> Result<usize, String> {
     let value: usize = s
@@ -120,6 +160,74 @@ mod tests {
         let err = parse_bounded_float("abc", -100.0, 100.0, "test");
         assert!(err.is_err());
         assert!(err.unwrap_err().contains("not a valid number"));
+    }
+
+    #[test]
+    fn test_parse_overlap_valid() {
+        assert_eq!(parse_overlap("0").ok(), Some(0.0));
+        assert_eq!(parse_overlap("1.5").ok(), Some(1.5));
+        // No upper bound here on purpose; an oversized but finite overlap is
+        // caught against the segment length in `AudioDecoder::next_segment`.
+        assert_eq!(parse_overlap("1e15").ok(), Some(1e15));
+    }
+
+    #[test]
+    fn test_parse_overlap_rejects_negative() {
+        let err = parse_overlap("-1").unwrap_err();
+        assert!(err.contains("finite non-negative"), "got: {err}");
+        assert!(err.contains("-1"), "the error should name the value: {err}");
+    }
+
+    #[test]
+    fn test_parse_overlap_rejects_nan() {
+        // The case a hand-rolled `value < 0.0` test lets through, since every
+        // NaN comparison is false. It was silently coerced to zero overlap.
+        assert!(parse_overlap("nan").is_err());
+        assert!(parse_overlap("NaN").is_err());
+        assert!(parse_overlap("-nan").is_err());
+    }
+
+    #[test]
+    fn test_parse_overlap_rejects_infinity() {
+        // `f32::from_str` accepts all four spellings, and each one used to make
+        // the run produce no segments at all.
+        assert!(parse_overlap("inf").is_err());
+        assert!(parse_overlap("infinity").is_err());
+        assert!(parse_overlap("-inf").is_err());
+        assert!(parse_overlap("1e40").is_err());
+    }
+
+    #[test]
+    fn test_parse_overlap_rejects_non_numbers() {
+        let err = parse_overlap("abc").unwrap_err();
+        assert!(err.contains("not a valid number"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_overlap_with_whitespace() {
+        // Environment variables pick up stray whitespace easily, and
+        // `BIRDA_OVERLAP` is one of the two channels this parser exists for.
+        assert_eq!(parse_overlap(" 1.5 ").ok(), Some(1.5));
+    }
+
+    #[test]
+    fn test_parse_overlap_matches_the_config_file_rule() {
+        // The whole point of #306: the flag, the environment variable and
+        // config.toml must agree. This pins the CLI half against the same
+        // inputs `validate_defaults` rules on, so the two cannot drift apart
+        // without a test failing.
+        for accepted in ["0", "0.0", "1.5"] {
+            assert!(
+                parse_overlap(accepted).is_ok(),
+                "{accepted} is accepted by validate_defaults and must be accepted here"
+            );
+        }
+        for rejected in ["-1", "nan", "inf"] {
+            assert!(
+                parse_overlap(rejected).is_err(),
+                "{rejected} is rejected by validate_defaults and must be rejected here"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -6,7 +6,16 @@ use crate::constants::MAX_BATCH_SIZE;
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
+    // Trimmed for the same reason `parse_batch_size` and `parse_overlap` trim:
+    // every one of these is reachable through a `BIRDA_*` environment variable,
+    // and a value that picked up a space in a shell profile or a Docker env
+    // file should not be a hard error. Without this the crate had two spellings
+    // of the same rule, so `BIRDA_OVERLAP=" 1.5 "` worked while
+    // `BIRDA_MIN_CONFIDENCE=" 0.5 "` failed, from options a user sets side by
+    // side. Trimming only widens what is accepted; it cannot change the value a
+    // legal input parses to.
     let value: f32 = s
+        .trim()
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
@@ -28,7 +37,10 @@ pub fn parse_confidence(s: &str) -> Result<f32, String> {
 /// * `max` - Maximum allowed value (inclusive)
 /// * `name` - Name of the parameter for error messages
 pub fn parse_bounded_float(s: &str, min: f64, max: f64, name: &str) -> Result<f64, String> {
+    // Trimmed; see `parse_confidence`. This one backs `--lat`/`BIRDA_LATITUDE`
+    // and `--lon`/`BIRDA_LONGITUDE`.
     let value: f64 = s
+        .trim()
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
@@ -114,7 +126,7 @@ pub fn parse_batch_size(s: &str) -> Result<usize, String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 
@@ -182,19 +194,33 @@ mod tests {
     fn test_parse_overlap_rejects_nan() {
         // The case a hand-rolled `value < 0.0` test lets through, since every
         // NaN comparison is false. It was silently coerced to zero overlap.
-        assert!(parse_overlap("nan").is_err());
-        assert!(parse_overlap("NaN").is_err());
-        assert!(parse_overlap("-nan").is_err());
+        //
+        // The message is asserted, not just `is_err()`. `f32::from_str` accepts
+        // all of these, so a bare `is_err()` would also pass if they fell into
+        // the "not a valid number" branch instead, and which branch catches
+        // them is exactly the claim the shared wording rests on.
+        for input in ["nan", "NaN", "-nan"] {
+            let err = parse_overlap(input).unwrap_err();
+            assert!(
+                err.contains("finite non-negative"),
+                "'{input}' must be rejected as non-finite, got: {err}"
+            );
+        }
     }
 
     #[test]
     fn test_parse_overlap_rejects_infinity() {
         // `f32::from_str` accepts all four spellings, and each one used to make
-        // the run produce no segments at all.
-        assert!(parse_overlap("inf").is_err());
-        assert!(parse_overlap("infinity").is_err());
-        assert!(parse_overlap("-inf").is_err());
-        assert!(parse_overlap("1e40").is_err());
+        // the run produce no segments at all. `1e40` is the interesting one: it
+        // is written as a finite literal and overflows to infinity on the way
+        // into an f32.
+        for input in ["inf", "infinity", "-inf", "1e40"] {
+            let err = parse_overlap(input).unwrap_err();
+            assert!(
+                err.contains("finite non-negative"),
+                "'{input}' must be rejected as non-finite, got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -204,28 +230,49 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_overlap_with_whitespace() {
-        // Environment variables pick up stray whitespace easily, and
-        // `BIRDA_OVERLAP` is one of the two channels this parser exists for.
+    fn test_env_backed_validators_all_tolerate_whitespace() {
+        // Environment variables pick up stray whitespace easily, and every one
+        // of these is reachable through a `BIRDA_*` variable. Asserted across
+        // all four together rather than for overlap alone, because the failure
+        // this pins is the crate holding two spellings of one rule: for a while
+        // `BIRDA_OVERLAP=" 1.5 "` was accepted and `BIRDA_LATITUDE=" 60.1 "`
+        // was not.
         assert_eq!(parse_overlap(" 1.5 ").ok(), Some(1.5));
+        assert_eq!(parse_confidence(" 0.5 ").ok(), Some(0.5));
+        assert_eq!(parse_latitude(" 60.17 ").ok(), Some(60.17));
+        assert_eq!(parse_longitude(" 24.94 ").ok(), Some(24.94));
+        assert_eq!(parse_batch_size(" 32 ").ok(), Some(32));
     }
 
     #[test]
     fn test_parse_overlap_matches_the_config_file_rule() {
         // The whole point of #306: the flag, the environment variable and
-        // config.toml must agree. This pins the CLI half against the same
-        // inputs `validate_defaults` rules on, so the two cannot drift apart
-        // without a test failing.
-        for accepted in ["0", "0.0", "1.5"] {
-            assert!(
-                parse_overlap(accepted).is_ok(),
-                "{accepted} is accepted by validate_defaults and must be accepted here"
-            );
-        }
-        for rejected in ["-1", "nan", "inf"] {
-            assert!(
-                parse_overlap(rejected).is_err(),
-                "{rejected} is rejected by validate_defaults and must be rejected here"
+        // config.toml must agree.
+        //
+        // This drives BOTH rules and compares their verdicts, rather than
+        // asserting `parse_overlap` against a list of inputs a comment claims
+        // `validate_defaults` agrees on. The list version was the shape this
+        // test had first, and it did not work: giving `validate_defaults` an
+        // upper bound the CLI does not have left every config test green, so
+        // the guard the doc comments on both sides advertise was not a guard at
+        // all. Comparing verdicts means the two cannot diverge on any input
+        // here without this failing, whichever side moves.
+        for input in [
+            "0", "0.0", "1.5", "1e15", // accepted by both
+            "-1", "nan", "inf", "-inf", "1e40", // rejected by both
+        ] {
+            let cli = parse_overlap(input);
+
+            let mut config = crate::config::Config::default();
+            config.defaults.overlap = input.trim().parse().expect("input must parse as f32");
+            let file = crate::config::validate_config(&config);
+
+            assert_eq!(
+                cli.is_ok(),
+                file.is_ok(),
+                "'{input}': the flag says {}, config.toml says {}. The two rules must agree.",
+                if cli.is_ok() { "ok" } else { "rejected" },
+                if file.is_ok() { "ok" } else { "rejected" },
             );
         }
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -2,6 +2,7 @@
 
 use crate::config::Config;
 use crate::error::{Error, Result};
+use std::io::Write;
 use std::path::Path;
 
 /// Load configuration from a TOML file.
@@ -58,38 +59,153 @@ pub fn load_default_config() -> Result<Config> {
     super::config_file_path().map_or_else(|_| Ok(Config::default()), |path| load_config_file(&path))
 }
 
-/// Save configuration to a TOML file.
+/// Wrap an I/O failure as a config write error naming the target path.
+fn write_error(path: &Path, source: std::io::Error) -> Error {
+    Error::ConfigWrite {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+/// Save configuration to a TOML file, atomically.
 ///
 /// The configuration is validated first, so no writer can persist a value that
 /// `config set` would have rejected. Several callers build a config by mutating
 /// a loaded one (`models add`, `models install`, `models remove`, the geomodel
 /// install) and reached this function without validating.
 ///
-/// Validating before the write also matters because this function truncates and
-/// rewrites the whole file: refusing early means an invalid config cannot
-/// destroy a good one on disk. That covers the validation failure mode only.
-/// The write itself is not atomic, so an interrupted or short write can still
-/// leave a truncated config.toml, which parses as all-defaults and loses every
-/// configured model.
+/// The write itself goes to a temporary file beside the target, which is then
+/// renamed over it. Both halves matter and they cover different failure modes.
+/// Validating first stops an invalid config destroying a good one on disk;
+/// replacing by rename stops an *interrupted* write doing the same.
+///
+/// The second one is why this is not a plain `fs::write`. That call truncates
+/// the file and then writes, so ENOSPC, SIGKILL or power loss in between leaves
+/// a zero-length or partial config.toml. A truncated config is not a loud
+/// failure: an empty file is valid TOML, deserialises to `Config::default()`,
+/// and the user silently loses every `[models.*]` block, their default model
+/// and their geomodel paths, with no error at any point. A rename is atomic
+/// within a filesystem, so a reader sees either the whole old file or the whole
+/// new one.
+///
+/// Two consequences of replacing rather than rewriting in place. The temporary
+/// must live in the target's directory, because rename across filesystems is
+/// not atomic (and `$TMPDIR` is routinely a different one), so it is created
+/// there and cleaned up on every path out. And the resulting file takes its
+/// permissions from the temporary rather than from the file it replaced, so an
+/// existing mode is copied across explicitly; see [`preserve_existing_mode`].
+///
+/// Still not addressed: the whole file is re-serialised from the struct, so
+/// comments and unrecognised keys are dropped as they always were.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
     super::validate_config(config)?;
 
-    // Create parent directories if they don't exist
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| Error::ConfigWrite {
-            path: path.to_path_buf(),
-            source: e,
-        })?;
-    }
+    // Rename replaces the name it is given, where a write follows it. A user
+    // whose config.toml is a symlink into a dotfiles repository would have the
+    // link replaced by a regular file and their real config left stale, so the
+    // link is resolved first and the write lands on the file it points at.
+    let target = resolve_link(path);
+    let target = target.as_path();
+
+    // `parent` is empty for a bare relative filename like `config.toml`, which
+    // is a valid path to save to and not the same thing as having no parent.
+    let dir = target
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(dir).map_err(|e| write_error(target, e))?;
 
     let contents =
         toml::to_string_pretty(config).map_err(|e| Error::ConfigSerialize { source: e })?;
 
-    std::fs::write(path, contents).map_err(|e| Error::ConfigWrite {
-        path: path.to_path_buf(),
-        source: e,
-    })
+    let mut temp = tempfile::NamedTempFile::new_in(dir).map_err(|e| write_error(target, e))?;
+    temp.write_all(contents.as_bytes())
+        .map_err(|e| write_error(target, e))?;
+
+    // Flush to disk before the rename, not after. Without this the rename can
+    // reach the disk while the data behind it has not, which on a crash leaves
+    // the config path pointing at a file of zeros: exactly the outcome the
+    // rename is here to prevent, just reached by a different route.
+    temp.as_file()
+        .sync_all()
+        .map_err(|e| write_error(target, e))?;
+
+    preserve_existing_mode(target, &temp)?;
+
+    // Drops the temporary on failure, so a rejected save leaves nothing behind.
+    temp.persist(target)
+        .map_err(|e| write_error(target, e.error))?;
+
+    sync_directory(dir);
+
+    Ok(())
 }
+
+/// The real file `path` names, following it if it is a symlink.
+///
+/// Falls back to `path` unchanged whenever it cannot be resolved, which is the
+/// ordinary case of saving a config that does not exist yet. `canonicalize`
+/// also flattens `.`, `..` and any symlinked parent directory, which is
+/// harmless here: every use of the result is relative to the file itself.
+fn resolve_link(path: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Give the temporary the mode of the file it is about to replace.
+///
+/// `NamedTempFile` creates at 0600, so without this the first save after this
+/// change would silently narrow a config the user had deliberately made
+/// readable to others. A file that does not exist yet has no mode to carry
+/// over and keeps the restrictive default, which is the right direction for a
+/// per-user config directory and is what a fresh install now gets.
+///
+/// A `metadata` failure other than "not found" is not fatal. It means the mode
+/// cannot be read, not that the save cannot proceed, and refusing to write the
+/// user's config over it would trade a cosmetic difference for a lost setting.
+/// The fallback is the restrictive mode, so the failure direction is safe.
+#[cfg(unix)]
+fn preserve_existing_mode(target: &Path, temp: &tempfile::NamedTempFile) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(existing) = std::fs::metadata(target) else {
+        return Ok(());
+    };
+
+    let mode = existing.permissions().mode() & 0o777;
+    temp.as_file()
+        .set_permissions(std::fs::Permissions::from_mode(mode))
+        .map_err(|e| write_error(target, e))
+}
+
+/// No-op on platforms without Unix permission bits.
+///
+/// Windows carries an ACL rather than a mode, and `MoveFileEx` preserves the
+/// ACL of the file being moved rather than of the one being replaced, so there
+/// is nothing to copy across by hand.
+#[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
+fn preserve_existing_mode(_target: &Path, _temp: &tempfile::NamedTempFile) -> Result<()> {
+    Ok(())
+}
+
+/// Flush the directory entry the rename created.
+///
+/// Best effort, deliberately. The rename is already atomic as far as any reader
+/// is concerned; this only decides whether the *new* name or the old one
+/// survives a power loss, and both are whole, valid configs. Some filesystems
+/// reject `fsync` on a directory outright, so failing a save that has already
+/// completed would cost the user a setting to buy durability that was never
+/// required for correctness.
+#[cfg(unix)]
+fn sync_directory(dir: &Path) {
+    if let Ok(handle) = std::fs::File::open(dir) {
+        drop(handle.sync_all());
+    }
+}
+
+/// No-op on platforms where a directory is not an openable file.
+#[cfg(not(unix))]
+fn sync_directory(_dir: &Path) {}
 
 /// Save configuration to the default platform-specific path.
 ///
@@ -208,6 +324,189 @@ min_confidence = 0.25
         assert_eq!(
             load_config_file(&path).unwrap().defaults.min_confidence,
             0.25
+        );
+    }
+
+    /// Every entry beside `path` that the caller did not expect to be there.
+    ///
+    /// A leaked temporary would sit next to the real config, which is both
+    /// litter in the user's config directory and, on the failure paths,
+    /// evidence that a partially written file survived. Stated as "anything
+    /// unexpected" rather than "anything matching the temp-file prefix", so it
+    /// still catches a leak if `tempfile` ever changes how it names them.
+    fn strays_beside(path: &Path, expected: &[&str]) -> Vec<String> {
+        std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| !expected.contains(&name.as_str()))
+            .collect()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_save_config_replaces_the_file_by_rename() {
+        // The atomicity guard (#307), and the only one that can fail
+        // deterministically without simulating a crash.
+        //
+        // A hardlink is a second name for the same inode. `fs::write` truncates
+        // and rewrites in place, so the link would show the new contents; a
+        // write to a sibling temp file followed by `rename` gives the config
+        // path a *different* inode, leaving the old one intact behind the link.
+        // Reading the old contents back through the link is therefore proof
+        // that the target was never truncated, which is what makes an
+        // interrupted write survivable: the reader either sees the whole old
+        // file or the whole new one, never a zero-length file that parses as
+        // all-defaults and silently drops every configured model.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let mut before = Config::default();
+        before.defaults.min_confidence = 0.25;
+        save_config(&before, &path).unwrap();
+
+        let link = dir.path().join("config.toml.link");
+        std::fs::hard_link(&path, &link).unwrap();
+
+        let mut after = Config::default();
+        after.defaults.min_confidence = 0.75;
+        save_config(&after, &path).unwrap();
+
+        assert_eq!(
+            load_config_file(&link).unwrap().defaults.min_confidence,
+            0.25,
+            "the previous file must survive untouched behind its own name; \
+             seeing 0.75 here means the config path was truncated in place \
+             rather than replaced by a rename"
+        );
+        assert_eq!(
+            load_config_file(&path).unwrap().defaults.min_confidence,
+            0.75,
+            "the config path must carry the new contents"
+        );
+    }
+
+    #[test]
+    fn test_save_config_leaves_no_temporary_file_behind() {
+        // The temporary has to be created beside the target, because `rename`
+        // is only atomic within a filesystem and $TMPDIR is routinely a
+        // different one. That puts it in the user's config directory, so a
+        // successful save must clean up after itself.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        save_config(&Config::default(), &path).unwrap();
+
+        assert!(
+            strays_beside(&path, &["config.toml"]).is_empty(),
+            "a successful save must not litter the config directory, found: {:?}",
+            strays_beside(&path, &["config.toml"])
+        );
+    }
+
+    #[test]
+    fn test_a_rejected_save_leaves_no_temporary_file_behind() {
+        // The failure path of the same concern. Validation runs before the
+        // temporary is created, so there is nothing to clean up here; the test
+        // exists so a later reordering that validates *after* writing cannot
+        // pass silently.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        assert!(save_config(&invalid_config(), &path).is_err());
+
+        assert!(
+            strays_beside(&path, &[]).is_empty(),
+            "a rejected save must not leave a partial file behind, found: {:?}",
+            strays_beside(&path, &[])
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_save_config_preserves_the_file_mode() {
+        // Replacing by rename means the new file's permissions come from the
+        // temporary, not from the file being replaced, so a rewrite would
+        // silently reset whatever mode the user had chosen. `NamedTempFile`
+        // creates at 0600, so without this the first `config set` after the
+        // upgrade would quietly narrow a shared 0644 config.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        save_config(&Config::default(), &path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let mut changed = Config::default();
+        changed.defaults.min_confidence = 0.5;
+        save_config(&changed, &path).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "a rewrite must keep the mode the user set"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_a_new_config_is_created_private() {
+        // The other half of the rule above. There is no previous mode to carry
+        // over for a file that does not exist yet, and a config directory is
+        // per-user, so the restrictive default `NamedTempFile` gives is kept
+        // rather than widened to match what `fs::write` used to produce.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        save_config(&Config::default(), &path).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o077,
+            0,
+            "a newly created config must not be group or world accessible"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_save_config_writes_through_a_symlinked_config() {
+        // The one behaviour a rename changes for the worse if left alone.
+        // `fs::write` follows a symlink; `rename` replaces it. Keeping a
+        // config.toml symlinked into a dotfiles repository is common enough
+        // that silently swapping the link for a regular file, and leaving the
+        // real file stale, would be a regression traded for the atomicity.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("dotfiles.toml");
+        let link_dir = dir.path().join("config");
+        std::fs::create_dir(&link_dir).unwrap();
+        let link = link_dir.join("config.toml");
+
+        save_config(&Config::default(), &real).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let mut changed = Config::default();
+        changed.defaults.min_confidence = 0.42;
+        save_config(&changed, &link).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive the save rather than be replaced by a file"
+        );
+        assert_eq!(
+            load_config_file(&real).unwrap().defaults.min_confidence,
+            0.42,
+            "the write must land on the file the link points at"
+        );
+        let expected = ["dotfiles.toml", "config"];
+        assert!(
+            strays_beside(&real, &expected).is_empty(),
+            "the temporary belongs beside the resolved file, and must be gone, found: {:?}",
+            strays_beside(&real, &expected)
         );
     }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -90,13 +90,20 @@ fn write_error(path: &Path, source: std::io::Error) -> Error {
 ///
 /// Two consequences of replacing rather than rewriting in place. The temporary
 /// must live in the target's directory, because rename across filesystems is
-/// not atomic (and `$TMPDIR` is routinely a different one), so it is created
-/// there and cleaned up on every path out. And the resulting file takes its
-/// permissions from the temporary rather than from the file it replaced, so an
-/// existing mode is copied across explicitly; see [`preserve_existing_mode`].
+/// not atomic (and `$TMPDIR` is routinely a different one), so it is created in
+/// the user's config directory and removed on every return path, success or
+/// failure. Not on every path out, though: the Ctrl+C handler installed in
+/// `run()` ends the process with `std::process::exit`, which runs no
+/// destructors, so interrupting a save can leave one `.tmp` file behind.
+/// And the resulting file takes its permissions from the temporary rather than
+/// from the file it replaced, so an existing mode is copied across explicitly;
+/// see [`preserve_existing_mode`].
 ///
-/// Still not addressed: the whole file is re-serialised from the struct, so
-/// comments and unrecognised keys are dropped as they always were.
+/// Two things this deliberately does not address. The whole file is
+/// re-serialised from the struct, so comments and unrecognised keys are dropped
+/// as they always were. And every caller is a lock-free load-mutate-save, so
+/// two concurrent saves still lose one of the two edits; the rename makes each
+/// write whole, not the pair of them serialised.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
     super::validate_config(config)?;
 
@@ -113,28 +120,44 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(dir).map_err(|e| write_error(target, e))?;
+    std::fs::create_dir_all(dir).map_err(|e| write_error(path, e))?;
 
     let contents =
         toml::to_string_pretty(config).map_err(|e| Error::ConfigSerialize { source: e })?;
 
-    let mut temp = tempfile::NamedTempFile::new_in(dir).map_err(|e| write_error(target, e))?;
+    // Worth knowing when this one fails: creating the temporary needs write and
+    // execute on the DIRECTORY, which a plain write never needed, so a config
+    // file the user can plainly write can now fail to save. The message names
+    // the config file like every other failure here, and the cause carries the
+    // detail, because the io::Error already names the temporary and so the
+    // directory with it.
+    let mut temp = tempfile::NamedTempFile::new_in(dir).map_err(|e| write_error(path, e))?;
     temp.write_all(contents.as_bytes())
-        .map_err(|e| write_error(target, e))?;
+        .map_err(|e| write_error(path, e))?;
+
+    // Mode first, then flush. `sync_all` persists the inode's metadata as well
+    // as its data, so widening the permissions afterwards would leave that one
+    // change unflushed and a crash could publish the file still at the
+    // temporary's private 0600. Writing the contents while it is still 0600 and
+    // widening only at the end is also the right order for a file that may hold
+    // something worth protecting.
+    preserve_existing_mode(target, &temp).map_err(|e| write_error(path, e))?;
 
     // Flush to disk before the rename, not after. Without this the rename can
     // reach the disk while the data behind it has not, which on a crash leaves
     // the config path pointing at a file of zeros: exactly the outcome the
     // rename is here to prevent, just reached by a different route.
+    //
+    // Untested, and untestable from here: deleting this line, or the directory
+    // fsync below, leaves the whole suite green, because the difference only
+    // shows up across a crash. Both are reasoned, not covered.
     temp.as_file()
         .sync_all()
-        .map_err(|e| write_error(target, e))?;
-
-    preserve_existing_mode(target, &temp)?;
+        .map_err(|e| write_error(path, e))?;
 
     // Drops the temporary on failure, so a rejected save leaves nothing behind.
     temp.persist(target)
-        .map_err(|e| write_error(target, e.error))?;
+        .map_err(|e| write_error(path, e.error))?;
 
     sync_directory(dir);
 
@@ -143,12 +166,52 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
 
 /// The real file `path` names, following it if it is a symlink.
 ///
-/// Falls back to `path` unchanged whenever it cannot be resolved, which is the
-/// ordinary case of saving a config that does not exist yet. `canonicalize`
-/// also flattens `.`, `..` and any symlinked parent directory, which is
-/// harmless here: every use of the result is relative to the file itself.
+/// `canonicalize` alone is not enough, and the gap is the case this function
+/// exists for. It requires every component INCLUDING the last to exist, so a
+/// symlink whose target has not been created yet fails with `NotFound`. Falling
+/// back to the unresolved path there would hand `persist` the link itself and
+/// the rename would replace it with a regular file, which is precisely the
+/// regression following the link is meant to prevent. It is also the ordinary
+/// bootstrap order: link config.toml into a dotfiles repository first, run
+/// birda second. `fs::write` handled it correctly, because `O_CREAT` follows a
+/// dangling link and creates the target.
+///
+/// So a failed `canonicalize` falls back to reading the link by hand. Only the
+/// link's own parent has to exist for that to give a usable path; if it does
+/// not, or `path` is simply a file that does not exist yet, `path` is returned
+/// unchanged, which is correct for both.
+///
+/// One hop, not a loop. A chain of dangling symlinks is not worth the cycle
+/// detection it would need, and stopping after one hop degrades to the old
+/// fallback rather than to anything worse.
 fn resolve_link(path: &Path) -> std::path::PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    if let Ok(resolved) = std::fs::canonicalize(path) {
+        return resolved;
+    }
+
+    let Ok(link_target) = std::fs::read_link(path) else {
+        return path.to_path_buf();
+    };
+
+    // A relative link resolves against the directory holding the link, not the
+    // process's working directory.
+    let target = if link_target.is_absolute() {
+        link_target
+    } else {
+        path.parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(link_target)
+    };
+
+    // The temporary is created in the target's directory, so that directory has
+    // to exist for the write to be possible at all. When it does not, the
+    // unresolved path is the better answer: it at least keeps the failure in
+    // the directory the user named.
+    if target.parent().is_some_and(Path::exists) {
+        target
+    } else {
+        path.to_path_buf()
+    }
 }
 
 /// Give the temporary the mode of the file it is about to replace.
@@ -164,27 +227,38 @@ fn resolve_link(path: &Path) -> std::path::PathBuf {
 /// user's config over it would trade a cosmetic difference for a lost setting.
 /// The fallback is the restrictive mode, so the failure direction is safe.
 #[cfg(unix)]
-fn preserve_existing_mode(target: &Path, temp: &tempfile::NamedTempFile) -> Result<()> {
+fn preserve_existing_mode(target: &Path, temp: &tempfile::NamedTempFile) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let Ok(existing) = std::fs::metadata(target) else {
         return Ok(());
     };
 
-    let mode = existing.permissions().mode() & 0o777;
+    // `0o7777`, not `0o777`: the mask exists to strip the file-type bits, and a
+    // narrower one would silently drop setuid, setgid and the sticky bit from a
+    // mode the user chose. None of the three is meaningful on a config file,
+    // which is the point: dropping them would be an unannounced change to
+    // something this function claims to preserve.
+    let mode = existing.permissions().mode() & 0o7777;
     temp.as_file()
         .set_permissions(std::fs::Permissions::from_mode(mode))
-        .map_err(|e| write_error(target, e))
 }
 
 /// No-op on platforms without Unix permission bits.
 ///
-/// Windows carries an ACL rather than a mode, and `MoveFileEx` preserves the
-/// ACL of the file being moved rather than of the one being replaced, so there
-/// is nothing to copy across by hand.
+/// Windows carries an ACL rather than a mode, and `MoveFileEx` does NOT carry
+/// the replaced file's security descriptor across; the temporary's own ACL
+/// survives the move. So the Unix hazard exists here too and is simply not
+/// handled: an explicit ACL set on config.toml is lost when it is replaced.
+///
+/// Accepted rather than fixed, because the temporary is created in the config
+/// directory and inherits that directory's inheritable ACEs, which is exactly
+/// what a file freshly created there would get. That is the right answer for a
+/// per-user config directory and the wrong one only for a config someone has
+/// deliberately re-ACLed, which needs `ReplaceFile` rather than `MoveFileEx`.
 #[cfg(not(unix))]
 #[allow(clippy::unnecessary_wraps)]
-fn preserve_existing_mode(_target: &Path, _temp: &tempfile::NamedTempFile) -> Result<()> {
+fn preserve_existing_mode(_target: &Path, _temp: &tempfile::NamedTempFile) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -217,7 +291,7 @@ pub fn save_default_config(config: &Config) -> Result<std::path::PathBuf> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
     use std::io::Write;
@@ -344,19 +418,24 @@ min_confidence = 0.25
 
     #[test]
     #[cfg(unix)]
-    fn test_save_config_replaces_the_file_by_rename() {
-        // The atomicity guard (#307), and the only one that can fail
-        // deterministically without simulating a crash.
+    fn test_save_config_does_not_truncate_the_target_in_place() {
+        // The #307 guard, and the only one that can fail deterministically
+        // without simulating a crash.
         //
         // A hardlink is a second name for the same inode. `fs::write` truncates
         // and rewrites in place, so the link would show the new contents; a
         // write to a sibling temp file followed by `rename` gives the config
         // path a *different* inode, leaving the old one intact behind the link.
-        // Reading the old contents back through the link is therefore proof
-        // that the target was never truncated, which is what makes an
-        // interrupted write survivable: the reader either sees the whole old
-        // file or the whole new one, never a zero-length file that parses as
-        // all-defaults and silently drops every configured model.
+        // Reading the old contents back through the link is therefore proof the
+        // target was never truncated, which is the specific regression #307 is
+        // about.
+        //
+        // Named for what it proves rather than for atomicity, because it proves
+        // less than that. It shows the config path acquired a new inode; it
+        // cannot see whether a reader had an uninterrupted view throughout.
+        // Unlinking the target immediately before the rename, which opens a
+        // window where the config does not exist at all, leaves this green.
+        // Closing that would need a concurrent reader or a crash harness.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
 
@@ -386,6 +465,45 @@ min_confidence = 0.25
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
+    fn test_save_config_works_when_the_config_is_not_on_the_temp_filesystem() {
+        // Pins the invariant every other test here is blind to: the temporary
+        // must be created in the TARGET's directory, not in $TMPDIR. Rename is
+        // only atomic within a filesystem and fails outright with EXDEV across
+        // one, so a temporary in $TMPDIR breaks for the ordinary desktop layout
+        // of /tmp on tmpfs and ~/.config on disk.
+        //
+        // Every other test saves into `tempfile::tempdir()`, which is itself
+        // under $TMPDIR, so `persist` never crosses a device and swapping
+        // `new_in(dir)` for `new()` leaves them all green. Saving into /dev/shm
+        // puts the target on a different filesystem from /tmp, which is what
+        // makes this one able to fail.
+        //
+        // If /dev/shm is missing or happens to share a device with $TMPDIR the
+        // test still passes rather than failing spuriously; it just stops
+        // proving anything, which is the safe direction for an environment
+        // assumption.
+        let shm = Path::new("/dev/shm");
+        if !shm.is_dir() {
+            return;
+        }
+        let Ok(dir) = tempfile::tempdir_in(shm) else {
+            return;
+        };
+        let path = dir.path().join("config.toml");
+
+        let mut config = Config::default();
+        config.defaults.min_confidence = 0.37;
+        save_config(&config, &path)
+            .expect("a save must not depend on $TMPDIR sharing a filesystem");
+
+        assert_eq!(
+            load_config_file(&path).unwrap().defaults.min_confidence,
+            0.37
+        );
+    }
+
+    #[test]
     fn test_save_config_leaves_no_temporary_file_behind() {
         // The temporary has to be created beside the target, because `rename`
         // is only atomic within a filesystem and $TMPDIR is routinely a
@@ -396,10 +514,13 @@ min_confidence = 0.25
 
         save_config(&Config::default(), &path).unwrap();
 
+        // Bound once rather than called twice: two `read_dir` calls could in
+        // principle disagree, so the message would explain a different state
+        // from the one the condition rejected.
+        let strays = strays_beside(&path, &["config.toml"]);
         assert!(
-            strays_beside(&path, &["config.toml"]).is_empty(),
-            "a successful save must not litter the config directory, found: {:?}",
-            strays_beside(&path, &["config.toml"])
+            strays.is_empty(),
+            "a successful save must not litter the config directory, found: {strays:?}"
         );
     }
 
@@ -414,10 +535,10 @@ min_confidence = 0.25
 
         assert!(save_config(&invalid_config(), &path).is_err());
 
+        let strays = strays_beside(&path, &[]);
         assert!(
-            strays_beside(&path, &[]).is_empty(),
-            "a rejected save must not leave a partial file behind, found: {:?}",
-            strays_beside(&path, &[])
+            strays.is_empty(),
+            "a rejected save must not leave a partial file behind, found: {strays:?}"
         );
     }
 
@@ -471,6 +592,45 @@ min_confidence = 0.25
 
     #[test]
     #[cfg(unix)]
+    fn test_save_config_writes_through_a_dangling_symlink() {
+        // The twin of the test below, and the one that fails against a
+        // `canonicalize`-only resolve. `canonicalize` needs the final component
+        // to exist, so a link whose target has not been created yet does not
+        // resolve, and falling back to the unresolved path makes the rename eat
+        // the link. This is the ordinary bootstrap order for a dotfiles setup:
+        // create the link, then run birda for the first time.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("dotfiles.toml");
+        let link_dir = dir.path().join("config");
+        std::fs::create_dir(&link_dir).unwrap();
+        let link = link_dir.join("config.toml");
+
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(
+            !real.exists(),
+            "the target must be absent for this to test anything"
+        );
+
+        let mut config = Config::default();
+        config.defaults.min_confidence = 0.33;
+        save_config(&config, &link).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "a dangling link must survive the save, not be replaced by a file"
+        );
+        assert_eq!(
+            load_config_file(&real).unwrap().defaults.min_confidence,
+            0.33,
+            "the save must create the file the dangling link points at"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn test_save_config_writes_through_a_symlinked_config() {
         // The one behaviour a rename changes for the worse if left alone.
         // `fs::write` follows a symlink; `rename` replaces it. Keeping a
@@ -502,11 +662,10 @@ min_confidence = 0.25
             0.42,
             "the write must land on the file the link points at"
         );
-        let expected = ["dotfiles.toml", "config"];
+        let strays = strays_beside(&real, &["dotfiles.toml", "config"]);
         assert!(
-            strays_beside(&real, &expected).is_empty(),
-            "the temporary belongs beside the resolved file, and must be gone, found: {:?}",
-            strays_beside(&real, &expected)
+            strays.is_empty(),
+            "the temporary belongs beside the resolved file, and must be gone, found: {strays:?}"
         );
     }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -176,14 +176,23 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
 /// birda second. `fs::write` handled it correctly, because `O_CREAT` follows a
 /// dangling link and creates the target.
 ///
-/// So a failed `canonicalize` falls back to reading the link by hand. Only the
-/// link's own parent has to exist for that to give a usable path; if it does
-/// not, or `path` is simply a file that does not exist yet, `path` is returned
-/// unchanged, which is correct for both.
+/// So a failed `canonicalize` falls back to reading the link by hand, and the
+/// link's target is used whether or not the directory holding it exists yet,
+/// since `save_config` creates that directory anyway. The unresolved path is
+/// returned only when `path` is not a symlink at all, which is the ordinary
+/// case of saving a config that does not exist yet.
 ///
-/// One hop, not a loop. A chain of dangling symlinks is not worth the cycle
-/// detection it would need, and stopping after one hop degrades to the old
-/// fallback rather than to anything worse.
+/// Deliberately no "does the target's parent exist?" guard. An earlier revision
+/// had one, and it reintroduced the exact bug this function exists to prevent,
+/// one directory deeper: linking config.toml into a dotfiles directory that had
+/// not been created yet failed the guard, fell back to the link, and the rename
+/// ate it, silently and with exit 0.
+///
+/// One hop, not a loop. A chain of dangling links is not worth the cycle
+/// detection it would need. Note what that means for `a -> b -> missing`: the
+/// write lands on `b` rather than on `a` or on the end of the chain. `a`
+/// survives as a link and still reads through, which is the property that
+/// matters; a cycle resolves the same way and terminates.
 fn resolve_link(path: &Path) -> std::path::PathBuf {
     if let Ok(resolved) = std::fs::canonicalize(path) {
         return resolved;
@@ -195,22 +204,12 @@ fn resolve_link(path: &Path) -> std::path::PathBuf {
 
     // A relative link resolves against the directory holding the link, not the
     // process's working directory.
-    let target = if link_target.is_absolute() {
+    if link_target.is_absolute() {
         link_target
     } else {
         path.parent()
             .unwrap_or_else(|| Path::new("."))
             .join(link_target)
-    };
-
-    // The temporary is created in the target's directory, so that directory has
-    // to exist for the write to be possible at all. When it does not, the
-    // unresolved path is the better answer: it at least keeps the failure in
-    // the directory the user named.
-    if target.parent().is_some_and(Path::exists) {
-        target
-    } else {
-        path.to_path_buf()
     }
 }
 
@@ -479,17 +478,26 @@ min_confidence = 0.25
         // puts the target on a different filesystem from /tmp, which is what
         // makes this one able to fail.
         //
-        // If /dev/shm is missing or happens to share a device with $TMPDIR the
-        // test still passes rather than failing spuriously; it just stops
-        // proving anything, which is the safe direction for an environment
-        // assumption.
+        // If /dev/shm is missing, or turns out to share a device with $TMPDIR,
+        // this proves nothing. That is the safe direction for an environment
+        // assumption, but a silent vacuous pass and a real pass would be
+        // indistinguishable, so the skip says so on stderr.
+        use std::os::unix::fs::MetadataExt;
+
         let shm = Path::new("/dev/shm");
-        if !shm.is_dir() {
-            return;
-        }
         let Ok(dir) = tempfile::tempdir_in(shm) else {
+            eprintln!("skipped: /dev/shm is unusable, cross-filesystem save not exercised");
             return;
         };
+        let shm_device = std::fs::metadata(dir.path()).unwrap().dev();
+        let tmp_device = std::fs::metadata(std::env::temp_dir()).unwrap().dev();
+        let same_device = shm_device == tmp_device;
+        assert!(
+            !same_device,
+            "/dev/shm and $TMPDIR share a device, so this cannot exercise a \
+             cross-filesystem rename. Unset TMPDIR, or delete this test rather \
+             than leaving it passing vacuously."
+        );
         let path = dir.path().join("config.toml");
 
         let mut config = Config::default();
@@ -626,6 +634,42 @@ min_confidence = 0.25
             load_config_file(&real).unwrap().defaults.min_confidence,
             0.33,
             "the save must create the file the dangling link points at"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_save_config_writes_through_a_dangling_symlink_into_a_missing_directory() {
+        // The same case one directory deeper, and the one a "does the target's
+        // parent exist?" guard silently broke: the guard rejected, the code
+        // fell back to the link, and the rename ate it with exit 0. Linking
+        // config.toml into a dotfiles directory that does not exist yet is an
+        // ordinary thing to do on a fresh machine.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("dotfiles").join("birda.toml");
+        let link = dir.path().join("config.toml");
+
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(
+            !real.parent().unwrap().exists(),
+            "the target's directory must be absent for this to test anything"
+        );
+
+        let mut config = Config::default();
+        config.defaults.min_confidence = 0.29;
+        save_config(&config, &link).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link must survive even when its target's directory had to be created"
+        );
+        assert_eq!(
+            load_config_file(&real).unwrap().defaults.min_confidence,
+            0.29,
+            "the save must create the directory and the file the link points at"
         );
     }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -179,8 +179,10 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
 /// So a failed `canonicalize` falls back to reading the link by hand, and the
 /// link's target is used whether or not the directory holding it exists yet,
 /// since `save_config` creates that directory anyway. The unresolved path is
-/// returned only when `path` is not a symlink at all, which is the ordinary
-/// case of saving a config that does not exist yet.
+/// returned when `read_link` fails, which is usually because `path` is not a
+/// symlink at all (the ordinary case of saving a config that does not exist
+/// yet) and otherwise because the link is unreadable. Both want the same
+/// answer.
 ///
 /// Deliberately no "does the target's parent exist?" guard. An earlier revision
 /// had one, and it reintroduced the exact bug this function exists to prevent,
@@ -188,11 +190,22 @@ pub fn save_config(config: &Config, path: &Path) -> Result<()> {
 /// not been created yet failed the guard, fell back to the link, and the rename
 /// ate it, silently and with exit 0.
 ///
+/// The cost of having no guard, stated because it goes past what `fs::write`
+/// did: a save through a dangling link now CREATES the directories leading to
+/// its target, where `fs::write` would have failed with ENOENT. For a link into
+/// an unmounted path, that materialises a directory inside the mountpoint. The
+/// link is always one the user placed at their own config path, so nothing
+/// crosses a privilege boundary, and this is still the better failure mode than
+/// eating the link.
+///
 /// One hop, not a loop. A chain of dangling links is not worth the cycle
-/// detection it would need. Note what that means for `a -> b -> missing`: the
-/// write lands on `b` rather than on `a` or on the end of the chain. `a`
-/// survives as a link and still reads through, which is the property that
-/// matters; a cycle resolves the same way and terminates.
+/// detection it would need. For `a -> b -> missing` the write lands on `b`
+/// rather than on `a` or on the end of the chain, so `a` survives as a link and
+/// still reads through, which is the property that matters. Every cycle
+/// terminates, but only a cycle of length two or more preserves that property:
+/// `a -> a` resolves to `a` itself and is replaced by a regular file. That
+/// costs nothing in practice, since a self-referential config link cannot be
+/// read either.
 fn resolve_link(path: &Path) -> std::path::PathBuf {
     if let Ok(resolved) = std::fs::canonicalize(path) {
         return resolved;
@@ -478,10 +491,17 @@ min_confidence = 0.25
         // puts the target on a different filesystem from /tmp, which is what
         // makes this one able to fail.
         //
-        // If /dev/shm is missing, or turns out to share a device with $TMPDIR,
-        // this proves nothing. That is the safe direction for an environment
-        // assumption, but a silent vacuous pass and a real pass would be
-        // indistinguishable, so the skip says so on stderr.
+        // Two environments make this inert: /dev/shm missing, and $TMPDIR
+        // pointed at /dev/shm so both ends share a device. It skips rather than
+        // fails in both, because a red build over an environment quirk is worse
+        // than a test that stops proving something, and `TMPDIR=/dev/shm` is a
+        // real technique for speeding up tempfile-heavy suites.
+        //
+        // Being honest about the cost: libtest captures the output of passing
+        // tests unless `--nocapture` is passed, and CI does not pass it, so on
+        // such a machine this goes quiet with nothing to show for it. Preferred
+        // anyway over the alternative of failing, and over a silent vacuous
+        // pass, which is what this replaced.
         use std::os::unix::fs::MetadataExt;
 
         let shm = Path::new("/dev/shm");
@@ -489,15 +509,17 @@ min_confidence = 0.25
             eprintln!("skipped: /dev/shm is unusable, cross-filesystem save not exercised");
             return;
         };
-        let shm_device = std::fs::metadata(dir.path()).unwrap().dev();
-        let tmp_device = std::fs::metadata(std::env::temp_dir()).unwrap().dev();
-        let same_device = shm_device == tmp_device;
-        assert!(
-            !same_device,
-            "/dev/shm and $TMPDIR share a device, so this cannot exercise a \
-             cross-filesystem rename. Unset TMPDIR, or delete this test rather \
-             than leaving it passing vacuously."
-        );
+
+        // `.ok()` rather than `.unwrap()`: a broken $TMPDIR should not surface
+        // here as a panic pointing at a device probe.
+        let device_of = |p: &Path| std::fs::metadata(p).map(|m| m.dev()).ok();
+        if device_of(dir.path()) == device_of(&std::env::temp_dir()) {
+            eprintln!(
+                "skipped: /dev/shm and $TMPDIR share a device, cross-filesystem save not exercised"
+            );
+            return;
+        }
+
         let path = dir.path().join("config.toml");
 
         let mut config = Config::default();

--- a/src/config/geomodel.rs
+++ b/src/config/geomodel.rs
@@ -190,12 +190,18 @@ fn acquire(
 
     let installed = runtime.block_on(crate::registry::install_range_filter(asset))?;
 
-    // Deliberately NOT written back to config.toml here. save_config truncates
-    // and rewrites the whole file, dropping comments and any unrecognised keys,
-    // and a failed write leaves an empty config that parses as all-defaults and
-    // silently loses every model the user had configured. An analyze run must
-    // not risk that; the paths resolve from the registry on the next run anyway,
-    // and 'birda models install geomodel' records them explicitly.
+    // Deliberately NOT written back to config.toml here. The destructive half
+    // of this reasoning is gone: save_config now writes to a temporary beside
+    // the target and renames over it, so an interrupted write can no longer
+    // leave an empty config that parses as all-defaults and silently loses
+    // every model the user had configured (#307).
+    //
+    // What remains is enough to keep the decision. save_config re-serialises
+    // the whole file from the struct, so it still drops comments and any
+    // unrecognised keys, and an analyze run rewriting the user's config as a
+    // side effect is surprising in its own right. The paths resolve from the
+    // registry on the next run anyway, and 'birda models install geomodel'
+    // records them explicitly.
     Ok(GeomodelResolution::Ready(installed))
 }
 

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -47,8 +47,12 @@ fn validate_defaults(config: &Config) -> Result<()> {
     //
     // So no upper bound is imposed here. One belongs with the segment length
     // rather than in a rule that cannot see it, and adding it would be new
-    // policy rather than a fix. Tracked in #306 along with the matching hole on
-    // the `--overlap` flag, which carries no value parser at all.
+    // policy rather than a fix.
+    //
+    // `--overlap` and `BIRDA_OVERLAP` win over this value and were checked by
+    // nothing at all, so the same rule now lives in `cli::validators::
+    // parse_overlap` (#306). The two are kept identical, wording included, and
+    // a unit test there pins them against the same inputs.
     if !defaults.overlap.is_finite() || defaults.overlap < 0.0 {
         return Err(Error::ConfigValidation {
             message: format!(

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -52,7 +52,10 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // `--overlap` and `BIRDA_OVERLAP` win over this value and were checked by
     // nothing at all, so the same rule now lives in `cli::validators::
     // parse_overlap` (#306). The two are kept identical, wording included, and
-    // a unit test there pins them against the same inputs.
+    // `test_parse_overlap_matches_the_config_file_rule` drives both and
+    // compares their verdicts, so neither side can be changed alone. Adding an
+    // upper bound here, for instance, fails that test rather than silently
+    // making config.toml stricter than the flag.
     if !defaults.overlap.is_finite() || defaults.overlap < 0.0 {
         return Err(Error::ConfigValidation {
             message: format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,23 @@ fn main() {
         // denied". That was survivable while the causes were few and obvious.
         // Writing the config atomically added several distinct failure points
         // behind that one message, which are indistinguishable without this.
+        //
+        // A cause the message above already spells out is skipped rather than
+        // repeated. `#[from]` implies `#[source]`, so a variant that also
+        // interpolates that source into its own message carries it twice, and
+        // walking the chain blindly printed "I/O error: No such file or
+        // directory" followed by "caused by: No such file or directory".
+        // Filtering here rather than rewriting the variant keeps each error's
+        // `Display` intact for the JSON envelope, which reports the message on
+        // its own and cannot walk a chain.
+        let mut rendered = e.to_string();
         let mut cause = std::error::Error::source(&e);
         while let Some(source) = cause {
-            eprintln!("  caused by: {source}");
+            let text = source.to_string();
+            if !rendered.contains(&text) {
+                eprintln!("  caused by: {text}");
+            }
+            rendered = text;
             cause = source.source();
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,20 @@
 fn main() {
     if let Err(e) = birda::run() {
         eprintln!("error: {e}");
+
+        // Print the causes too. Most error variants keep the underlying I/O,
+        // TOML or serde failure as a `#[source]`, and thiserror does not render
+        // a source in the top-level `Display`, so the reason was being dropped:
+        // the user saw "failed to write config file 'X'" and never "Permission
+        // denied". That was survivable while the causes were few and obvious.
+        // Writing the config atomically added several distinct failure points
+        // behind that one message, which are indistinguishable without this.
+        let mut cause = std::error::Error::source(&e);
+        while let Some(source) = cause {
+            eprintln!("  caused by: {source}");
+            cause = source.source();
+        }
+
         std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,31 @@ fn main() {
         // Filtering here rather than rewriting the variant keeps each error's
         // `Display` intact for the JSON envelope, which reports the message on
         // its own and cannot walk a chain.
-        let mut rendered = e.to_string();
+        //
+        // Two properties, each closing one way of getting this wrong.
+        //
+        // `ends_with` rather than `contains`, because appending is the shape
+        // the duplication actually takes: a variant that renders its own source
+        // puts it at the end, as in `#[error("I/O error: {0}")]`. A substring
+        // test would also drop a distinct cause that happened to appear
+        // anywhere in its parent, for instance inside an interpolated path.
+        //
+        // Checked against every line already shown, not just the previous one,
+        // so the guarantee holds at any depth. `AudioOpen` and `AudioDecode`
+        // wrap boxed errors from the decoder libraries, so a chain here can be
+        // deeper than the single `#[from]` hop the rest of the enum uses.
+        //
+        // Where the two pull against each other, this errs toward printing a
+        // line twice rather than hiding a cause: a repeated line is noise, a
+        // suppressed one loses the reason the command failed.
+        let mut shown = vec![e.to_string()];
         let mut cause = std::error::Error::source(&e);
         while let Some(source) = cause {
             let text = source.to_string();
-            if !rendered.contains(&text) {
+            if !shown.iter().any(|seen| seen.ends_with(&text)) {
                 eprintln!("  caused by: {text}");
             }
-            rendered = text;
+            shown.push(text);
             cause = source.source();
         }
 

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -525,17 +525,35 @@ fn test_a_valid_overlap_flag_is_accepted() {
     // bound is imposed here (an oversized overlap is caught against the segment
     // length in `AudioDecoder::next_segment`, which is the only place that
     // knows it).
+    //
+    // `seed_config` is called even though the config content is irrelevant,
+    // because it carries the assertion that the temp HOME actually redirected
+    // the config directory. Without it this test reaches config load against
+    // the developer's real config.toml on any platform where the redirection
+    // does not work, and a real `overlap = nan` there would fail it spuriously.
     let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\noverlap = 0.0\n");
     let input = dummy_input(home.path());
 
-    let stderr = stderr_of(&run_in(
-        home.path(),
-        &["--overlap", "1.5", input.to_str().unwrap()],
-    ));
+    let output = run_in(home.path(), &["--overlap", "1.5", input.to_str().unwrap()]);
 
+    // Asserted as "not a usage error", not merely as the absence of the
+    // rule message. Absence alone passes when the flag does not exist: renaming
+    // `--overlap` to `--overlapx` kills the four rejection tests above and this
+    // one still passed, so it was a control against the parser being too strict
+    // and not against the flag being unwired at all. Exit code 2 is what clap
+    // returns for both "invalid value" and "unexpected argument", so pinning it
+    // closes both.
+    assert_ne!(
+        output.status.code(),
+        Some(CLAP_USAGE_ERROR),
+        "a finite non-negative overlap must be accepted by the value parser, got: {}",
+        stderr_of(&output)
+    );
     assert!(
-        !stderr.contains(OVERLAP_VIOLATION),
-        "a finite non-negative overlap must not be rejected, got: {stderr}"
+        !stderr_of(&output).contains(OVERLAP_VIOLATION),
+        "a finite non-negative overlap must not be rejected, got: {}",
+        stderr_of(&output)
     );
 }
 

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -1,4 +1,5 @@
-//! Integration tests for configuration validation on load (#295).
+//! Integration tests for configuration validation on load (#295), and for the
+//! overlap rule reaching every input channel rather than only the file (#306).
 //!
 //! These drive the real binary rather than calling `validate_config` directly,
 //! and that is the point. Every rule in `src/config/validate.rs` already
@@ -75,6 +76,16 @@ const BIRDA_ENV_VARS: [&str; 19] = [
 /// The isolation has to cover the environment as well as the filesystem, hence
 /// [`BIRDA_ENV_VARS`].
 fn run_in(home: &Path, args: &[&str]) -> std::process::Output {
+    run_in_with_env(home, &[], args)
+}
+
+/// [`run_in`], with `env` applied after the wholesale clearing.
+///
+/// The order matters: [`BIRDA_ENV_VARS`] is removed first so a variable
+/// exported in the developer's shell cannot leak in, and the caller's overrides
+/// go on afterwards. A test that set `BIRDA_OVERLAP` before the loop would have
+/// it removed again and then pass vacuously against the config-file default.
+fn run_in_with_env(home: &Path, env: &[(&str, &str)], args: &[&str]) -> std::process::Output {
     let mut cmd = cargo_bin_cmd!("birda");
     cmd.env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join("config"))
@@ -82,6 +93,9 @@ fn run_in(home: &Path, args: &[&str]) -> std::process::Output {
         .timeout(COMMAND_TIMEOUT);
     for var in BIRDA_ENV_VARS {
         cmd.env_remove(var);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
     }
     for arg in args {
         cmd.arg(arg);
@@ -207,6 +221,15 @@ const OVERLAP_VIOLATION: &str = "overlap must be a finite non-negative number";
 /// parse failure (2) or a panic (101). Pinned so a rejection test cannot be
 /// satisfied by the wrong kind of failure.
 const APPLICATION_ERROR: i32 = 1;
+
+/// The exit code clap uses when an argument fails its `value_parser`.
+///
+/// The overlap tests below pin this rather than [`APPLICATION_ERROR`], because
+/// the whole point of #306 is that the flag and the environment variable are
+/// rejected by the same mechanism as every sibling option, which is clap. A
+/// rejection that arrived later, as an application error, would mean the value
+/// parser is still not wired.
+const CLAP_USAGE_ERROR: i32 = 2;
 
 /// Assert a command ran to completion, so it was not gated on the config.
 ///
@@ -415,6 +438,105 @@ fn test_a_dangling_default_model_does_not_block_the_models_commands() {
 
     assert_command_succeeds(home.path(), &["models", "list"]);
     assert_command_succeeds(home.path(), &["models", "check"]);
+}
+
+/// Assert clap refused the run, naming the offending overlap value.
+///
+/// Takes the whole invocation rather than just the value, because #306 is about
+/// two input channels agreeing, and the flag and the environment variable reach
+/// clap by different routes.
+fn assert_overlap_rejected(home: &Path, env: &[(&str, &str)], args: &[&str]) {
+    let input = dummy_input(home);
+    let mut full: Vec<&str> = args.to_vec();
+    let input = input.to_str().unwrap();
+    full.push(input);
+
+    let output = run_in_with_env(home, env, &full);
+
+    assert_eq!(
+        output.status.code(),
+        Some(CLAP_USAGE_ERROR),
+        "an invalid overlap must be refused by the value parser, got: {}",
+        stderr_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains(OVERLAP_VIOLATION),
+        "the flag and the config file should give the same diagnostic \
+         ({OVERLAP_VIOLATION}), got: {stderr}"
+    );
+}
+
+#[test]
+fn test_a_nan_overlap_flag_is_rejected() {
+    // #306. `--overlap` was the one numeric option on `AnalyzeArgs` with no
+    // value parser, so it took whatever `f32::from_str` accepted. NaN reached
+    // `overlap * sample_rate`, Rust saturates that cast rather than trapping,
+    // and the setting became a silent zero: the run completed, produced
+    // non-overlapping segments and said nothing.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_overlap_rejected(home.path(), &[], &["--overlap", "nan"]);
+}
+
+#[test]
+fn test_an_infinite_overlap_flag_is_rejected() {
+    // The worst of the three, because it changed the result rather than
+    // ignoring the setting. The same saturating cast sends infinity to
+    // `usize::MAX`, `chunk_samples.saturating_sub(overlap_samples)` gives a
+    // step of 0, and the run yields no segments at all: exit 0, empty output,
+    // no diagnostic.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_overlap_rejected(home.path(), &[], &["--overlap", "inf"]);
+}
+
+#[test]
+fn test_a_negative_overlap_flag_is_rejected() {
+    // Written as a separate argument rather than `--overlap=-1` to pin
+    // `allow_hyphen_values`. Without it clap consumes the leading `-` as the
+    // start of another flag and fails with "a value is required", which is a
+    // usage error about the wrong thing: the user did supply a value, it was
+    // just not a legal one. `--lat` and `--lon` carry the same attribute for
+    // the same reason.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_overlap_rejected(home.path(), &[], &["--overlap", "-1"]);
+}
+
+#[test]
+fn test_the_overlap_env_var_is_validated() {
+    // The channel the config-file fix did not reach. `BIRDA_OVERLAP` and
+    // `--overlap` both win over the config value, so a rule enforced only on
+    // the file left the two disagreeing: `overlap = -1` in config.toml was a
+    // hard error while `BIRDA_OVERLAP=-1` was accepted and silently became zero
+    // overlap. Driven through the environment because clap applies the value
+    // parser to both sources and only an end-to-end run proves it.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_overlap_rejected(home.path(), &[("BIRDA_OVERLAP", "-1")], &[]);
+}
+
+#[test]
+fn test_a_valid_overlap_flag_is_accepted() {
+    // The control for the four above, which would all pass just as well if the
+    // value parser rejected everything. 1.5 is finite and non-negative, so it
+    // must reach the run; that it exceeds nothing is the point, since no upper
+    // bound is imposed here (an oversized overlap is caught against the segment
+    // length in `AudioDecoder::next_segment`, which is the only place that
+    // knows it).
+    let home = tempfile::tempdir().unwrap();
+    let input = dummy_input(home.path());
+
+    let stderr = stderr_of(&run_in(
+        home.path(),
+        &["--overlap", "1.5", input.to_str().unwrap()],
+    ));
+
+    assert!(
+        !stderr.contains(OVERLAP_VIOLATION),
+        "a finite non-negative overlap must not be rejected, got: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #307. Fixes #306.

Two independent bugfixes in the same area, plus the findings from the pre-push gate run over them.

## #307: config.toml was written non-atomically

`save_config` ended in `std::fs::write`, which truncates the existing file and then writes. Between those two steps the config is empty, so ENOSPC, SIGKILL or power loss in that window left a zero-length or partial `config.toml`.

That is not a benign failure, because a truncated file still parses. An empty `config.toml` is valid TOML, deserialises to `Config::default()`, and the user silently loses every `[models.*]` block, their default model and their geomodel paths, with no error at any point.

The codebase already knew this: `config::geomodel` declined to write the resolved geomodel paths back specifically to avoid the hazard, so a feature had been given up to route around it. #295 added validation before the write, which stops an invalid config destroying a good one; the interrupted-write mode was untouched.

The write now goes to a temporary beside the target, is fsynced, and is renamed over it. Three consequences of replacing rather than rewriting in place, each handled and each pinned by a test:

- The temporary must live in the target's directory, since rename across filesystems is not atomic and `$TMPDIR` is routinely a different one. That puts it in the user's config directory, so it is cleaned up on every return path.
- The new file takes its mode from the temporary, not from the file it replaces, so an existing mode is copied across explicitly. A config that does not exist yet keeps the restrictive default and is created 0600.
- Rename replaces the name it is given where a write follows it, so a `config.toml` symlinked into a dotfiles repository is resolved first and the write lands on the file it points at. This holds for a dangling link too, which is the ordinary bootstrap order.

Atomicity is pinned through a hardlink: a second name for the same inode still reads the old contents after a save, which is only true if the target was replaced rather than truncated in place. That fails deterministically against the old code without simulating a crash.

`tempfile` moves from dev-dependencies to dependencies. It was already in the normal dependency graph via `self-replace`, so no new crate enters the build.

## #306: --overlap and BIRDA_OVERLAP bypassed validation

Every numeric option on `AnalyzeArgs` carried a clap `value_parser` except `--overlap`, which was a bare `Option<f32>`. The flag and the environment variable both win over `defaults.overlap`, so the config-file rule never reached the two channels a user is most likely to type into:

```
overlap = -1 in config.toml   -> error: must be a finite non-negative number
BIRDA_OVERLAP=-1              -> accepted, silently became zero overlap
birda --overlap nan rec.wav   -> accepted, silently became zero overlap
birda --overlap inf rec.wav   -> accepted, produced no segments at all
```

None of the three failed loudly. `overlap * sample_rate` is cast to `usize` and Rust saturates that cast, so NaN and a negative value both became 0. Infinity saturates to `usize::MAX`, the step becomes 0, and the run exits 0 having emitted nothing.

`parse_overlap` applies the same rule as `validate_defaults`, and a unit test now drives both functions and compares their verdicts, so neither side can move alone.

## What the gate changed beyond the two fixes

Worth calling out explicitly, since it goes past the two issues:

- **`.trim()` was added to `parse_confidence` and `parse_bounded_float`.** `parse_overlap` and `parse_batch_size` already trimmed, so `BIRDA_OVERLAP=" 1.5 "` worked while `BIRDA_MIN_CONFIDENCE=" 0.5 "` failed, from options a user sets side by side in one shell profile. It is purely widening: Rust's `f32::from_str` rejects all surrounding whitespace, so trimming is the identity on every previously-accepted input.
- **`main.rs` now prints the error `source()` chain.** Most variants keep the underlying failure as a `#[source]` and thiserror does not render it, so the user saw "failed to write config file 'X'" and never "Permission denied". The atomic write added several distinct failure points behind that one message. A cause the message above already contains is skipped, so `Error::Io`, which interpolates its own source, does not print it twice.

## Behaviour changes worth a release note

- The overlap rejection is a **breaking CLI change**: anyone with `BIRDA_OVERLAP` set to a negative, NaN or infinite value now gets exit 2 where the run previously completed. Realistically nobody sets those deliberately, but the failure is total.
- A **newly created** config is 0600 where it used to be 0644 under the usual umask. Existing files keep their mode.
- A **hardlinked** config now goes stale, since rename gives the path a new inode. A symlinked one is followed and still works.
- If you bind-mount the config **file** into a container, mount the directory instead: renaming over a bind-mount target fails with `EBUSY`.

## Not addressed here, filed instead

#310 (a real panic: `birda clip --end inf`), #311, #312, #313, #314, #315, #316.


## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo clippy --no-default-features -- -D warnings` and `cargo test` are all clean (480 tests). The changed files add no warnings under `cargo clippy --all-targets` either.

Three review rounds ran over this, each reviewing the previous round's fixes, because the fixes are the part nobody has looked at. Round 2 found five defects the first fix wave introduced, including a `resolve_link` guard that reintroduced the exact symlink destruction it was meant to prevent, one directory deeper. Round 3 found eight more, none Critical or High, of which three are closed here. The last commit is a small wave of comment corrections and one test made portable, and it has not itself been independently reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration files are now saved atomically, helping prevent data loss during interrupted writes while preserving permissions.
  - Command-line errors now include underlying causes for clearer troubleshooting.

- **Bug Fixes**
  - Overlap values are consistently validated across CLI, environment variables, and configuration files.
  - Negative, non-finite, and invalid overlap values now receive clear diagnostics.
  - Leading and trailing whitespace is handled consistently for numeric settings.

- **Documentation**
  - Updated configuration, environment variable, and Windows guidance with validation and file-saving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
