### PR TITLE
fix: warm up at the batch size each file actually uses, and bump birdnet-onnx to rc.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "birdnet-onnx"
-version = "2.0.0-rc.15"
+version = "2.0.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe8249f40eb1de8636af1db90c4369f5e7aab2a8933643eec05ae9322b8f1e"
+checksum = "8e8cb24a3de80380fb5e97408f352bda3c41cc479c0d36e8dcd51f0184e5e36e"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/bin/gen-registry.rs"
 required-features = ["gen-registry"]
 
 [dependencies]
-birdnet-onnx = { version = "2.0.0-rc.15", features = ["load-dynamic"] }
+birdnet-onnx = { version = "2.0.0-rc.16", features = ["load-dynamic"] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["load-dynamic"] }
 symphonia = { git = "https://github.com/tphakala/Symphonia", branch = "feature/rf64-support", features = ["aac", "mp3", "flac", "wav", "pcm"] }
 rubato = "4.0"

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -13,6 +13,7 @@ use birdnet_onnx::{
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use super::get_tensorrt_library_name;
@@ -201,6 +202,47 @@ pub struct BirdClassifier {
     bsg_processor: Option<BsgPostProcessor>,
     /// Execution provider status (requested, actual, fallback reason).
     ep_status: ExecutionProviderStatus,
+    /// Batch sizes this classifier has already been warmed up for.
+    ///
+    /// Kept here rather than in the pipeline because it is a property of this
+    /// classifier's session, and a run processes files of differing lengths
+    /// that each pick their own batch size.
+    warmed: WarmupRegistry,
+}
+
+/// Which batch sizes a classifier has already been warmed up for.
+///
+/// Execution providers compile a graph per input shape, and the first
+/// inference at a shape is the one that pays for it. Under `OpenVINO` that first
+/// inference does not merely cost time: for `Perch` v2 it returns output
+/// tensors that were never filled, so the batch is silently scored as noise.
+/// Warming a shape absorbs that first run, leaving every batch the caller
+/// actually cares about at least the second of its shape.
+#[derive(Debug, Default)]
+struct WarmupRegistry {
+    sizes: Mutex<HashSet<usize>>,
+}
+
+impl WarmupRegistry {
+    /// Whether `batch_size` has already been warmed.
+    ///
+    /// A poisoned registry means another thread panicked mid-warmup. The set
+    /// is still readable and the worst case is a redundant warmup, so this
+    /// recovers rather than turning it into a failed run.
+    fn is_warm(&self, batch_size: usize) -> bool {
+        self.sizes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&batch_size)
+    }
+
+    /// Record `batch_size` as warmed.
+    fn mark_warm(&self, batch_size: usize) {
+        self.sizes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(batch_size);
+    }
 }
 
 impl BirdClassifier {
@@ -310,6 +352,7 @@ impl BirdClassifier {
             uses_tensorrt,
             bsg_processor,
             ep_status,
+            warmed: WarmupRegistry::default(),
         })
     }
 
@@ -358,6 +401,31 @@ impl BirdClassifier {
             })
     }
 
+    /// Warm up for `batch_size` unless that shape has already been warmed.
+    ///
+    /// Every batch size a run submits has to go through this before it carries
+    /// real audio. Warming one shape does nothing for another: providers key
+    /// their compiled graph on the input shape, so each distinct batch size
+    /// pays its own first-inference cost, and under `OpenVINO` that first
+    /// inference returns unpopulated outputs rather than merely being slow.
+    ///
+    /// Repeat calls for a shape already warmed return without running
+    /// inference, so this is cheap to call once per file.
+    pub fn ensure_warm(&self, batch_size: usize) -> Result<()> {
+        if self.warmed.is_warm(batch_size) {
+            return Ok(());
+        }
+
+        self.warmup(batch_size)?;
+
+        // Recorded only after the warmup succeeds. A failed warmup that was
+        // recorded anyway would let the next caller skip straight to real
+        // audio on a shape that was never warmed.
+        self.warmed.mark_warm(batch_size);
+
+        Ok(())
+    }
+
     /// Perform a warm-up inference to initialize GPU resources.
     ///
     /// This method runs inference with the specified batch size to trigger any
@@ -370,6 +438,8 @@ impl BirdClassifier {
     ///
     /// `TensorRT` engine compilation can take several minutes on first run, but
     /// the compiled engine is cached for subsequent runs.
+    ///
+    /// Prefer [`Self::ensure_warm`], which skips shapes already warmed.
     pub fn warmup(&self, batch_size: usize) -> Result<()> {
         let sample_count = self.inner.config().sample_count;
         let dummy_segment = vec![0.0f32; sample_count];
@@ -569,6 +639,68 @@ impl BirdClassifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn warmup_registry_starts_cold_for_every_size() {
+        let registry = WarmupRegistry::default();
+
+        assert!(!registry.is_warm(1));
+        assert!(!registry.is_warm(8));
+        assert!(!registry.is_warm(16));
+    }
+
+    #[test]
+    fn warmup_registry_reports_a_marked_size_as_warm() {
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(8);
+
+        assert!(registry.is_warm(8));
+    }
+
+    #[test]
+    fn warmup_registry_keeps_sizes_independent() {
+        // The bug this guards against: warming the configured batch size and
+        // treating the whole classifier as warm, while a short file submits a
+        // smaller batch that was never warmed. Each size stands alone.
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(16);
+
+        assert!(registry.is_warm(16));
+        assert!(!registry.is_warm(8), "warming 16 must not vouch for 8");
+        assert!(!registry.is_warm(1), "warming 16 must not vouch for 1");
+    }
+
+    #[test]
+    fn warmup_registry_marking_twice_is_idempotent() {
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(4);
+        registry.mark_warm(4);
+
+        assert!(registry.is_warm(4));
+    }
+
+    #[test]
+    fn warmup_registry_survives_a_poisoned_lock() {
+        // Recovery matters because a panic in one warmup would otherwise turn
+        // every later `ensure_warm` into a failure, including for sizes that
+        // were warmed successfully before the panic.
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(8);
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = registry.sizes.lock();
+            #[allow(clippy::panic)]
+            {
+                panic!("poison the registry");
+            }
+        }));
+        assert!(poisoned.is_err(), "the test must actually poison the lock");
+        assert!(registry.sizes.is_poisoned());
+
+        assert!(registry.is_warm(8), "a poisoned registry still reads");
+        registry.mark_warm(2);
+        assert!(registry.is_warm(2), "a poisoned registry still records");
+    }
 
     #[test]
     #[allow(clippy::unwrap_used)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ fn warmup_classifier(classifier: &BirdClassifier, batch_size: usize) -> Result<(
     use std::time::{Duration, Instant};
 
     if !classifier.uses_tensorrt() {
-        return classifier.warmup(batch_size);
+        return classifier.ensure_warm(batch_size);
     }
 
     let spinner = ProgressBar::new_spinner();
@@ -550,7 +550,7 @@ fn warmup_classifier(classifier: &BirdClassifier, batch_size: usize) -> Result<(
     spinner.enable_steady_tick(Duration::from_millis(100));
 
     let warmup_start = Instant::now();
-    let result = classifier.warmup(batch_size);
+    let result = classifier.ensure_warm(batch_size);
     let warmup_duration = warmup_start.elapsed();
 
     spinner.finish_and_clear();

--- a/src/pipeline/processor.rs
+++ b/src/pipeline/processor.rs
@@ -555,6 +555,27 @@ pub fn process_file(
         info!("Processing audio (duration unknown)");
     }
 
+    // Warm up for the batch size this file will actually submit.
+    //
+    // The startup warmup runs at the configured batch size, but a file shorter
+    // than that is capped to its own segment count just above, and partial
+    // batches are padded up to the capped value rather than the configured one.
+    // A short file therefore runs every one of its batches at a shape the
+    // startup warmup never touched.
+    //
+    // That is not just a missed optimization. Under OpenVINO the first
+    // inference at a new shape comes back with output tensors that were never
+    // filled, which for `Perch` v2 means the whole batch is scored as noise:
+    // no error, no warning, just a file's worth of wrong detections. With the
+    // default batch size of 16 and Perch's 5-second segments, that covers
+    // every recording under 80 seconds, and a single-batch file has no second
+    // batch to come out right.
+    //
+    // Warming the effective size here means the first real batch is at least
+    // the second inference of its shape. `ensure_warm` skips sizes already
+    // warmed, so a directory of same-length files pays for this once.
+    classifier.ensure_warm(effective_batch_size)?;
+
     // Create batch context for GPU memory efficiency (if effective_batch_size > 1)
     // Context is created once and reused for all batches in this file
     // IMPORTANT: This uses effective_batch_size to avoid over-allocating memory


### PR DESCRIPTION
Two fixes, both about getting correct detections out of models that were quietly producing wrong ones.

## Related issues

Fixes #333.

## BirdNET v3.0 could not be loaded

Every v3.0 model failed to build with `label count mismatch: model expects 1280, got 422`, on CPU and on GPU alike. birdnet-onnx rc.15 assigned roles to a two-output model by position, class scores first and embeddings second, but every published v3.0 export uses the opposite order, so the 1280-wide embedding tensor was read as the class scores. rc.16 resolves the roles from the output names instead. That bump is the first commit here.

rc.16 also pins `ort` to `=2.0.0-rc.12`. birda already pinned the same version directly, so the resolved dependency graph does not change.

## Perch v2 silently returned noise for short recordings on OpenVINO

This is the one worth reading about. A tawny owl that CPU scores at 86% came back as `Alarm` at 5%, and most segments came back with no predictions at all. There was no error and no warning, just a file's worth of wrong detections written to CSV.

An execution provider compiles a graph per input shape, and the first inference at a shape is the one that pays for it. Under OpenVINO that first inference does not merely cost time for Perch v2: it returns output tensors that were never filled. The startup warmup absorbs that cost, which is why this stayed invisible for so long.

Short files never run at the size the startup warmup used. `process_file` caps the batch to the file's own segment count, and pads partial batches up to the capped value rather than the configured one, so every batch of a short file runs at a shape the warmup never touched. With the default batch size of 16 and Perch's 5 second segments, that is every recording under 80 seconds, and a file with a single batch has no second batch to come out right.

That mismatch is also what made the bug look shape dependent rather than length dependent. On the same 8 segment file, `-b 8` was correct and `-b 9` was not, even though both submit an identical 8 row batch. The only thing that differed was the warmup size. The decisive test was two identical files in one process: the first came back as noise, the second correct.

The fix warms the batch size each file will actually submit. Sizes already warmed are skipped, so a directory of same length files pays for this once, and the registry lives on the classifier because a run processes files of differing lengths that each pick their own size.

## Verification

Measured on an Intel host where auto mode selects OpenVINO, against all four configured models on both CPU and OpenVINO.

| model | before, OpenVINO | after, OpenVINO | CPU reference |
|---|---|---|---|
| birdnet-v24 | Strix aluco 0.9964 | Strix aluco 0.9964 | Strix aluco 0.9969 |
| birdnet-v30-nordic | fails to load | Strix aluco 0.7299 | Strix aluco 0.7122 |
| perch-v2 | no detections | Strix aluco 0.8638 | Strix aluco 0.8606 |
| perch-v2-nordic | no detections | Strix aluco 0.9591 | Strix aluco 0.9581 |

A segment count sweep from 1 to 8 segments, which disagreed with CPU at every single length, now agrees at every length. Longer files were already running at the warmed size and are unchanged: a 24 segment file and a 3 hour file both produce the same results as before.

`cargo fmt --check`, `cargo clippy -- -D warnings` and the full suite of 603 tests all pass. The five new tests covering the warmup registry are mutation checked: I confirmed that a mutant which records every batch size, and a mutant where `is_warm` always returns true, each fail them.
