### PR TITLE
chore: lint test code in CI, and clear the 221 warnings it was hiding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,12 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      # --all-targets so tests are linted too. Without it clippy only sees the
+      # lib and the binary, and the test code drifts unchecked: this flag was
+      # added against a backlog of 221 warnings that had accumulated entirely
+      # in test code, none of which any CI run had ever reported.
       - name: Run clippy
-        run: cargo clippy --no-default-features -- -D warnings
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      # --all-targets so tests are linted too, matching the CI workflow.
       - name: Run clippy
-        run: cargo clippy --no-default-features -- -D warnings
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --no-default-features --no-fail-fast

--- a/src/audio/chunker.rs
+++ b/src/audio/chunker.rs
@@ -76,7 +76,6 @@ pub fn chunk_audio(
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -115,7 +115,6 @@ fn estimate_output_len(input_len: usize, from_rate: u32, to_rate: u32) -> usize 
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::f32::consts::PI;

--- a/src/cli/clip.rs
+++ b/src/cli/clip.rs
@@ -109,7 +109,6 @@ fn parse_time(s: &str) -> Result<f64, String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/cli/species.rs
+++ b/src/cli/species.rs
@@ -314,7 +314,6 @@ fn write_species_list(path: &std::path::Path, species: &[(String, f32)]) -> Resu
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -132,7 +132,6 @@ pub fn parse_batch_size(s: &str) -> Result<usize, String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/clipper/command.rs
+++ b/src/clipper/command.rs
@@ -244,7 +244,8 @@ fn process_detection_file(
         ProgressBar::hidden()
     } else {
         let pb = ProgressBar::new(groups.len() as u64);
-        // Template is hardcoded and known to be valid
+        // Template is hardcoded and known to be valid, so the only way this
+        // expect fires is a typo in the literal above, which the tests catch.
         #[allow(clippy::expect_used)]
         pb.set_style(
             ProgressStyle::default_bar()
@@ -412,7 +413,6 @@ fn find_source_audio(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/clipper/extractor.rs
+++ b/src/clipper/extractor.rs
@@ -267,7 +267,6 @@ impl ClipExtractor {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/clipper/parser.rs
+++ b/src/clipper/parser.rs
@@ -172,7 +172,6 @@ pub fn parse_detection_file(path: &Path) -> Result<Vec<ParsedDetection>, Error> 
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -205,7 +205,6 @@ pub fn save_default_config(config: &Config) -> Result<std::path::PathBuf> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/config/geomodel.rs
+++ b/src/config/geomodel.rs
@@ -282,7 +282,6 @@ pub(crate) fn human_size(bytes: Option<u64>) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -47,7 +47,6 @@ pub fn tensorrt_cache_dir() -> Result<PathBuf> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/src/config/range_filter.rs
+++ b/src/config/range_filter.rs
@@ -149,7 +149,6 @@ pub fn build_range_filter_config(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use crate::config::types::UnmatchedPolicy;

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -412,8 +412,6 @@ impl std::str::FromStr for ModelType {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -177,7 +177,6 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
 // float comparisons check that a literal passed in came back unchanged, so an
 // epsilon would weaken them. Matches the convention used by the other test
 // modules in this crate.
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -636,142 +636,6 @@ impl BirdClassifier {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn warmup_registry_starts_cold_for_every_size() {
-        let registry = WarmupRegistry::default();
-
-        assert!(!registry.is_warm(1));
-        assert!(!registry.is_warm(8));
-        assert!(!registry.is_warm(16));
-    }
-
-    #[test]
-    fn warmup_registry_reports_a_marked_size_as_warm() {
-        let registry = WarmupRegistry::default();
-        registry.mark_warm(8);
-
-        assert!(registry.is_warm(8));
-    }
-
-    #[test]
-    fn warmup_registry_keeps_sizes_independent() {
-        // The bug this guards against: warming the configured batch size and
-        // treating the whole classifier as warm, while a short file submits a
-        // smaller batch that was never warmed. Each size stands alone.
-        let registry = WarmupRegistry::default();
-        registry.mark_warm(16);
-
-        assert!(registry.is_warm(16));
-        assert!(!registry.is_warm(8), "warming 16 must not vouch for 8");
-        assert!(!registry.is_warm(1), "warming 16 must not vouch for 1");
-    }
-
-    #[test]
-    fn warmup_registry_marking_twice_is_idempotent() {
-        let registry = WarmupRegistry::default();
-        registry.mark_warm(4);
-        registry.mark_warm(4);
-
-        assert!(registry.is_warm(4));
-    }
-
-    #[test]
-    fn warmup_registry_survives_a_poisoned_lock() {
-        // Recovery matters because a panic in one warmup would otherwise turn
-        // every later `ensure_warm` into a failure, including for sizes that
-        // were warmed successfully before the panic.
-        let registry = WarmupRegistry::default();
-        registry.mark_warm(8);
-
-        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = registry.sizes.lock();
-            #[allow(clippy::panic)]
-            {
-                panic!("poison the registry");
-            }
-        }));
-        assert!(poisoned.is_err(), "the test must actually poison the lock");
-        assert!(registry.sizes.is_poisoned());
-
-        assert!(registry.is_warm(8), "a poisoned registry still reads");
-        registry.mark_warm(2);
-        assert!(registry.is_warm(2), "a poisoned registry still records");
-    }
-
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn test_filter_predictions_with_species_list() {
-        use birdnet_onnx::Prediction;
-
-        let predictions = vec![
-            Prediction {
-                species: "Parus major_Great Tit".to_string(),
-                confidence: 0.95,
-                index: 0,
-            },
-            Prediction {
-                species: "Turdus merula_Blackbird".to_string(),
-                confidence: 0.85,
-                index: 1,
-            },
-            Prediction {
-                species: "Cyanistes caeruleus_Blue Tit".to_string(),
-                confidence: 0.75,
-                index: 2,
-            },
-        ];
-
-        let species_list: HashSet<String> = vec![
-            "Parus major_Great Tit".to_string(),
-            "Cyanistes caeruleus_Blue Tit".to_string(),
-        ]
-        .into_iter()
-        .collect();
-
-        // Filter using the species list (now O(1) lookup)
-        let filtered: Vec<Prediction> = predictions
-            .iter()
-            .filter(|p| species_list.contains(&p.species))
-            .cloned()
-            .collect();
-
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().any(|p| p.species.contains("Parus major")));
-        assert!(filtered.iter().any(|p| p.species.contains("Cyanistes")));
-        assert!(!filtered.iter().any(|p| p.species.contains("Turdus")));
-    }
-
-    #[test]
-    fn test_execution_provider_status_creation() {
-        let status = ExecutionProviderStatus {
-            requested: "auto".to_string(),
-            actual: "CUDA".to_string(),
-            fallback_reason: Some("TensorRT libraries not found".to_string()),
-        };
-
-        assert_eq!(status.requested, "auto");
-        assert_eq!(status.actual, "CUDA");
-        assert!(status.fallback_reason.is_some());
-    }
-
-    #[test]
-    fn test_execution_provider_status_no_fallback() {
-        let status = ExecutionProviderStatus {
-            requested: "cuda".to_string(),
-            actual: "CUDA".to_string(),
-            fallback_reason: None,
-        };
-
-        assert_eq!(status.requested, "cuda");
-        assert_eq!(status.actual, "CUDA");
-        assert!(status.fallback_reason.is_none());
-    }
-}
-
 /// Holds the result of execution provider selection.
 struct ProviderSelection {
     /// Builder with the chosen provider configured.
@@ -1232,4 +1096,140 @@ fn provider_unavailable_error(provider_name: &str, available: &[ExecutionProvide
     message.push_str("  birda <input>           (auto mode with fallback)\n");
 
     Error::ClassifierBuild { reason: message }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warmup_registry_starts_cold_for_every_size() {
+        let registry = WarmupRegistry::default();
+
+        assert!(!registry.is_warm(1));
+        assert!(!registry.is_warm(8));
+        assert!(!registry.is_warm(16));
+    }
+
+    #[test]
+    fn warmup_registry_reports_a_marked_size_as_warm() {
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(8);
+
+        assert!(registry.is_warm(8));
+    }
+
+    #[test]
+    fn warmup_registry_keeps_sizes_independent() {
+        // The bug this guards against: warming the configured batch size and
+        // treating the whole classifier as warm, while a short file submits a
+        // smaller batch that was never warmed. Each size stands alone.
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(16);
+
+        assert!(registry.is_warm(16));
+        assert!(!registry.is_warm(8), "warming 16 must not vouch for 8");
+        assert!(!registry.is_warm(1), "warming 16 must not vouch for 1");
+    }
+
+    #[test]
+    fn warmup_registry_marking_twice_is_idempotent() {
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(4);
+        registry.mark_warm(4);
+
+        assert!(registry.is_warm(4));
+    }
+
+    #[test]
+    fn warmup_registry_survives_a_poisoned_lock() {
+        // Recovery matters because a panic in one warmup would otherwise turn
+        // every later `ensure_warm` into a failure, including for sizes that
+        // were warmed successfully before the panic.
+        let registry = WarmupRegistry::default();
+        registry.mark_warm(8);
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = registry.sizes.lock();
+            #[allow(clippy::panic)]
+            {
+                panic!("poison the registry");
+            }
+        }));
+        assert!(poisoned.is_err(), "the test must actually poison the lock");
+        assert!(registry.sizes.is_poisoned());
+
+        assert!(registry.is_warm(8), "a poisoned registry still reads");
+        registry.mark_warm(2);
+        assert!(registry.is_warm(2), "a poisoned registry still records");
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_filter_predictions_with_species_list() {
+        use birdnet_onnx::Prediction;
+
+        let predictions = [
+            Prediction {
+                species: "Parus major_Great Tit".to_string(),
+                confidence: 0.95,
+                index: 0,
+            },
+            Prediction {
+                species: "Turdus merula_Blackbird".to_string(),
+                confidence: 0.85,
+                index: 1,
+            },
+            Prediction {
+                species: "Cyanistes caeruleus_Blue Tit".to_string(),
+                confidence: 0.75,
+                index: 2,
+            },
+        ];
+
+        let species_list: HashSet<String> = vec![
+            "Parus major_Great Tit".to_string(),
+            "Cyanistes caeruleus_Blue Tit".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        // Filter using the species list (now O(1) lookup)
+        let filtered: Vec<Prediction> = predictions
+            .iter()
+            .filter(|p| species_list.contains(&p.species))
+            .cloned()
+            .collect();
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().any(|p| p.species.contains("Parus major")));
+        assert!(filtered.iter().any(|p| p.species.contains("Cyanistes")));
+        assert!(!filtered.iter().any(|p| p.species.contains("Turdus")));
+    }
+
+    #[test]
+    fn test_execution_provider_status_creation() {
+        let status = ExecutionProviderStatus {
+            requested: "auto".to_string(),
+            actual: "CUDA".to_string(),
+            fallback_reason: Some("TensorRT libraries not found".to_string()),
+        };
+
+        assert_eq!(status.requested, "auto");
+        assert_eq!(status.actual, "CUDA");
+        assert!(status.fallback_reason.is_some());
+    }
+
+    #[test]
+    fn test_execution_provider_status_no_fallback() {
+        let status = ExecutionProviderStatus {
+            requested: "cuda".to_string(),
+            actual: "CUDA".to_string(),
+            fallback_reason: None,
+        };
+
+        assert_eq!(status.requested, "cuda");
+        assert_eq!(status.actual, "CUDA");
+        assert!(status.fallback_reason.is_none());
+    }
 }

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -1151,7 +1151,6 @@ mod tests {
 
         let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = registry.sizes.lock();
-            #[allow(clippy::panic)]
             {
                 panic!("poison the registry");
             }
@@ -1165,7 +1164,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::unwrap_used)]
     fn test_filter_predictions_with_species_list() {
         use birdnet_onnx::Prediction;
 

--- a/src/inference/geomodel.rs
+++ b/src/inference/geomodel.rs
@@ -180,8 +180,6 @@ impl GeomodelScores {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/inference/geomodel_filter.rs
+++ b/src/inference/geomodel_filter.rs
@@ -79,8 +79,6 @@ pub fn filter_predictions(
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use crate::inference::geomodel::SpeciesMapping;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2979,7 +2979,6 @@ mod tests {
     // A test command line that fails to parse is a broken test, not a runtime
     // condition to handle, so `expect` is the right call here. Matches the
     // convention the other test modules in this crate use.
-    #[allow(clippy::expect_used)]
     mod requires_valid_config {
         use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,31 @@
 //! This crate provides audio analysis capabilities using `BirdNET` and Perch models.
 
 #![warn(missing_docs)]
+// Test code is held to different rules than shipping code, and these four lints
+// encode the difference.
+//
+// `unwrap`, `expect` and `panic` are how a test reports failure: a panic in a
+// test is the assertion firing, not an unhandled error path, and rewriting them
+// into propagated `Result`s would hide which assertion failed. The crate-level
+// deny still applies to everything birda actually ships, because `cfg(test)` is
+// false in that build.
+//
+// `float_cmp` is a false positive throughout this suite. Every exact float
+// assertion here is on a value that is passed through rather than computed: a
+// literal parsed from a file, a coordinate round-tripped through JSON, or a
+// clip boundary clamped to a whole number. Exact equality is the assertion the
+// test wants, and an epsilon would stop it catching a boundary that is off by a
+// hair. Where a value IS computed, these tests already compare against an
+// epsilon by hand.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::float_cmp
+    )
+)]
 
 pub mod audio;
 pub mod cli;
@@ -2305,7 +2330,7 @@ mod tests {
         }
     }
 
-    /// Create default AnalyzeArgs (all None/false).
+    /// Create default `AnalyzeArgs` (all None/false).
     fn default_args() -> AnalyzeArgs {
         AnalyzeArgs::default()
     }
@@ -2496,11 +2521,13 @@ mod tests {
     fn test_adhoc_ignores_the_deprecated_meta_model_flag() {
         // --meta-model-path is retained as a hidden flag so scripts do not
         // break, but it no longer configures anything.
-        let mut args = AnalyzeArgs::default();
-        args.model_path = Some(PathBuf::from("/adhoc/model.onnx"));
-        args.labels_path = Some(PathBuf::from("/adhoc/labels.txt"));
-        args.model_type = Some(ModelType::BirdnetV24);
-        args.meta_model_path = Some(PathBuf::from("/adhoc/meta.onnx"));
+        let args = AnalyzeArgs {
+            model_path: Some(PathBuf::from("/adhoc/model.onnx")),
+            labels_path: Some(PathBuf::from("/adhoc/labels.txt")),
+            model_type: Some(ModelType::BirdnetV24),
+            meta_model_path: Some(PathBuf::from("/adhoc/meta.onnx")),
+            ..Default::default()
+        };
 
         let config = Config::default();
         let (model_config, name) = resolve_model_config(&args, &config).unwrap();

--- a/src/locking/file_lock.rs
+++ b/src/locking/file_lock.rs
@@ -169,7 +169,6 @@ pub fn cleanup_all_locks() {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::fs::File;

--- a/src/locking/file_lock.rs
+++ b/src/locking/file_lock.rs
@@ -176,7 +176,7 @@ mod tests {
     use std::sync::Mutex;
     use tempfile::TempDir;
 
-    /// Serialize locking tests to avoid race conditions with cleanup_all_locks()
+    /// Serialize locking tests to avoid race conditions with `cleanup_all_locks()`
     /// which drains the entire global registry.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 

--- a/src/output/audacity.rs
+++ b/src/output/audacity.rs
@@ -46,7 +46,6 @@ impl OutputWriter for AudacityWriter {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -132,7 +132,6 @@ fn escape_csv(value: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/output/kaleidoscope.rs
+++ b/src/output/kaleidoscope.rs
@@ -75,7 +75,6 @@ impl OutputWriter for KaleidoscopeWriter {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/output/parquet.rs
+++ b/src/output/parquet.rs
@@ -484,7 +484,7 @@ mod tests {
             scientific_name: "Poecile atricapillus".to_string(),
             common_name: "Black-capped Chickadee".to_string(),
             confidence: 0.95,
-            metadata: Default::default(),
+            metadata: crate::output::DetectionMetadata::default(),
         }];
 
         let schema = build_schema(&[]);

--- a/src/output/raven.rs
+++ b/src/output/raven.rs
@@ -86,7 +86,6 @@ fn generate_species_code(common_name: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/output/reporter.rs
+++ b/src/output/reporter.rs
@@ -555,8 +555,14 @@ mod tests {
         };
         reporter.pipeline_started(5, "test-model", 0.1, &dummy_ep, None);
 
-        let output = buffer.lock().expect("lock");
-        let output_str = String::from_utf8_lossy(&output);
+        // Scoped so the guard is released before the assertions run: holding a
+        // lock across assertions means a failing assert unwinds while still
+        // holding it, poisoning the mutex and turning one clear failure into a
+        // cascade of confusing ones in sibling tests that share the buffer.
+        let output_str = {
+            let output = buffer.lock().expect("lock");
+            String::from_utf8_lossy(&output).into_owned()
+        };
         assert!(output_str.contains("\"event\":\"pipeline_started\""));
         assert!(output_str.contains("\"total_files\":5"));
     }
@@ -594,13 +600,19 @@ mod tests {
             scientific_name: "Parus major".to_string(),
             common_name: "Great Tit".to_string(),
             confidence: 0.95,
-            metadata: Default::default(),
+            metadata: crate::output::DetectionMetadata::default(),
         }];
 
         reporter.detections(Path::new("test.wav"), &detections, None);
 
-        let output = buffer.lock().expect("lock");
-        let output_str = String::from_utf8_lossy(&output);
+        // Scoped so the guard is released before the assertions run: holding a
+        // lock across assertions means a failing assert unwinds while still
+        // holding it, poisoning the mutex and turning one clear failure into a
+        // cascade of confusing ones in sibling tests that share the buffer.
+        let output_str = {
+            let output = buffer.lock().expect("lock");
+            String::from_utf8_lossy(&output).into_owned()
+        };
         assert!(output_str.contains("\"event\":\"detections\""));
         assert!(output_str.contains("\"Great Tit\""));
         assert!(output_str.contains("\"confidence\":0.95"));

--- a/src/output/types.rs
+++ b/src/output/types.rs
@@ -80,7 +80,6 @@ impl Detection {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/pipeline/coordinator.rs
+++ b/src/pipeline/coordinator.rs
@@ -178,7 +178,6 @@ fn is_audio_file(path: &Path) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/src/registry/cleanup.rs
+++ b/src/registry/cleanup.rs
@@ -248,7 +248,7 @@ mod tests {
         let present = dir.path().join("gone.onnx");
         std::fs::write(&present, b"x").unwrap();
 
-        let failures = remove_orphans(&[present.clone()]);
+        let failures = remove_orphans(std::slice::from_ref(&present));
 
         assert!(!present.exists());
         assert!(failures.is_empty());

--- a/src/registry/cleanup.rs
+++ b/src/registry/cleanup.rs
@@ -83,7 +83,6 @@ pub fn remove_orphans(paths: &[PathBuf]) -> Vec<(PathBuf, std::io::Error)> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use crate::config::{ModelConfig, ModelType};

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -540,7 +540,6 @@ fn roll_back(paths: &[&Path]) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -865,8 +865,9 @@ mod tests {
             name.starts_with("birdnet-geomodel-v3.0.2.onnx."),
             "part file must sit beside the destination, got {name}"
         );
-        assert!(
-            name.ends_with(".part"),
+        assert_eq!(
+            Path::new(&name).extension(),
+            Some(std::ffi::OsStr::new("part")),
             "part file must carry the partial suffix, got {name}"
         );
         assert!(

--- a/src/registry/license.rs
+++ b/src/registry/license.rs
@@ -142,7 +142,6 @@ fn license_summary(license: &LicenseInfo, vendor: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -165,7 +165,6 @@ pub fn find_model<'a>(registry: &'a Registry, id: &str) -> Option<&'a ModelEntry
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::registry::types::{FileInfo, LabelsInfo, LanguageVariant, LicenseInfo, ModelFiles};

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -411,7 +411,6 @@ pub fn show_languages(registry: &Registry, id: &str) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -329,49 +329,6 @@ pub fn show_info(registry: &Registry, id: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
-mod tests {
-    use super::*;
-
-    fn license(commercial_use: bool, share_alike: bool) -> LicenseInfo {
-        LicenseInfo {
-            r#type: "TEST-1.0".into(),
-            url: "https://example.com/licence".into(),
-            commercial_use,
-            attribution_required: true,
-            share_alike,
-        }
-    }
-
-    #[test]
-    fn test_license_line_names_every_restriction_that_applies() {
-        // The defect this replaced: the classifier loop showed only
-        // "(non-commercial)" and the range filter only "(share-alike)", so
-        // birdnet-v24 and bsg-fi-v44 listed with no share-alike note despite
-        // carrying that obligation. Both restrictions must show together.
-        let line = license_line(&license(false, true));
-
-        assert!(line.contains("non-commercial"), "got: {line}");
-        assert!(line.contains("share-alike"), "got: {line}");
-    }
-
-    #[test]
-    fn test_license_line_names_share_alike_on_a_commercial_licence() {
-        // The geomodel's shape: CC BY-SA permits commercial use but still binds
-        // share-alike, so the note must not be suppressed by commercial_use.
-        let line = license_line(&license(true, true));
-
-        assert!(!line.contains("non-commercial"), "got: {line}");
-        assert!(line.contains("share-alike"), "got: {line}");
-    }
-
-    #[test]
-    fn test_license_line_adds_nothing_for_an_unrestricted_licence() {
-        assert_eq!(license_line(&license(true, false)), "TEST-1.0");
-    }
-}
-
 /// List the regional tiles a model publishes, grouped by continent.
 ///
 /// Regions are what a user picks; the variant is picked for them, so this lists
@@ -451,4 +408,47 @@ pub fn show_languages(registry: &Registry, id: &str) -> Result<()> {
     println!("  birda models install {} --language <code>", model.id);
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
+mod tests {
+    use super::*;
+
+    fn license(commercial_use: bool, share_alike: bool) -> LicenseInfo {
+        LicenseInfo {
+            r#type: "TEST-1.0".into(),
+            url: "https://example.com/licence".into(),
+            commercial_use,
+            attribution_required: true,
+            share_alike,
+        }
+    }
+
+    #[test]
+    fn test_license_line_names_every_restriction_that_applies() {
+        // The defect this replaced: the classifier loop showed only
+        // "(non-commercial)" and the range filter only "(share-alike)", so
+        // birdnet-v24 and bsg-fi-v44 listed with no share-alike note despite
+        // carrying that obligation. Both restrictions must show together.
+        let line = license_line(&license(false, true));
+
+        assert!(line.contains("non-commercial"), "got: {line}");
+        assert!(line.contains("share-alike"), "got: {line}");
+    }
+
+    #[test]
+    fn test_license_line_names_share_alike_on_a_commercial_licence() {
+        // The geomodel's shape: CC BY-SA permits commercial use but still binds
+        // share-alike, so the note must not be suppressed by commercial_use.
+        let line = license_line(&license(true, true));
+
+        assert!(!line.contains("non-commercial"), "got: {line}");
+        assert!(line.contains("share-alike"), "got: {line}");
+    }
+
+    #[test]
+    fn test_license_line_adds_nothing_for_an_unrestricted_licence() {
+        assert_eq!(license_line(&license(true, false)), "TEST-1.0");
+    }
 }

--- a/src/registry/selection.rs
+++ b/src/registry/selection.rs
@@ -260,7 +260,6 @@ pub fn select_variant<'a>(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use crate::registry::types::{FileInfo, LicenseInfo};

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -317,9 +317,7 @@ mod tests {
             files: None,
             build: Some(1),
             default_variant: Some("fp32".to_string()),
-            selection: [("cuda".to_string(), "fp16".to_string())]
-                .into_iter()
-                .collect(),
+            selection: std::iter::once(("cuda".to_string(), "fp16".to_string())).collect(),
             variants: vec![
                 variant("fp32", None, 11560),
                 variant("fp16", None, 11560),

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -271,7 +271,6 @@ pub struct LanguageVariant {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
 

--- a/src/update/replace.rs
+++ b/src/update/replace.rs
@@ -207,12 +207,12 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_set_executable_on_temp_file() {
+        use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let path = dir.path().join("test-bin");
         std::fs::write(&path, b"fake binary").expect("failed to write test file");
         set_executable(&path).expect("set_executable should succeed");
 
-        use std::os::unix::fs::PermissionsExt;
         let mode = std::fs::metadata(&path)
             .expect("failed to read metadata")
             .permissions()

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -484,7 +484,6 @@ fn sync_directory(dir: &Path) {
 fn sync_directory(_dir: &Path) {}
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/utils/species_list.rs
+++ b/src/utils/species_list.rs
@@ -41,7 +41,6 @@ pub fn read_species_list(path: &Path) -> Result<Vec<String>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Test setup code - panics are acceptable
 mod tests {
     use super::*;
     use std::io::Write;

--- a/tests/cli_output_integration.rs
+++ b/tests/cli_output_integration.rs
@@ -1,4 +1,17 @@
 //! Integration tests for CLI output enhancements.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::prelude::*;

--- a/tests/clip_integration_test.rs
+++ b/tests/clip_integration_test.rs
@@ -5,8 +5,19 @@
 //! These drive the real binary, because the hazard is in the seam between the
 //! CLI parsers, the range guard and the extractor's allocation, and each layer
 //! looks correct on its own.
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::io::Write;
 use std::path::PathBuf;

--- a/tests/clipper_grouper_test.rs
+++ b/tests/clipper_grouper_test.rs
@@ -1,4 +1,17 @@
 //! Tests for detection grouping.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use birda::clipper::{ParsedDetection, group_detections};
 

--- a/tests/clipper_parser_test.rs
+++ b/tests/clipper_parser_test.rs
@@ -1,4 +1,17 @@
 //! Tests for detection file parser.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::io::Write;
 
@@ -7,11 +20,11 @@ use tempfile::NamedTempFile;
 
 #[test]
 fn test_parse_birda_csv_format() {
-    let csv_content = r#"Start (s),End (s),Scientific name,Common name,Confidence
+    let csv_content = r"Start (s),End (s),Scientific name,Common name,Confidence
 0.0,3.0,Parus major,Great Tit,0.8542
 3.0,6.0,Cyanistes caeruleus,Eurasian Blue Tit,0.7123
 6.0,9.0,Parus major,Great Tit,0.9001
-"#;
+";
 
     let mut file = NamedTempFile::with_suffix(".BirdNET.results.csv").unwrap();
     file.write_all(csv_content.as_bytes()).unwrap();
@@ -74,9 +87,9 @@ fn test_parse_missing_column_returns_error() {
 #[test]
 fn test_parse_csv_with_optional_columns() {
     // birda CSV output may include optional metadata columns
-    let csv_content = r#"Start (s),End (s),Scientific name,Common name,Confidence,Lat,Lon,Week,Model
+    let csv_content = r"Start (s),End (s),Scientific name,Common name,Confidence,Lat,Lon,Week,Model
 0.0,3.0,Parus major,Great Tit,0.8542,60.1699,24.9384,15,birdnet-v24
-"#;
+";
 
     let mut file = NamedTempFile::with_suffix(".csv").unwrap();
     file.write_all(csv_content.as_bytes()).unwrap();
@@ -90,9 +103,9 @@ fn test_parse_csv_with_optional_columns() {
 #[test]
 fn test_parse_invalid_time_range_returns_error() {
     // End time before start time should be rejected
-    let csv_content = r#"Start (s),End (s),Scientific name,Common name,Confidence
+    let csv_content = r"Start (s),End (s),Scientific name,Common name,Confidence
 5.0,3.0,Parus major,Great Tit,0.85
-"#;
+";
 
     let mut file = NamedTempFile::with_suffix(".csv").unwrap();
     file.write_all(csv_content.as_bytes()).unwrap();

--- a/tests/clipper_writer_test.rs
+++ b/tests/clipper_writer_test.rs
@@ -1,6 +1,17 @@
 //! Tests for WAV file writer.
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use birda::clipper::WavWriter;
 use tempfile::TempDir;
@@ -51,7 +62,9 @@ fn test_write_clip_creates_species_directory() {
     let writer = WavWriter::new(temp_dir.path().to_path_buf());
 
     // Simple sine wave samples
-    let samples: Vec<f32> = (0..48000).map(|i| (i as f32 * 0.01).sin()).collect();
+    let samples: Vec<f32> = (0..48_000u16)
+        .map(|i| (f32::from(i) * 0.01).sin())
+        .collect();
 
     let path = writer
         .write_clip(&samples, 48000, "Parus major", 0.85, 10.5, 11.5)
@@ -75,7 +88,7 @@ fn test_write_clip_filename_format() {
     let filename = path.file_name().unwrap().to_str().unwrap();
     // Format: species_confidence_start-end.wav
     assert!(filename.starts_with("Cyanistes caeruleus_92p_"));
-    assert!(filename.ends_with(".wav"));
+    assert_eq!(path.extension(), Some(std::ffi::OsStr::new("wav")));
 }
 
 #[test]
@@ -116,7 +129,9 @@ fn test_written_wav_is_valid() {
     let temp_dir = TempDir::new().unwrap();
     let writer = WavWriter::new(temp_dir.path().to_path_buf());
 
-    let samples: Vec<f32> = (0..48000).map(|i| (i as f32 * 0.01).sin()).collect();
+    let samples: Vec<f32> = (0..48_000u16)
+        .map(|i| (f32::from(i) * 0.01).sin())
+        .collect();
 
     let path = writer
         .write_clip(&samples, 48000, "Test Species", 0.85, 0.0, 1.0)

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -12,8 +12,19 @@
 //! A unit test cannot tell those two states apart, because both call the same
 //! passing function. Only spawning the binary against a seeded `config.toml`
 //! exercises the wiring, which is where the defect lived.
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/tests/csv_bom_test.rs
+++ b/tests/csv_bom_test.rs
@@ -1,4 +1,17 @@
 //! Integration tests for CSV UTF-8 BOM functionality.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 #[test]
 #[ignore = "Manual test: requires audio files and models. See comment for instructions."]

--- a/tests/cuda_detection_test.rs
+++ b/tests/cuda_detection_test.rs
@@ -1,4 +1,17 @@
 //! Integration tests for CUDA library detection.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use birda::inference::{get_cuda_library_patterns, is_cuda_available};
 

--- a/tests/geomodel_discoverability.rs
+++ b/tests/geomodel_discoverability.rs
@@ -8,8 +8,19 @@
 //! geomodel` still failed, because that function takes the asset directly and
 //! the dispatch never reaches it for this id. Only driving the binary exercises
 //! the dispatch, which is where the defect lived.
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::time::Duration;
 

--- a/tests/geomodel_range_filter.rs
+++ b/tests/geomodel_range_filter.rs
@@ -1,4 +1,4 @@
-//! End-to-end tests for the BirdNET Geomodel range filter path.
+//! End-to-end tests for the `BirdNET` Geomodel range filter path.
 //!
 //! These run against a tiny fixture ONNX with the same input and output
 //! contract as the real geomodel (3 float32 inputs, N sigmoid outputs), so the
@@ -10,8 +10,19 @@
 //! fresh checkout) each test skips rather than running: `ort` does not fail
 //! fast on a missing library, it blocks, so an unguarded session build hangs
 //! the job until the CI timeout instead of reporting anything useful.
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use birda::config::UnmatchedPolicy;
 use birda::inference::range_filter::RangeFilter;
@@ -268,7 +279,15 @@ fn test_rerank_scales_confidence_by_the_predicted_score() {
     );
 
     assert_eq!(filtered.len(), 1);
-    assert!((filtered[0].confidence - 0.8 * score).abs() < 1e-6);
+    // Written as the plain two-step expression rather than the `mul_add` clippy
+    // suggests. `suboptimal_flops` is a performance lint and there is no hot
+    // path in an assertion, while `mul_add` fuses the multiply and add into a
+    // single rounding. That would compute the expected value more precisely
+    // than the production code being checked computes the actual one, which is
+    // the wrong reference for this test to compare against.
+    #[allow(clippy::suboptimal_flops)]
+    let expected_delta = (filtered[0].confidence - 0.8 * score).abs();
+    assert!(expected_delta < 1e-6);
 }
 
 #[test]

--- a/tests/model_gallery_regional.rs
+++ b/tests/model_gallery_regional.rs
@@ -4,6 +4,19 @@
 //! clap wiring, the registry contents and the output shape together. None of
 //! them download anything: every assertion is about listing, or about rejecting
 //! bad input before a single byte moves.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use assert_cmd::Command;
 use predicates::prelude::*;

--- a/tests/providers_command_test.rs
+++ b/tests/providers_command_test.rs
@@ -2,6 +2,19 @@
 //!
 //! Note: These tests require ONNX Runtime to be available.
 //! They will be skipped if ONNX Runtime initialization fails (e.g., in CI).
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::time::Duration;
 
@@ -40,9 +53,8 @@ fn get_providers_json() -> Option<Value> {
 
 #[test]
 fn test_providers_command_human_readable() {
-    let stdout = match run_providers_command(&[]) {
-        Some(stdout) => stdout,
-        None => return,
+    let Some(stdout) = run_providers_command(&[]) else {
+        return;
     };
 
     let output = String::from_utf8(stdout).expect("stdout should be valid UTF-8");
@@ -52,9 +64,8 @@ fn test_providers_command_human_readable() {
 
 #[test]
 fn test_providers_command_json_output() {
-    let json = match get_providers_json() {
-        Some(json) => json,
-        None => return,
+    let Some(json) = get_providers_json() else {
+        return;
     };
 
     // Verify structure - spec_version should be present and non-empty
@@ -101,9 +112,8 @@ fn test_providers_command_json_output() {
 
 #[test]
 fn test_providers_json_all_fields_present() {
-    let json = match get_providers_json() {
-        Some(json) => json,
-        None => return,
+    let Some(json) = get_providers_json() else {
+        return;
     };
 
     let providers = json["payload"]["providers"]
@@ -146,9 +156,8 @@ fn test_providers_json_all_fields_present() {
 
 #[test]
 fn test_providers_command_shows_usage_help() {
-    let stdout = match run_providers_command(&[]) {
-        Some(stdout) => stdout,
-        None => return,
+    let Some(stdout) = run_providers_command(&[]) else {
+        return;
     };
 
     let output = String::from_utf8(stdout).expect("stdout should be valid UTF-8");

--- a/tests/registry_generation.rs
+++ b/tests/registry_generation.rs
@@ -7,7 +7,19 @@
 //! ```text
 //! cargo test --features gen-registry --test registry_generation
 //! ```
-
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 #![cfg(feature = "gen-registry")]
 
 use birda::registry::Registry;

--- a/tests/runtime_init_test.rs
+++ b/tests/runtime_init_test.rs
@@ -1,4 +1,17 @@
 //! Regression tests for ONNX Runtime startup failures.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use std::time::Duration;
 

--- a/tests/species_list_integration.rs
+++ b/tests/species_list_integration.rs
@@ -2,6 +2,19 @@
 //!
 //! Note: These tests require actual model files to run.
 //! They will be skipped if model environment variables are not set.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 #[cfg(test)]
 mod tests {
@@ -28,7 +41,6 @@ mod tests {
         if get_test_model_path().is_none() {
             eprintln!("Skipping integration test - model files not configured");
             eprintln!("Set BIRDA_TEST_MODEL, BIRDA_TEST_LABELS, and BIRDA_TEST_META_MODEL to run");
-            return;
         }
 
         // Test will run when models are available

--- a/tests/stdout_integration.rs
+++ b/tests/stdout_integration.rs
@@ -1,4 +1,17 @@
 //! Integration tests for --stdout mode.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;

--- a/tests/tensorrt_detection_test.rs
+++ b/tests/tensorrt_detection_test.rs
@@ -1,4 +1,17 @@
-//! Integration tests for TensorRT library detection.
+//! Integration tests for `TensorRT` library detection.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. Every exact float assertion in these
+// tests is on a passed-through value (a literal parsed from a file, a
+// coordinate round-tripped through JSON, a clip boundary clamped to a whole
+// number) rather than a computed one, so exact equality is the assertion the
+// test wants. The crate-level deny still governs everything birda ships.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp
+)]
 
 use birda::inference::{get_tensorrt_library_name, is_tensorrt_available};
 


### PR DESCRIPTION
## Summary

CI ran `cargo clippy --no-default-features -- -D warnings`, which checks the lib and the binary and nothing else. Test code was never linted, so it drifted: 221 warnings had accumulated across the inline `#[cfg(test)]` modules and `tests/`, and no CI run had ever reported one of them. Adding `--all-targets` to the clippy step in both workflows is the part that stops this recurring; everything else here is paying off the backlog that omission allowed.

`cargo clippy --fix` was no help, incidentally: zero of the 221 carried a machine-applicable suggestion.

## Most of the 221 were not defects

178 were `unwrap_used` and `expect_used`, and 14 were `float_cmp`. Both are correct in test code rather than sloppy. A panic in a test IS the assertion firing, and rewriting those into propagated errors would only hide which assertion fired.

Every exact float assertion in this suite turned out to be on a value that is passed through rather than computed: a literal parsed from a file, a coordinate round-tripped through JSON, or a clip boundary clamped to a whole number. Exact equality is the assertion those tests want, and an epsilon would stop them catching a boundary that is off by a hair. Where a value is genuinely computed, these tests already compare against an epsilon by hand.

So those four lints are scoped off in test builds only: one `cfg_attr(test)` at the crate root, which leaves the deny fully in force for everything birda ships, plus one header per file under `tests/`, since each of those is its own crate.

This is not a new policy. The codebase already carried 40 of these allows scattered across individual test modules and functions. The second commit deletes them, so the rule is stated once instead of forty times and cannot drift between copies.

That deletion was also the only way to learn which of the 40 were load-bearing. Two were: a hardcoded progress-bar template in the clipper command, and a UTF-8 cache path in the TensorRT provider setup. Both are in shipping code rather than a test module, so the crate-level policy correctly does not cover them, and lib-only clippy failed the moment they were dropped. Both are restored with a comment naming the invariant that makes the expect safe, which is what an allow on production code should carry and what none of the 40 did.

## The remaining 43 are fixed properly, not suppressed

Needless raw string hashes, manual let-else, a needless return, missing doc backticks, `Default::default()` where naming the type is clearer, a `vec!` that only needed an array, a clone that `slice::from_ref` does without allocating, an `items_after_statements`, and two test modules that had ordinary functions sitting after them.

Three were judgement calls rather than mechanical:

**`significant_drop_tightening`** (2 sites) held a mutex guard across their assertions. Worth tightening for a reason clippy does not give: a failing assert unwinds while still holding the lock, which poisons the mutex and turns one clear failure into a cascade of confusing ones in sibling tests sharing the buffer.

**`case_sensitive_file_extension_comparisons`** (2 sites) now ask the path for its extension instead of matching a suffix on the rendered string. That is both what clippy wants and the clearer assertion.

**`suboptimal_flops`** is deliberately allowed at its one site rather than applied. It is a performance lint, an assertion has no hot path, and `mul_add` fuses the multiply and add into a single rounding. Applying it would compute the expected value more precisely than the production code computes the actual one, which is the wrong reference for that test to compare against.

## Test plan

- [x] `cargo clippy --no-default-features --features load-dynamic --all-targets -- -D warnings` is clean (was 221 warnings)
- [x] `cargo clippy --no-default-features --features load-dynamic -- -D warnings` still clean, confirming nothing about shipping code's lint coverage changed
- [x] `cargo fmt --check` passes
- [x] All 609 tests pass, 0 failures
- [x] The only remaining allows for these four lints in `src/` are the two production sites, each with a stated invariant
