### PR TITLE
fix: reject non-finite clip times, and stop a huge range aborting the process (#310)

### DIFF
--- a/src/cli/clip.rs
+++ b/src/cli/clip.rs
@@ -59,8 +59,25 @@ fn parse_padding(s: &str) -> Result<f64, String> {
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
-    if value < 0.0 {
-        return Err(format!("padding cannot be negative, got {value}"));
+    // `is_finite` is what catches NaN, and it has to be spelled this way round:
+    // a bare `value < 0.0` test is false for NaN, which is how NaN got through
+    // before. The two paddings then failed differently, and neither failed
+    // loudly:
+    //
+    // - `--pre nan` reached `(start - pre).max(0.0)`, and `f64::max` returns
+    //   the other operand for a NaN receiver, so the start bound collapsed to
+    //   0.0. Not "the padding was ignored": the clip began at the start of the
+    //   file however late `--start` was.
+    // - `--post nan` reached `end + post`, which has no `.max` to launder it,
+    //   so the end bound stayed NaN all the way to the seconds-to-samples cast
+    //   and came out as 0, underflowing the sample-count subtraction.
+    //
+    // Infinity used the same hole and pushed the bounds to a range no file
+    // contains.
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!(
+            "padding must be a finite non-negative number, got {value}"
+        ));
     }
 
     if value > MAX_PADDING {
@@ -77,9 +94,86 @@ fn parse_time(s: &str) -> Result<f64, String> {
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
-    if value < 0.0 {
-        return Err(format!("time cannot be negative, got {value}"));
+    // See `parse_padding` for why the finiteness test comes first. Both values
+    // this parser backs were reachable: `--end inf` saturated to `u64::MAX`
+    // when the extractor converted seconds to samples and aborted the process
+    // with a capacity overflow, while `--start nan` wrote a clip named
+    // `detection_NaN-5` over a range nobody asked for, and exited 0.
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!(
+            "time must be a finite non-negative number, got {value}"
+        ));
     }
 
     Ok(value)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_time_accepts_finite_non_negative() {
+        assert_eq!(parse_time("0").unwrap(), 0.0);
+        assert_eq!(parse_time("12.5").unwrap(), 12.5);
+    }
+
+    #[test]
+    fn test_parse_time_rejects_negative() {
+        let err = parse_time("-1").unwrap_err();
+        assert!(err.contains("finite non-negative"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_time_rejects_non_finite() {
+        // The regression this file exists for: `--end inf` reached the
+        // extractor as a saturated `u64::MAX` sample count and aborted the
+        // process, and `--start nan` wrote a clip named after a NaN.
+        for input in ["inf", "-inf", "infinity", "nan", "NaN", "-nan"] {
+            let err = parse_time(input).expect_err("non-finite time must be rejected");
+            assert!(err.contains("finite non-negative"), "{input}: {err}");
+        }
+    }
+
+    #[test]
+    fn test_parse_time_rejects_garbage() {
+        let err = parse_time("abc").unwrap_err();
+        assert!(err.contains("not a valid number"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_padding_accepts_finite_in_range() {
+        assert_eq!(parse_padding("0").unwrap(), 0.0);
+        assert_eq!(parse_padding("2.5").unwrap(), 2.5);
+        assert_eq!(
+            parse_padding(&MAX_PADDING.to_string()).unwrap(),
+            MAX_PADDING
+        );
+    }
+
+    #[test]
+    fn test_parse_padding_rejects_non_finite() {
+        // `--pre nan` used to be swallowed by `(start - pre).max(0.0)`, which
+        // returns 0.0 for a NaN receiver, so the padding was dropped and the
+        // run still exited 0.
+        for input in ["inf", "-inf", "nan", "NaN"] {
+            let err = parse_padding(input).expect_err("non-finite padding must be rejected");
+            assert!(err.contains("finite non-negative"), "{input}: {err}");
+        }
+    }
+
+    #[test]
+    fn test_parse_padding_rejects_out_of_range() {
+        assert!(
+            parse_padding("-1")
+                .unwrap_err()
+                .contains("finite non-negative")
+        );
+        assert!(
+            parse_padding(&(MAX_PADDING + 1.0).to_string())
+                .unwrap_err()
+                .contains("cannot exceed")
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,11 @@ mod args;
 pub mod clip;
 pub mod help;
 pub mod species;
-mod validators;
+// Crate-visible rather than private so a sibling that restates one of these
+// rules can be tested against it directly. `clipper::command` re-applies the
+// confidence rule at its library boundary, and #306 is what happens when two
+// spellings of one rule are only claimed to agree.
+pub(crate) mod validators;
 
 pub use args::{AnalyzeArgs, Cli, Command, ConfigAction, ModelsAction, SortOrder};
 pub use clip::ClipArgs;

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -2,7 +2,7 @@
 //!
 //! Shared validation functions for CLI argument parsing.
 
-use crate::constants::MAX_BATCH_SIZE;
+use crate::constants::{MAX_BATCH_SIZE, confidence};
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -19,9 +19,15 @@ pub fn parse_confidence(s: &str) -> Result<f32, String> {
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
-    if !(0.0..=1.0).contains(&value) {
+    // The bounds come from the constants rather than literals so that
+    // `clipper::command::validate_float_args`, which re-applies this rule at
+    // the library boundary, reads the same two values instead of a second copy
+    // of them.
+    if !(confidence::MIN..=confidence::MAX).contains(&value) {
         return Err(format!(
-            "confidence must be between 0.0 and 1.0, got {value}"
+            "confidence must be between {:.1} and {:.1}, got {value}",
+            confidence::MIN,
+            confidence::MAX
         ));
     }
 

--- a/src/clipper/command.rs
+++ b/src/clipper/command.rs
@@ -8,26 +8,69 @@ use tracing::{info, warn};
 use crate::Error;
 use crate::cli::ClipArgs;
 use crate::config::OutputMode;
-use crate::constants::{clipper, output_extensions};
+use crate::constants::{clipper, confidence, output_extensions};
 use crate::output::{ClipExtractionEntry, ClipExtractionPayload, ResultType, emit_json_result};
 
 use super::{
     ClipExtractor, DetectionGroup, ParsedDetection, WavWriter, group_detections,
-    parse_detection_file,
+    parse_detection_file, validate_time_range,
 };
 
 /// Execute the clip command.
 ///
 /// # Errors
 ///
-/// Returns an error if clip extraction fails.
+/// Returns [`Error::InvalidPadding`] or [`Error::InvalidConfidence`] if the
+/// caller built `args` outside clap with a value the CLI would have refused,
+/// [`Error::InvalidTimeRange`] for a bad direct-extraction range, and an error
+/// if clip extraction fails.
 pub fn execute(args: &ClipArgs, output_mode: OutputMode) -> Result<(), Error> {
+    validate_float_args(args)?;
+
     // Detect mode based on presence of --start/--end
     if let (Some(start), Some(end)) = (args.start, args.end) {
         execute_direct_extraction(args, start, end, output_mode)
     } else {
         execute_csv_mode(args, output_mode)
     }
+}
+
+/// Re-check the float arguments at the library boundary.
+///
+/// `ClipArgs` is public and so is this module, so a caller can build one
+/// without going through clap's `value_parser`s. Every value checked here
+/// fails quietly rather than loudly when it is not finite, which is why the
+/// check is worth repeating rather than delegated to the CLI:
+///
+/// - a NaN `pre` collapses the start bound to 0.0, because `f64::max` returns
+///   the other operand for a NaN receiver, so `(start - pre).max(0.0)` yields
+///   the beginning of the file however late the detection was;
+/// - a NaN `post` leaves the end bound NaN, which the seconds-to-samples cast
+///   turns into 0;
+/// - every comparison against a NaN `confidence` is false, so the filter in
+///   `process_detection_file` discards every detection and the run reports
+///   success over an empty result.
+///
+/// The bounds are deliberately the same ones `cli::clip`'s parsers and
+/// `cli::validators::parse_confidence` enforce. #306 was filed because a rule
+/// held on one route and not on another, and this is the other route.
+fn validate_float_args(args: &ClipArgs) -> Result<(), Error> {
+    // The negated `contains` is what rejects NaN and infinity, and it has to
+    // be spelled this way round: a bare `value < 0.0 || value > MAX` is false
+    // for NaN on both halves. Same spelling as `cli::validators`.
+    for value in [args.pre, args.post] {
+        if !(0.0..=clipper::MAX_PADDING).contains(&value) {
+            return Err(Error::InvalidPadding { value });
+        }
+    }
+
+    if !(confidence::MIN..=confidence::MAX).contains(&args.confidence) {
+        return Err(Error::InvalidConfidence {
+            value: args.confidence,
+        });
+    }
+
+    Ok(())
 }
 
 /// Execute clip extraction from CSV detection files.
@@ -83,10 +126,7 @@ fn execute_direct_extraction(
     end: f64,
     output_mode: OutputMode,
 ) -> Result<(), Error> {
-    // Validation
-    if end <= start {
-        return Err(Error::InvalidTimeRange { start, end });
-    }
+    validate_time_range(start, end)?;
 
     // audio is guaranteed by clap constraints
     let audio_path = args.audio.as_ref().ok_or_else(|| Error::Internal {
@@ -369,4 +409,174 @@ fn find_source_audio(
         detection_path: detection_file.to_path_buf(),
         audio_path: search_dir.join(base_stem),
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// A `ClipArgs` with every value in range, for the library-boundary tests
+    /// to perturb one field at a time. Built by hand rather than through clap
+    /// on purpose: the check under test exists precisely for callers that skip
+    /// clap.
+    fn valid_args() -> ClipArgs {
+        ClipArgs {
+            files: Vec::new(),
+            output: PathBuf::from("clips"),
+            confidence: 0.0,
+            pre: clipper::DEFAULT_PRE_PADDING,
+            post: clipper::DEFAULT_POST_PADDING,
+            audio: None,
+            base_dir: None,
+            start: None,
+            end: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_float_args_accepts_the_defaults() {
+        assert!(validate_float_args(&valid_args()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_float_args_rejects_non_finite_padding() {
+        // Not reachable through clap, which rejects these in its
+        // `value_parser`. Reachable through the library, which is the point.
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0] {
+            for mutate in [
+                (|a: &mut ClipArgs, v: f64| a.pre = v) as fn(&mut ClipArgs, f64),
+                |a: &mut ClipArgs, v: f64| a.post = v,
+            ] {
+                let mut args = valid_args();
+                mutate(&mut args, value);
+                assert!(
+                    matches!(
+                        validate_float_args(&args),
+                        Err(Error::InvalidPadding { .. })
+                    ),
+                    "padding {value} was not rejected"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_validate_float_args_applies_the_same_padding_ceiling_as_the_cli() {
+        // The CLI parser caps padding at `MAX_PADDING`. A library caller that
+        // skipped clap used to get no ceiling at all, which is the #306 shape:
+        // one rule, two routes, two answers.
+        let mut args = valid_args();
+        args.pre = clipper::MAX_PADDING;
+        assert!(
+            validate_float_args(&args).is_ok(),
+            "the ceiling is inclusive"
+        );
+
+        args.pre = clipper::MAX_PADDING + 1.0;
+        assert!(matches!(
+            validate_float_args(&args),
+            Err(Error::InvalidPadding { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_float_args_rejects_an_out_of_range_confidence() {
+        // A NaN confidence makes `d.confidence >= args.confidence` false for
+        // every detection, so the run discards them all and still exits 0.
+        for value in [f32::NAN, f32::INFINITY, -0.1, 1.1] {
+            let mut args = valid_args();
+            args.confidence = value;
+            assert!(
+                matches!(
+                    validate_float_args(&args),
+                    Err(Error::InvalidConfidence { .. })
+                ),
+                "confidence {value} was not rejected"
+            );
+        }
+    }
+
+    /// Both guards run before any I/O, so `execute` can be driven with no
+    /// fixture at all. These exist because the five tests around them call
+    /// `validate_float_args` directly, which covers the rule and says nothing
+    /// about whether anything calls it: deleting either `?` in `execute` left
+    /// the whole suite green.
+    #[test]
+    fn test_execute_applies_the_float_guard() {
+        let mut args = valid_args();
+        args.pre = f64::NAN;
+        assert!(matches!(
+            execute(&args, OutputMode::Human),
+            Err(Error::InvalidPadding { .. })
+        ));
+
+        let mut args = valid_args();
+        args.confidence = f32::NAN;
+        assert!(matches!(
+            execute(&args, OutputMode::Human),
+            Err(Error::InvalidConfidence { .. })
+        ));
+    }
+
+    #[test]
+    fn test_execute_applies_the_range_guard() {
+        // An inverted range, which is also the CLI-route case no test drove:
+        // clap accepts each bound on its own and only the command sees the
+        // pair.
+        let mut args = valid_args();
+        args.audio = Some(PathBuf::from("/nonexistent/birda-command-test.wav"));
+        args.start = Some(5.0);
+        args.end = Some(1.0);
+        assert!(matches!(
+            execute(&args, OutputMode::Human),
+            Err(Error::InvalidTimeRange { .. })
+        ));
+
+        args.end = Some(f64::INFINITY);
+        assert!(matches!(
+            execute(&args, OutputMode::Human),
+            Err(Error::InvalidTimeRange { .. })
+        ));
+
+        // Finite and increasing, and still wrong. `parse_time` refuses a
+        // negative start, and until the same rule reached the shared helper a
+        // library caller with this got seconds 0 to 4 back, under a name
+        // claiming -100 to -1, because `(start - pre).max(0.0)` clamps.
+        args.start = Some(-100.0);
+        args.end = Some(-1.0);
+        assert!(matches!(
+            execute(&args, OutputMode::Human),
+            Err(Error::InvalidTimeRange { .. })
+        ));
+    }
+
+    /// The rule `validate_float_args` claims to share with the CLI, enforced
+    /// rather than asserted in prose. The two spell it differently
+    /// (`confidence::MIN..=MAX` here, the literals `0.0..=1.0` in
+    /// `parse_confidence`), so only a differential test keeps them together.
+    #[test]
+    fn test_the_confidence_rule_matches_the_cli_parser() {
+        for value in ["-0.1", "0.0", "0.5", "1.0", "1.1", "nan", "inf", "-inf"] {
+            let cli_ok = crate::cli::validators::parse_confidence(value).is_ok();
+
+            let mut args = valid_args();
+            args.confidence = value.parse().unwrap_or(f32::NAN);
+            let library_ok = validate_float_args(&args).is_ok();
+
+            assert_eq!(cli_ok, library_ok, "the two routes disagree on {value}");
+        }
+    }
+
+    #[test]
+    fn test_validate_float_args_accepts_the_confidence_bounds() {
+        for value in [confidence::MIN, confidence::MAX] {
+            let mut args = valid_args();
+            args.confidence = value;
+            assert!(
+                validate_float_args(&args).is_ok(),
+                "{value} should be legal"
+            );
+        }
+    }
 }

--- a/src/clipper/extractor.rs
+++ b/src/clipper/extractor.rs
@@ -15,9 +15,32 @@ use symphonia::core::units::Time;
 use tracing::trace;
 
 use crate::Error;
-use crate::constants::clipper::SEEK_THRESHOLD_SECS;
+use crate::constants::clipper::{
+    MAX_CLIP_PREALLOC_SAMPLES, MAX_CLIP_PREALLOC_SECS, SEEK_THRESHOLD_SECS,
+};
 
-use super::DetectionGroup;
+use super::{DetectionGroup, validate_time_range};
+
+/// How many samples an extracted clip may reserve up front, for a file at
+/// `sample_rate`.
+///
+/// Two terms, because each covers the other's blind spot.
+///
+/// The rate-scaled one keeps the cap meaning the same duration whatever the
+/// recording is: a flat sample count would be a full minute at 48 kHz but a
+/// fifth of that on ultrasonic material, short enough that the default bat
+/// clip would exceed it before anything unusual happened.
+///
+/// The absolute one is not belt and braces. `sample_rate` is read straight out
+/// of the container and validated nowhere, so a hand-built WAV declaring
+/// `u32::MAX` scales the first term to 257 billion samples and asks for a
+/// terabyte, which is #310 again by another road. `unwrap_or(0)` fails towards
+/// no reservation rather than an unbounded one, for the same reason.
+fn prealloc_cap(sample_rate: u32) -> usize {
+    MAX_CLIP_PREALLOC_SECS
+        .saturating_mul(usize::try_from(sample_rate).unwrap_or(0))
+        .min(MAX_CLIP_PREALLOC_SAMPLES)
+}
 
 /// Result of clip extraction.
 pub struct ExtractedClip {
@@ -58,12 +81,18 @@ impl ClipExtractor {
     ///
     /// # Errors
     ///
-    /// Returns an error if the audio file cannot be read or decoded.
+    /// Returns [`Error::InvalidTimeRange`] if `group`'s bounds are not finite
+    /// or do not increase, and an error if the audio file cannot be read or
+    /// decoded.
     pub fn extract_clip(
         &self,
         source_path: &Path,
         group: &DetectionGroup,
     ) -> Result<ExtractedClip, Error> {
+        // `ClipExtractor` is public and the range reaches an allocation below,
+        // so validate here instead of trusting every path in.
+        validate_time_range(group.start, group.end)?;
+
         // Open the audio file
         let file = std::fs::File::open(source_path).map_err(|e| Error::AudioOpen {
             path: source_path.to_path_buf(),
@@ -112,8 +141,25 @@ impl ClipExtractor {
         let start_sample = (group.start * f64::from(sample_rate)) as u64;
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let end_sample = (group.end * f64::from(sample_rate)) as u64;
-        #[allow(clippy::cast_possible_truncation)]
-        let expected_samples = (end_sample - start_sample) as usize;
+
+        // Capped, because a range that passes validation can still be
+        // enormous: an end of 1e12 seconds is finite and non-negative, and at
+        // 48 kHz it works out to 4.8e16 samples, which `Vec::with_capacity`
+        // answers by aborting the process. Undersizing only costs
+        // reallocations, since the buffer grows to whatever the decode loop
+        // actually produces.
+        //
+        // `saturating_sub` cannot trigger given the check above (the cast is
+        // monotonic, so a validated `end > start` gives `end_sample >=
+        // start_sample`); it is here so the expression stays correct on its
+        // own terms rather than depending on a check twenty lines away.
+        // `usize::MAX` is likewise unreachable on a 64-bit target and is the
+        // honest fallback on a 32-bit one, where the `.min` then applies the
+        // real bound.
+        //
+        let expected_samples = usize::try_from(end_sample.saturating_sub(start_sample))
+            .unwrap_or(usize::MAX)
+            .min(prealloc_cap(sample_rate));
 
         // Create decoder
         let decoder_opts = DecoderOptions::default();
@@ -217,5 +263,91 @@ impl ClipExtractor {
             samples,
             sample_rate,
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn group(start: f64, end: f64) -> DetectionGroup {
+        DetectionGroup {
+            scientific_name: "Parus major".to_string(),
+            common_name: "Great Tit".to_string(),
+            start,
+            end,
+            max_confidence: 1.0,
+            detection_count: 1,
+        }
+    }
+
+    /// A path that cannot exist, so a validation error proves the range is
+    /// rejected before any I/O rather than deep in the decode loop, where the
+    /// bad value has already been cast to a sample count.
+    fn missing_path() -> &'static Path {
+        Path::new("/nonexistent/birda-extractor-test-fixture.wav")
+    }
+
+    #[test]
+    fn test_prealloc_cap_scales_with_the_rate_but_never_past_the_ceiling() {
+        // The ordinary case: a full minute of audio, whatever the rate.
+        assert_eq!(prealloc_cap(48_000), MAX_CLIP_PREALLOC_SECS * 48_000);
+        assert_eq!(
+            prealloc_cap(crate::constants::bat::SAMPLE_RATE),
+            MAX_CLIP_PREALLOC_SAMPLES,
+            "the ceiling is set at the highest rate the tool handles, so it \
+             should bind exactly there and not below"
+        );
+
+        // The reason the ceiling exists. Nothing validates the rate a
+        // container declares, and 60 seconds at `u32::MAX` is 257 billion
+        // samples, a terabyte of reservation from a hand-built header.
+        assert_eq!(prealloc_cap(u32::MAX), MAX_CLIP_PREALLOC_SAMPLES);
+        assert!(
+            MAX_CLIP_PREALLOC_SAMPLES < MAX_CLIP_PREALLOC_SECS.saturating_mul(u32::MAX as usize)
+        );
+
+        // A rate of zero reserves nothing rather than everything.
+        assert_eq!(prealloc_cap(0), 0);
+    }
+
+    #[test]
+    fn test_extract_clip_rejects_non_finite_range_before_touching_the_file() {
+        for (start, end) in [
+            (0.0, f64::INFINITY),
+            (f64::NAN, 5.0),
+            (0.0, f64::NAN),
+            (f64::NEG_INFINITY, 5.0),
+            (f64::NAN, f64::NAN),
+        ] {
+            let result = ClipExtractor::new().extract_clip(missing_path(), &group(start, end));
+            assert!(
+                matches!(result, Err(Error::InvalidTimeRange { .. })),
+                "start={start} end={end} was not rejected as an invalid range"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_clip_rejects_empty_and_inverted_ranges() {
+        for (start, end) in [(5.0, 5.0), (5.0, 1.0)] {
+            let result = ClipExtractor::new().extract_clip(missing_path(), &group(start, end));
+            assert!(
+                matches!(result, Err(Error::InvalidTimeRange { .. })),
+                "start={start} end={end} was not rejected as an invalid range"
+            );
+        }
+    }
+
+    #[test]
+    fn test_a_valid_range_gets_past_validation() {
+        // The counterpart to the cases above: a sane range must reach the file
+        // open and fail there, not in the range check.
+        let result = ClipExtractor::new().extract_clip(missing_path(), &group(1.0, 3.0));
+        assert!(
+            matches!(result, Err(Error::AudioOpen { .. })),
+            "a valid range should have reached the file open and failed there"
+        );
     }
 }

--- a/src/clipper/mod.rs
+++ b/src/clipper/mod.rs
@@ -14,3 +14,37 @@ pub use extractor::{ClipExtractor, ExtractedClip};
 pub use grouper::{DetectionGroup, group_detections};
 pub use parser::{ParsedDetection, parse_detection_file};
 pub use writer::WavWriter;
+
+use crate::Error;
+
+/// Check that a clip's time range is usable, at every layer that accepts one.
+///
+/// Shared rather than restated, because the two callers are the command's
+/// range guard and the extractor's own entry check, and a rule spelled twice
+/// is a rule that can be tightened in one place only. Issue #306 was filed
+/// against exactly that shape.
+///
+/// The finiteness test has to come first and cannot be inferred from the
+/// ordering: every comparison against NaN is false, so `end <= start` accepts
+/// NaN, and it accepts an infinite `end` too because nothing is greater than
+/// infinity. Both then reach a seconds-to-samples cast, which saturates rather
+/// than trapping.
+///
+/// The lower bound is not implied by the ordering either. `--start -100 --end
+/// -1` is finite and increasing, and `parse_time` refuses it, but a library
+/// caller reaches this with it: `(start - pre).max(0.0)` then clamps to 0.0
+/// and the caller silently receives the opening seconds of the file under a
+/// name claiming a range it never asked for. Same class of wrong answer #310
+/// was filed for, so the rule is enforced here rather than only in clap.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidTimeRange`] if either bound is not finite or
+/// negative, or if `end` is not strictly greater than `start`.
+pub(crate) fn validate_time_range(start: f64, end: f64) -> Result<(), Error> {
+    if !start.is_finite() || !end.is_finite() || start < 0.0 || end <= start {
+        return Err(Error::InvalidTimeRange { start, end });
+    }
+
+    Ok(())
+}

--- a/src/clipper/parser.rs
+++ b/src/clipper/parser.rs
@@ -6,8 +6,10 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use tracing::warn;
 
 use crate::Error;
+use crate::constants::clipper::MAX_SKIPPED_ROW_WARNINGS;
 
 /// Internal record for CSV deserialization.
 #[derive(Debug, Deserialize)]
@@ -47,14 +49,23 @@ pub struct ParsedDetection {
 /// Handles UTF-8 BOM if present, quoted fields with embedded commas,
 /// and escaped quotes within fields.
 ///
+/// A row whose start, end or confidence is not finite is **dropped**, with a
+/// warning naming its line, and the call still succeeds. Every returned
+/// [`ParsedDetection`] therefore has finite fields and `end > start`, and the
+/// returned length may be shorter than the file. The alternative, failing the
+/// file, costs every good row beside the bad one, because a caller that gets
+/// an error here has no way to recover the rest.
+///
 /// # Errors
 ///
 /// Returns an error if:
 /// - The file cannot be read
 /// - Required columns are missing
 /// - Values cannot be parsed
+/// - A row's end time is not greater than its start time
 ///
-/// Returns `Ok(vec![])` if the file contains no detections (empty or header-only).
+/// Returns `Ok(vec![])` if the file contains no detections (empty, header-only,
+/// or every row dropped).
 pub fn parse_detection_file(path: &Path) -> Result<Vec<ParsedDetection>, Error> {
     let mut reader = csv::ReaderBuilder::new()
         .has_headers(true)
@@ -66,11 +77,67 @@ pub fn parse_detection_file(path: &Path) -> Result<Vec<ParsedDetection>, Error> 
         })?;
 
     let mut detections = Vec::new();
+    let mut skipped = 0usize;
 
     for (line_num, result) in reader.deserialize::<DetectionRecord>().enumerate() {
         let record = result.map_err(|e| Error::InvalidDetectionFormat {
             message: format!("line {}: {e}", line_num + 2),
         })?;
+
+        // The ordering test below cannot reject a non-finite value:
+        // `record.end <= record.start` is false whenever either side is NaN,
+        // and false again for an infinite end, so both used to reach the
+        // extractor. An infinite end aborted the process with a capacity
+        // overflow, a NaN start was laundered into 0.0 by the grouper's
+        // `.max(0.0)` and produced a clip over a range the file never claimed,
+        // and a NaN confidence made `confidence >= threshold` false so the row
+        // vanished with no diagnostic at all.
+        //
+        // Skipped rather than rejected, and the distinction is the whole point
+        // of the check. `process_detection_file` discards an entire file when
+        // this function returns an error, so a hard error here trades one
+        // unusable row for every good row beside it: a 10,000-row file with a
+        // single bad line yields nothing. The extractor's own guard already
+        // contains a bad range safely one row at a time, so failing the file
+        // buys no safety and costs the other 9,999 clips.
+        //
+        // The pre-existing `end <= start` rejection below keeps its hard-error
+        // contract, which `test_invalid_time_range_error` here and
+        // `test_parse_invalid_time_range_returns_error` in
+        // `tests/clipper_parser_test.rs` both pin. The argument above applies
+        // to it just as well, so the two rejections now differ in blast radius
+        // for no reason a user could infer, but widening a twice-pinned
+        // contract is a policy change rather than a fix for #310. Tracked in
+        // #319 with the rest of the command's error contract.
+        //
+        // The per-row warnings are counted and capped, because the row count
+        // is caller-supplied: a file of nothing but malformed rows would
+        // otherwise spend several times the parsing cost on formatting
+        // diagnostics nobody will read past the first few.
+        if !record.start.is_finite() || !record.end.is_finite() {
+            skipped += 1;
+            if skipped <= MAX_SKIPPED_ROW_WARNINGS {
+                warn!(
+                    "line {}: skipping detection, start ({}) and end ({}) must both be finite",
+                    line_num + 2,
+                    record.start,
+                    record.end
+                );
+            }
+            continue;
+        }
+
+        if !record.confidence.is_finite() {
+            skipped += 1;
+            if skipped <= MAX_SKIPPED_ROW_WARNINGS {
+                warn!(
+                    "line {}: skipping detection, confidence ({}) must be finite",
+                    line_num + 2,
+                    record.confidence
+                );
+            }
+            continue;
+        }
 
         // Validate time range
         if record.end <= record.start {
@@ -93,10 +160,19 @@ pub fn parse_detection_file(path: &Path) -> Result<Vec<ParsedDetection>, Error> 
         });
     }
 
+    if skipped > MAX_SKIPPED_ROW_WARNINGS {
+        warn!(
+            "skipped {skipped} malformed detections in '{}'; {} further warnings suppressed",
+            path.display(),
+            skipped - MAX_SKIPPED_ROW_WARNINGS
+        );
+    }
+
     Ok(detections)
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;
@@ -119,6 +195,158 @@ mod tests {
         assert_eq!(detections[0].scientific_name, "Turdus merula");
         assert!((detections[0].confidence - 0.85).abs() < 0.001);
         assert_eq!(detections[1].scientific_name, "Parus major");
+    }
+
+    /// Write a one-detection CSV and parse it, so the non-finite cases below
+    /// differ only in the row under test.
+    fn parse_single_row(row: &str) -> Result<Vec<ParsedDetection>, Error> {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        writeln!(file, "{row}").unwrap();
+        file.flush().unwrap();
+
+        parse_detection_file(file.path())
+    }
+
+    #[test]
+    fn test_parse_skips_rows_with_non_finite_times() {
+        // `end <= start` is false whenever either side is NaN, and false again
+        // for an infinite end, so both used to reach the extractor: infinity
+        // aborted the process on a `Vec::with_capacity`, NaN wrote a clip over
+        // a range the file never claimed.
+        for row in [
+            "0.0,inf,Parus major,Great Tit,0.85",
+            "0.0,-inf,Parus major,Great Tit,0.85",
+            "nan,3.0,Parus major,Great Tit,0.85",
+            "0.0,nan,Parus major,Great Tit,0.85",
+            "inf,inf,Parus major,Great Tit,0.85",
+        ] {
+            let detections = parse_single_row(row).unwrap();
+            assert!(detections.is_empty(), "{row} produced {detections:?}");
+        }
+    }
+
+    #[test]
+    fn test_parse_keeps_the_rows_around_a_skipped_time_range() {
+        // The measured cost of getting this wrong: a hard error here discards
+        // the whole file, so a 10,000-row detection file with one bad line
+        // yields nothing at all. The extractor's own guard already contains a
+        // bad range one row at a time.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        writeln!(file, "0.0,3.0,Parus major,Great Tit,0.85").unwrap();
+        writeln!(file, "5.0,inf,Parus major,Great Tit,0.85").unwrap();
+        writeln!(file, "10.0,13.0,Turdus merula,Eurasian Blackbird,0.91").unwrap();
+        file.flush().unwrap();
+
+        let detections = parse_detection_file(file.path()).unwrap();
+        assert_eq!(
+            detections.len(),
+            2,
+            "only the infinite row should be dropped"
+        );
+        assert!(
+            detections
+                .iter()
+                .all(|d| d.start.is_finite() && d.end.is_finite())
+        );
+    }
+
+    #[test]
+    fn test_parse_skips_every_bad_row_even_past_the_warning_cap() {
+        // The warnings are capped, the skipping is not. A file with more
+        // malformed rows than `MAX_SKIPPED_ROW_WARNINGS` must still drop all
+        // of them and keep all the good ones.
+        let bad_rows = MAX_SKIPPED_ROW_WARNINGS * 3;
+
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        for i in 0..bad_rows {
+            writeln!(file, "{i}.0,inf,Parus major,Great Tit,0.85").unwrap();
+        }
+        writeln!(file, "0.0,3.0,Turdus merula,Eurasian Blackbird,0.85").unwrap();
+        file.flush().unwrap();
+
+        let detections = parse_detection_file(file.path()).unwrap();
+        assert_eq!(detections.len(), 1, "{bad_rows} bad rows should all skip");
+        assert_eq!(detections[0].scientific_name, "Turdus merula");
+    }
+
+    #[test]
+    fn test_parse_skips_a_confidence_that_overflows_f32() {
+        // `1e40` is an ordinary decimal a hand-edited or third-party CSV can
+        // carry, and it overflows `f32` to infinity on the way in. Before it
+        // was skipped here it survived as `inf`, comparing greater than every
+        // threshold.
+        let detections = parse_single_row("0.0,3.0,Parus major,Great Tit,1e40").unwrap();
+        assert!(detections.is_empty(), "{detections:?}");
+    }
+
+    #[test]
+    fn test_parse_skips_a_row_with_a_non_finite_confidence() {
+        // A NaN confidence made `confidence >= threshold` false, dropping the
+        // detection with no diagnostic and a zero exit code. It is now skipped
+        // with a warning rather than failing the file: `process_detection_file`
+        // discards a whole file when this function errors, so one odd
+        // confidence must not cost the rows around it.
+        let detections = parse_single_row("0.0,3.0,Parus major,Great Tit,nan").unwrap();
+        assert!(detections.is_empty(), "{detections:?}");
+    }
+
+    #[test]
+    fn test_parse_keeps_the_rows_around_a_skipped_confidence() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        writeln!(file, "0.0,3.0,Parus major,Great Tit,0.85").unwrap();
+        writeln!(file, "5.0,8.0,Parus major,Great Tit,nan").unwrap();
+        writeln!(file, "10.0,13.0,Turdus merula,Eurasian Blackbird,0.91").unwrap();
+        file.flush().unwrap();
+
+        let detections = parse_detection_file(file.path()).unwrap();
+        assert_eq!(detections.len(), 2, "only the NaN row should be dropped");
+        assert!(detections.iter().all(|d| d.confidence.is_finite()));
+    }
+
+    #[test]
+    fn test_parse_still_rejects_an_inverted_range_by_line() {
+        // The pre-existing hard-error contract, unchanged by #310: a non-finite
+        // value skips its row, an inverted range still fails the file.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        writeln!(file, "0.0,3.0,Parus major,Great Tit,0.85").unwrap();
+        writeln!(file, "8.0,5.0,Parus major,Great Tit,0.85").unwrap();
+        file.flush().unwrap();
+
+        let err =
+            parse_detection_file(file.path()).expect_err("an inverted range must be rejected");
+        assert!(err.to_string().contains("line 3"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_accepts_finite_boundary_values() {
+        let detections = parse_single_row("0.0,0.001,Parus major,Great Tit,0.0").unwrap();
+        assert_eq!(detections.len(), 1);
+        assert!(detections[0].confidence.abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -203,6 +203,57 @@ pub mod clipper {
 
     /// Supported audio file extensions for source audio resolution.
     pub const AUDIO_EXTENSIONS: &[&str] = &["wav", "flac", "mp3", "m4a", "aac"];
+
+    /// Upper bound, in seconds of audio, on what an extracted clip reserves up
+    /// front.
+    ///
+    /// Denominated in seconds rather than samples on purpose: the extractor
+    /// multiplies by the file's own sample rate. A flat sample count would
+    /// mean 60 seconds at 48 kHz but only 11.25 at `bat::SAMPLE_RATE`, which
+    /// is short enough that the default bat clip (a 3-second detection plus
+    /// the default padding) would exceed it before anything unusual happened.
+    ///
+    /// The reservation is only a sizing hint: the decode loop pushes the
+    /// samples it actually finds and the buffer grows on demand, so a longer
+    /// clip costs geometric reallocations, the last of which holds both
+    /// buffers and so peaks around 1.5 times the final size. Below the cap
+    /// that costs nothing at all, and above it a modest fraction of the
+    /// extraction.
+    ///
+    /// The cap exists because the requested range is caller-supplied and its
+    /// length is not otherwise bounded. `--end 1e12` is finite, non-negative
+    /// and passes every range check, yet at 48 kHz it asks for 4.8e16 samples,
+    /// and a reservation that large aborts the process rather than returning
+    /// an error.
+    ///
+    /// Clips longer than this exist and are fine: `MAX_PADDING` alone allows a
+    /// 603-second clip around a 3-second detection, and `group_detections`
+    /// merges overlapping padded ranges without limit, so a species calling
+    /// through a dawn recording routinely produces one much longer group.
+    pub const MAX_CLIP_PREALLOC_SECS: usize = 60;
+
+    /// Absolute ceiling on an extracted clip's reservation, whatever the file
+    /// claims its sample rate to be.
+    ///
+    /// `MAX_CLIP_PREALLOC_SECS` is scaled by the rate read out of the
+    /// container, and that rate is not validated anywhere: a hand-built WAV
+    /// can declare `u32::MAX`, which scales the ceiling to 257 billion samples
+    /// and asks for a terabyte. That is the reservation #310 was filed about,
+    /// reintroduced through the mechanism added to prevent it, so the
+    /// rate-scaled term needs a term beside it that no input can move.
+    ///
+    /// 60 seconds at the highest rate the tool actually handles, so it binds
+    /// only when a file is lying.
+    pub const MAX_CLIP_PREALLOC_SAMPLES: usize =
+        MAX_CLIP_PREALLOC_SECS * super::bat::SAMPLE_RATE as usize;
+
+    /// Malformed detection rows reported individually before the rest are
+    /// summarised.
+    ///
+    /// The row count is caller-supplied, so a file of nothing but malformed
+    /// rows would otherwise emit one formatted warning per row, which costs
+    /// several times what parsing the rows costs.
+    pub const MAX_SKIPPED_ROW_WARNINGS: usize = 10;
 }
 
 /// Bat detection constants.

--- a/src/error.rs
+++ b/src/error.rs
@@ -433,12 +433,44 @@ pub enum Error {
     },
 
     /// Invalid time range for clip extraction.
-    #[error("invalid time range: end ({end}s) must be greater than start ({start}s)")]
+    ///
+    /// Covers a non-finite bound as well as an out-of-order one, because the
+    /// ordering test alone never rejects NaN.
+    // Unit outside the parentheses, as in `InvalidPadding`: a NaN bound would
+    // otherwise render as `NaNs`.
+    #[error(
+        "invalid time range: start {start}, end {end} (both must be finite non-negative seconds, with end greater than start)"
+    )]
     InvalidTimeRange {
         /// Start time in seconds.
         start: f64,
         /// End time in seconds.
         end: f64,
+    },
+
+    /// Invalid clip padding value.
+    // No unit suffix directly after `{value}`: this variant exists to report
+    // non-finite values, and `NaNs` reads as a plural rather than a quantity.
+    // The parenthesised-constraint shape matches `InvalidLatitude` and its
+    // siblings.
+    #[error(
+        "invalid padding: {value} (must be a finite number of seconds from 0.0 to {:.1})",
+        crate::constants::clipper::MAX_PADDING
+    )]
+    InvalidPadding {
+        /// The rejected padding value in seconds.
+        value: f64,
+    },
+
+    /// Invalid clip confidence threshold.
+    #[error(
+        "invalid confidence: {value} (must be a finite number from {:.1} to {:.1})",
+        crate::constants::confidence::MIN,
+        crate::constants::confidence::MAX
+    )]
+    InvalidConfidence {
+        /// The rejected confidence value.
+        value: f32,
     },
 
     /// BSG model configuration error.
@@ -619,5 +651,44 @@ mod tests {
             value: "foobar".to_string(),
         };
         assert_eq!(err.to_string(), "invalid output format: foobar");
+    }
+
+    /// The three #310 messages, asserted on their rendered text rather than
+    /// their variant. The rest of the suite matches on the variant, so the
+    /// wording was free to drift, and the wording is the whole user-visible
+    /// half of the fix. Each case is a non-finite value on purpose: that is
+    /// the population these variants exist to report, and it is where a unit
+    /// suffix placed straight after the value renders as `NaNs`.
+    #[test]
+    fn test_invalid_time_range_renders_both_bounds() {
+        let err = Error::InvalidTimeRange {
+            start: f64::NAN,
+            end: 5.0,
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid time range: start NaN, end 5 \
+             (both must be finite non-negative seconds, with end greater than start)"
+        );
+    }
+
+    #[test]
+    fn test_invalid_padding_renders_the_value_and_the_ceiling() {
+        let err = Error::InvalidPadding {
+            value: f64::INFINITY,
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid padding: inf (must be a finite number of seconds from 0.0 to 300.0)"
+        );
+    }
+
+    #[test]
+    fn test_invalid_confidence_renders_the_value_and_the_range() {
+        let err = Error::InvalidConfidence { value: f32::NAN };
+        assert_eq!(
+            err.to_string(),
+            "invalid confidence: NaN (must be a finite number from 0.0 to 1.0)"
+        );
     }
 }

--- a/tests/clip_integration_test.rs
+++ b/tests/clip_integration_test.rs
@@ -1,11 +1,51 @@
-//! Integration test for clip extraction.
+//! Integration test for clip extraction, including the non-finite and
+//! out-of-range time inputs of #310, which used to abort the process on an
+//! allocation or exit 0 after writing a clip nobody asked for.
+//!
+//! These drive the real binary, because the hazard is in the seam between the
+//! CLI parsers, the range guard and the extractor's allocation, and each layer
+//! looks correct on its own.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::Output;
+use std::time::Duration;
 
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use hound::{SampleFormat, WavSpec, WavWriter};
 use tempfile::TempDir;
+
+/// Bound every spawn, following `tests/config_validation.rs`.
+///
+/// `test_clip_survives_a_range_far_beyond_the_file` is why this matters here:
+/// it asks for a range of 1e12 seconds, and the regression it guards against
+/// is the extractor trying to service that literally. Unbounded, such a
+/// regression hangs the suite instead of failing it.
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A `birda` invocation insulated from the developer's shell.
+///
+/// Two variables would otherwise decide what these assertions see:
+///
+/// - `--output-mode` is `global = true` and bound to `BIRDA_OUTPUT_MODE`, so
+///   it applies to `clip` as well as `analyze`, and it reshapes both streams.
+/// - `init_logging` builds its filter with `EnvFilter::try_from_default_env`,
+///   so an inherited `RUST_LOG` overrides the built-in level. The skipped-row
+///   assertions below match on `warn!` output, and `RUST_LOG=error` makes
+///   them match nothing.
+///
+/// Either one exported in a shell profile changes the result rather than
+/// failing outright, which is the harder failure to notice.
+fn birda_cmd() -> Command {
+    let mut cmd = cargo_bin_cmd!("birda");
+    cmd.timeout(COMMAND_TIMEOUT)
+        .env_remove("BIRDA_OUTPUT_MODE")
+        .env_remove("RUST_LOG");
+    cmd
+}
 
 /// Create a dummy WAV file with silence for testing.
 fn create_test_wav(path: &std::path::Path, duration_secs: u32, sample_rate: u32) {
@@ -47,7 +87,7 @@ fn test_clip_command_extracts_clips() {
 
     let output_dir = temp_dir.path().join("clips");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_birda"))
+    let output = birda_cmd()
         .args([
             "clip",
             csv_path.to_str().unwrap(),
@@ -84,7 +124,7 @@ fn test_clip_command_extracts_clips() {
 
 #[test]
 fn test_clip_help_displays() {
-    let output = Command::new(env!("CARGO_BIN_EXE_birda"))
+    let output = birda_cmd()
         .args(["clip", "--help"])
         .output()
         .expect("failed to execute birda clip --help");
@@ -146,4 +186,360 @@ fn test_csv_roundtrip_parse() {
     assert_eq!(parsed[0].scientific_name, "Parus major");
     assert_eq!(parsed[1].scientific_name, "Cyanistes caeruleus");
     assert!((parsed[0].confidence - 0.8542).abs() < 0.001);
+}
+
+/// Run `birda clip` in direct-extraction mode and hand back the finished process.
+fn run_direct_clip(wav: &std::path::Path, out: &std::path::Path, extra: &[&str]) -> Output {
+    let mut args = vec![
+        "clip",
+        "--audio",
+        wav.to_str().unwrap(),
+        "--output",
+        out.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+
+    birda_cmd()
+        .args(&args)
+        .output()
+        .expect("failed to execute birda clip")
+}
+
+/// A run rejected by clap's `value_parser` must fail cleanly: non-zero exit, a
+/// diagnostic naming the offending option, and no panic or allocation abort.
+///
+/// The `error: invalid value` assertion is what pins each test to the layer it
+/// names. Every guard added for #310 sits at a different layer and they all
+/// phrase the rejection similarly, so a test matching only on the message text
+/// stays green when the parser it is meant to cover is deleted and a
+/// downstream guard catches the value instead. That is not hypothetical: it
+/// was true of the padding test until this assertion was added. Only the clap
+/// parser produces this prefix.
+fn assert_rejected_by_clap(output: &Output, expected: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected a non-zero exit, got success. stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("error: invalid value"),
+        "the value should have been rejected by the argument parser, not \
+         further downstream: {stderr}"
+    );
+    assert!(
+        stderr.contains(expected),
+        "stderr did not mention {expected:?}: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "the run panicked instead of reporting an error: {stderr}"
+    );
+    assert!(
+        !stderr.contains("memory allocation of"),
+        "the run aborted on an allocation instead of reporting an error: {stderr}"
+    );
+}
+
+/// `--end inf` used to abort the process with `capacity overflow`: the cast
+/// from seconds to samples saturates rather than trapping, so the extractor
+/// asked `Vec::with_capacity` for `u64::MAX` samples.
+#[test]
+fn test_clip_rejects_infinite_end() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("tone.wav");
+    create_test_wav(&wav_path, 5, 48000);
+
+    let output = run_direct_clip(
+        &wav_path,
+        &temp_dir.path().join("clips"),
+        &["--start", "0", "--end", "inf"],
+    );
+
+    assert_rejected_by_clap(&output, "finite non-negative");
+}
+
+/// `--start nan` used to exit 0 after writing `detection_NaN-5.wav` over a
+/// range nobody asked for, because every comparison against NaN is false.
+#[test]
+fn test_clip_rejects_nan_start() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("tone.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = run_direct_clip(&wav_path, &output_dir, &["--start", "nan", "--end", "5"]);
+
+    assert_rejected_by_clap(&output, "finite non-negative");
+    assert!(
+        !output_dir.exists() || std::fs::read_dir(&output_dir).unwrap().next().is_none(),
+        "a rejected run must not write a clip"
+    );
+}
+
+/// `--pre nan` was swallowed by `(start - pre).max(0.0)`, which returns the
+/// other operand for a NaN receiver, so the padding vanished without a word.
+#[test]
+fn test_clip_rejects_nan_padding() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("tone.wav");
+    create_test_wav(&wav_path, 5, 48000);
+
+    for flag in ["--pre", "--post"] {
+        let output = run_direct_clip(
+            &wav_path,
+            &temp_dir.path().join("clips"),
+            &["--start", "1", "--end", "3", flag, "nan"],
+        );
+        assert_rejected_by_clap(&output, "finite non-negative");
+    }
+}
+
+/// The case the finiteness checks do not cover: `--end 1e12` is finite,
+/// non-negative and passes every range test, yet at 48 kHz it asks for 4.8e16
+/// samples, and the process used to die with
+/// `memory allocation of 192000000000960000 bytes failed`. The reservation is
+/// now capped, so the run succeeds and returns what the file actually holds.
+#[test]
+fn test_clip_survives_a_range_far_beyond_the_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("tone.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = run_direct_clip(
+        &wav_path,
+        &output_dir,
+        &["--start", "0", "--end", "1e12", "--pre", "0", "--post", "0"],
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "a huge but finite range must not abort the process: {stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(!stderr.contains("memory allocation of"), "{stderr}");
+
+    let clips: Vec<_> = walk_wav_files(&output_dir);
+    assert_eq!(
+        clips.len(),
+        1,
+        "expected exactly one clip in {output_dir:?}"
+    );
+
+    // The clip is bounded by the file, not by the requested end.
+    let reader = hound::WavReader::open(&clips[0]).unwrap();
+    assert_eq!(
+        reader.duration(),
+        5 * 48000,
+        "the clip should hold the whole 5s file"
+    );
+}
+
+/// An infinite end in a detection file reached the same allocation as the CLI
+/// route, because `end <= start` is false for infinity too.
+#[test]
+fn test_clip_skips_non_finite_rows_in_a_detection_file() {
+    // Every fixture is three rows with the bad one in the middle, because a
+    // single-row fixture cannot see the failure this test exists for: a hard
+    // error in the parser discards the whole file, so the two good rows
+    // disappear with the bad one and the run still exits 0. `line 3` is what
+    // pins each case to the parser; the extractor rejects a non-finite range
+    // too, and both layers phrase it the same way.
+    for (bad_row, expected) in [
+        ("5.0,inf,Parus major,Great Tit,0.85", "line 3"),
+        ("nan,8.0,Parus major,Great Tit,0.85", "line 3"),
+        ("5.0,8.0,Parus major,Great Tit,nan", "line 3"),
+        // An ordinary decimal that overflows f32 to infinity on the way in.
+        ("5.0,8.0,Parus major,Great Tit,1e40", "line 3"),
+    ] {
+        let temp_dir = TempDir::new().unwrap();
+        let wav_path = temp_dir.path().join("rec.wav");
+        create_test_wav(&wav_path, 20, 48000);
+
+        let csv_path = temp_dir.path().join("rec.wav.BirdNET.results.csv");
+        let mut csv_file = std::fs::File::create(&csv_path).unwrap();
+        writeln!(
+            csv_file,
+            "Start (s),End (s),Scientific name,Common name,Confidence"
+        )
+        .unwrap();
+        writeln!(csv_file, "0.0,3.0,Turdus merula,Eurasian Blackbird,0.85").unwrap();
+        writeln!(csv_file, "{bad_row}").unwrap();
+        writeln!(csv_file, "12.0,15.0,Erithacus rubecula,European Robin,0.91").unwrap();
+        drop(csv_file);
+
+        let output_dir = temp_dir.path().join("clips");
+        let output = birda_cmd()
+            .args([
+                "clip",
+                csv_path.to_str().unwrap(),
+                "--output",
+                output_dir.to_str().unwrap(),
+                "--pre",
+                "0",
+                "--post",
+                "0",
+            ])
+            .output()
+            .expect("failed to execute birda clip");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!stderr.contains("panicked"), "{bad_row}: {stderr}");
+        assert!(
+            !stderr.contains("memory allocation of"),
+            "{bad_row}: {stderr}"
+        );
+        assert!(
+            stderr.contains(expected),
+            "{bad_row}: stderr did not name the offending line: {stderr}"
+        );
+        assert!(
+            stderr.contains("skipping detection"),
+            "{bad_row}: the skip should be reported, not silent: {stderr}"
+        );
+
+        // Exit 0 is deliberate, not an oversight. `clip` takes many detection
+        // files and reports per-file problems as warnings, so one skipped row
+        // is not a failed run. What matters is that the good rows survived.
+        assert!(
+            output.status.success(),
+            "{bad_row}: skipping a row should not fail the run: {stderr}"
+        );
+        assert_eq!(
+            walk_wav_files(&output_dir).len(),
+            2,
+            "{bad_row}: the two valid detections should still produce clips"
+        );
+    }
+}
+
+/// Collect every `.wav` anywhere under `dir`, at any depth.
+fn walk_wav_files(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return found;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(walk_wav_files(&path));
+        } else if path.extension().is_some_and(|e| e == "wav") {
+            found.push(path);
+        }
+    }
+
+    found
+}
+
+/// The reservation is a sizing hint, and this is what says so.
+///
+/// A mutation adding `samples.truncate(expected_samples)` to the extractor,
+/// turning the hint into a hard bound, passed the whole suite: every other
+/// fixture is short enough to sit under the cap, so nothing ever exercised the
+/// buffer growing past it. A clip silently cut to the cap length would have
+/// shipped green.
+///
+/// The fixture is deliberately at 8 kHz. The cap scales with the file's own
+/// sample rate, so a low rate keeps "longer than the cap" cheap to generate
+/// while still crossing it, and the length is derived from the constant rather
+/// than hardcoded so raising the cap cannot quietly retire the test.
+#[test]
+fn test_a_clip_longer_than_the_preallocation_cap_is_complete() {
+    use birda::constants::clipper::MAX_CLIP_PREALLOC_SECS;
+
+    const RATE: u32 = 8_000;
+    let over_cap_secs = u32::try_from(MAX_CLIP_PREALLOC_SECS).unwrap() + 5;
+
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("long.wav");
+    create_test_wav(&wav_path, over_cap_secs, RATE);
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = run_direct_clip(
+        &wav_path,
+        &output_dir,
+        &[
+            "--start",
+            "0",
+            "--end",
+            &over_cap_secs.to_string(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ],
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+
+    let clips = walk_wav_files(&output_dir);
+    assert_eq!(clips.len(), 1, "expected one clip in {output_dir:?}");
+
+    let reader = hound::WavReader::open(&clips[0]).unwrap();
+    assert_eq!(
+        reader.duration(),
+        over_cap_secs * RATE,
+        "the clip was cut short, so the reservation is bounding the output \
+         rather than sizing it"
+    );
+}
+
+/// The per-row warnings are capped and then summarised, and this is what says
+/// so. Deleting both the cap and the summary left the whole suite green, since
+/// every other fixture has at most one bad row.
+#[test]
+fn test_skipped_row_warnings_are_capped_and_then_summarised() {
+    use birda::constants::clipper::MAX_SKIPPED_ROW_WARNINGS;
+
+    let bad_rows = MAX_SKIPPED_ROW_WARNINGS + 5;
+
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("rec.wav");
+    create_test_wav(&wav_path, 20, 48000);
+
+    let csv_path = temp_dir.path().join("rec.wav.BirdNET.results.csv");
+    let mut csv_file = std::fs::File::create(&csv_path).unwrap();
+    writeln!(
+        csv_file,
+        "Start (s),End (s),Scientific name,Common name,Confidence"
+    )
+    .unwrap();
+    for i in 0..bad_rows {
+        writeln!(csv_file, "{i}.0,inf,Parus major,Great Tit,0.85").unwrap();
+    }
+    writeln!(csv_file, "0.0,3.0,Turdus merula,Eurasian Blackbird,0.85").unwrap();
+    drop(csv_file);
+
+    let output_dir = temp_dir.path().join("clips");
+    let output = birda_cmd()
+        .args([
+            "clip",
+            csv_path.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let per_row = stderr.matches("skipping detection").count();
+    assert_eq!(
+        per_row, MAX_SKIPPED_ROW_WARNINGS,
+        "expected exactly {MAX_SKIPPED_ROW_WARNINGS} per-row warnings for \
+         {bad_rows} bad rows: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("skipped {bad_rows} malformed detections")),
+        "the suppressed rows should still be counted: {stderr}"
+    );
+
+    // The cap bounds the diagnostics, never the skipping.
+    assert_eq!(walk_wav_files(&output_dir).len(), 1);
 }


### PR DESCRIPTION
Closes #310.

## The reported bugs

```
$ birda clip --audio tone.wav --start 0 --end inf --output out
thread 'main' panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow

$ birda clip --audio tone.wav --start nan --end 5 --output out2
out2/detection_NaN-5/detection_NaN-5_100p_0.0-10.0.wav      # exit 0
```

One cause under all of it: `parse_time` and `parse_padding` rejected bad input with a bare `value < 0.0`. Every comparison against NaN is false, and `inf < 0.0` is false too, so NaN and infinity both walked through. The range guard in `execute_direct_extraction` was `end <= start`, which NaN slips past for the same reason. Both now use the spelling `parse_overlap` already had, and the range rule moved into a shared `clipper::validate_time_range` so the command guard and the extractor guard cannot be tightened one without the other.

The two paddings failed differently, and the issue's own description of this was too kind. `--pre nan` did not "ignore the padding": `f64::max` returns the other operand for a NaN receiver, so `(start - pre).max(0.0)` collapsed the start bound to 0.0 and the clip began at the start of the file however late `--start` was. `--post nan` has no `.max` to launder it, so the end bound stayed NaN into the seconds-to-samples cast.

## Three more routes to the same failure, in the same command

**The detection-file parser had the identical hole.** `record.end <= record.start` is false whenever either side is NaN and false again for an infinite end, so a CSV carrying either reached the extractor and panicked exactly as the CLI route did.

Such a row is now **skipped with a warning naming its line**, not rejected. That distinction is the whole point: a parse error makes `process_detection_file` discard the entire file, so a hard error would trade one unusable row for every good row beside it. Measured on a four-row file with one poisoned row, that is three clips instead of none. It needs no exotic input either, since `1e40` is an ordinary decimal that overflows `f32` to infinity on the way into the confidence column. The warnings are capped at ten with a summary after, because the row count is caller-supplied. The pre-existing `end <= start` rejection keeps its hard-error contract, which an existing test pins; widening that is tracked in #319.

**The library boundary enforced a weaker rule than the CLI.** `ClipArgs` and `clipper::command::execute` are both public, so a caller reaches these hazards without passing through clap. `execute` now applies the CLI's rules itself, including the `MAX_PADDING` ceiling and the confidence range. The confidence half matters most: every comparison against a NaN threshold is false, so the filter would have discarded every detection and reported success.

**The extractor aborted on input that was never non-finite at all.** This one is not in the issue. `--end 1e12` is finite, non-negative and passes every range check, but at 48 kHz it works out to 4.8e16 samples:

```
$ birda clip --audio tone.wav --start 0 --end 1e12 --output out4
memory allocation of 192000000000000000 bytes failed
```

The reservation is only a sizing hint, so it is capped and the buffer grows to whatever the decode loop actually produces. The cap has two terms because each covers the other's blind spot:

- **scaled by the file's own rate**, because a flat sample count would be a full minute at 48 kHz but 11.25 seconds at the 256 kHz bat rate, short enough that the *default* bat clip would exceed it before anything unusual happened;
- **an absolute ceiling**, because the rate is read out of the container and validated nowhere. A hand-built WAV declaring `u32::MAX` scales the first term to 257 billion samples and asks for 1.03 TB, which is this very bug by another road. The final review round caught that, in a fix I had written to prevent it.

Benchmarked: nothing below the cap, 6 to 14 percent of extraction above it, about 6 percent of a whole invocation on a ten-minute clip.

`ClipExtractor::extract_clip` is public, so it validates the range itself rather than trusting its callers.

## Verification

Every guard was checked by reverting it individually and confirming the new tests go red. Three attempts did not survive that and were rewritten:

- the padding test passed with the clap guard deleted, because `execute`'s own check phrases the rejection the same way;
- the detection-file test could be satisfied by the extractor's error rather than the parser's, since both layers say "must both be finite";
- deleting either new call site in `execute` left the whole suite green, because the tests exercised the predicates directly and nothing exercised the binding;
- a mutation turning the sizing hint into a hard bound also shipped green, since every fixture was shorter than the cap.

Each test now pins the layer it names, through clap's `error: invalid value` prefix or the line number only the parser knows, and two tests drive `execute` itself. A separate test extracts a clip longer than the cap.

The allocation abort cannot be caught by `#[should_panic]`, which is why capping the reservation is the fix rather than guarding the caller.

`cargo fmt --check`, `cargo clippy --all-features -- -D warnings` and `cargo test` are clean, 515 tests passing. Under `--all-targets` the branch takes the repo from 292 warnings to 242 (issue #292's backlog), adding none.

## Behaviour changes worth knowing

- A detection row with a non-finite value is skipped rather than silently mishandled. Rows that previously produced a bogus clip (a NaN start laundered to 0.0, an `inf` confidence comparing greater than every threshold) now produce none.
- `--end 1e12` succeeds instead of aborting, returning the audio the file actually holds.
- `ClipExtractor::extract_clip` now returns `Err` for a zero-length range where it previously returned an empty clip, and for an inverted one where it previously underflowed. Library callers only; the command rejected both earlier.
- A library caller can no longer pass a negative padding to crop the window inward, nor a negative time range. The CLI never allowed either. `--start -100 --end -1` is finite and increasing, so it passed every guard, and `(start - pre).max(0.0)` handed back the opening seconds of the file under a name claiming otherwise.
- `parse_confidence` reads `confidence::MIN`/`MAX` instead of its own `0.0..=1.0` literals, so the two routes share the rule rather than restating it. Its message renders identically.
- `src/cli/validators` is `pub(crate)` so the confidence rule can be tested against the CLI's copy of it rather than merely claimed to match.

## Follow-ups filed

The pre-push gate surfaced more than this PR should carry. Filed rather than folded in:

- **#319** `birda clip` reports success when it extracted nothing: the CSV route exits 0 even when every file failed, the JSON payload has no failure channel, the documented `error` event is emitted by nothing, and a range outside the audio writes a 0-frame WAV reported as a clip.
- **#320** Remaining unvalidated public surfaces (`group_detections`, `WavWriter::write_clip`), the last bare float comparisons of this class, two defensive gaps in the decode loop, `extract_clip` materialising the whole clip, and two measured performance wins (slicing the per-packet overlap once is 22 to 37 percent off every clip).
- **#321** Batched low-severity findings: the clip parsers living outside `validators.rs`, `Error` not being `#[non_exhaustive]`, and several documentation drifts.

## Known inconsistency, deliberately not resolved here

A non-finite row is skipped; a row with `end <= start` still discards the whole file. Both exit 0. The argument for skipping applies to the inverted row too, but that contract is pinned by two existing tests and widening it is a policy change rather than a fix for #310. Noted in the code and added to #319, where it belongs alongside the exit-code decision it depends on.
