### PR TITLE
fix: enforce batch_size and day_of_year bounds on every input route

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,16 @@ An analysis run validates the configuration file before it starts, so a bad valu
 
 For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude`, `longitude`, `batch_size` and `day_of_year` agree across their routes too.
 
-`batch_size` and `day_of_year` were the last two to disagree. The 512 cap on `batch_size` exists to keep a run from exhausting GPU memory, and it used to apply to `--batch-size` alone, so a larger value hand-edited into `config.toml` went straight to the inference path. `day_of_year` was bounded on `--day-of-year` and nowhere else, and `birda config set defaults.day_of_year` did not exist, so the file was both the only way to set it and the only unchecked one.
+`batch_size` and `day_of_year` were the last two to disagree, and in both cases the config file was the route without the rule. The 512 cap on `batch_size` exists to keep a run from exhausting GPU memory, and it applied to `--batch-size` and `BIRDA_BATCH_SIZE` but not to the file, so a larger value hand-edited into `config.toml` went straight to the inference path. `day_of_year` was bounded on the flag and the environment variable, and `birda config set defaults.day_of_year` did not exist, so editing the file was the only way to set the stored default and the only route with nothing checking it.
+
+If you already have a `config.toml` with `batch_size` above 512 or a `day_of_year` outside 1 to 366, this release starts refusing it: an analysis run stops with an error naming the key, and so does any command that saves the configuration. Bring the value into range to get going again:
+
+```bash
+birda config set defaults.batch_size ""    # or a size in 1-512; empty restores the smart default
+birda config set defaults.day_of_year ""   # or a day in 1-366; empty restores auto-detection
+```
+
+If more than one value is out of range, each write is rejected by the other fault and you will need to edit `config.toml` directly; that limitation is described below.
 
 ```text
 $ birda recording.wav

--- a/README.md
+++ b/README.md
@@ -364,9 +364,11 @@ combined_prefix = "BirdNET"
 
 ### Configuration Validation
 
-An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (at least 1), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
+An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (1 to 512), `day_of_year` (1 to 366), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
 
-For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude` and `longitude` agree across their routes too.
+For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude`, `longitude`, `batch_size` and `day_of_year` agree across their routes too.
+
+`batch_size` and `day_of_year` were the last two to disagree. The 512 cap on `batch_size` exists to keep a run from exhausting GPU memory, and it used to apply to `--batch-size` alone, so a larger value hand-edited into `config.toml` went straight to the inference path. `day_of_year` was bounded on `--day-of-year` and nowhere else, and `birda config set defaults.day_of_year` did not exist, so the file was both the only way to set it and the only unchecked one.
 
 ```text
 $ birda recording.wav

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -276,24 +276,27 @@ pub struct AnalyzeArgs {
     #[arg(short = 'c', long, value_parser = parse_confidence, env = "BIRDA_MIN_CONFIDENCE")]
     pub min_confidence: Option<f32>,
 
+    // `//` rather than `///`, same reason as `yes` below: this was rendered
+    // into `--help`, where a user asking what `--overlap` does got two
+    // paragraphs about clap attributes.
+    //
+    // `allow_hyphen_values` so a negative value reaches the parser and gets
+    // the real diagnostic. Without it clap reads the leading `-` as the start
+    // of another flag and reports "a value is required", which is a usage
+    // error about the wrong thing.
+    //
+    // `--lat` and `--lon` carry the same attribute for a stronger reason, not
+    // the same one: a negative coordinate is *valid input*, so without it
+    // every southern and western hemisphere position is unreachable. Here a
+    // negative overlap is invalid either way and only the message improves.
+    // The cost, shared with those two, is that `--overlap --cpu file.wav`
+    // consumes `--cpu` as the value and reports that it is not a number
+    // rather than that no value was supplied.
     /// Segment overlap in seconds.
-    ///
-    /// `allow_hyphen_values` so a negative value reaches the parser and gets
-    /// the real diagnostic. Without it clap reads the leading `-` as the start
-    /// of another flag and reports "a value is required", which is a usage
-    /// error about the wrong thing.
-    ///
-    /// `--lat` and `--lon` carry the same attribute for a stronger reason, not
-    /// the same one: a negative coordinate is *valid input*, so without it
-    /// every southern and western hemisphere position is unreachable. Here a
-    /// negative overlap is invalid either way and only the message improves.
-    /// The cost, shared with those two, is that `--overlap --cpu file.wav`
-    /// consumes `--cpu` as the value and reports that it is not a number
-    /// rather than that no value was supplied.
     #[arg(long, allow_hyphen_values = true, value_parser = parse_overlap, env = "BIRDA_OVERLAP")]
     pub overlap: Option<f32>,
 
-    /// Inference batch size (must be at least 1).
+    /// Inference batch size (1-512).
     #[arg(short, long, value_parser = parse_batch_size, env = "BIRDA_BATCH_SIZE")]
     pub batch_size: Option<usize>,
 
@@ -402,13 +405,21 @@ pub struct AnalyzeArgs {
           requires = "month", conflicts_with = "week")]
     pub day: Option<u32>,
 
+    // Kept as a `//` comment for the reason spelled out on `yes` below: clap
+    // renders `///` into `--help`, and this is rationale for the code rather
+    // than guidance for the user.
+    //
+    // The bound lives in `constants::day_of_year`. `parse_day_of_year` applies
+    // it to this flag and to `BIRDA_DAY_OF_YEAR`, the same parser applies it
+    // through `config set`, and `validate_defaults` applies it to config.toml,
+    // which is the route that had no check at all before #312. The parser
+    // replaced an inline `clap::value_parser!(u32).range(1..=366)`, whose bound
+    // no other route could read.
+    //
+    // `--week`, `--month` and `--day` above keep their inline ranges because
+    // they have no config-file counterpart to disagree with.
     /// Day of year for BSG SDM adjustment (1-366).
     /// If not provided and BSG model is used, auto-detected from file timestamp.
-    ///
-    /// Validated by `parse_day_of_year` rather than by an inline clap range, so
-    /// the flag, `BIRDA_DAY_OF_YEAR`, `config set` and config.toml all apply one
-    /// bound. `--week`, `--month` and `--day` above keep their inline ranges
-    /// because they have no config-file counterpart to disagree with.
     #[arg(long, value_parser = parse_day_of_year, env = "BIRDA_DAY_OF_YEAR")]
     pub day_of_year: Option<u32>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -404,7 +404,12 @@ pub struct AnalyzeArgs {
 
     /// Day of year for BSG SDM adjustment (1-366).
     /// If not provided and BSG model is used, auto-detected from file timestamp.
-    #[arg(long, value_parser = clap::value_parser!(u32).range(1..=366), env = "BIRDA_DAY_OF_YEAR")]
+    ///
+    /// Validated by `parse_day_of_year` rather than by an inline clap range, so
+    /// the flag, `BIRDA_DAY_OF_YEAR`, `config set` and config.toml all apply one
+    /// bound. `--week`, `--month` and `--day` above keep their inline ranges
+    /// because they have no config-file counterpart to disagree with.
+    #[arg(long, value_parser = parse_day_of_year, env = "BIRDA_DAY_OF_YEAR")]
     pub day_of_year: Option<u32>,
 
     /// Range filter threshold (0.0-1.0).
@@ -476,7 +481,8 @@ impl AnalyzeArgs {
 
 // Re-use shared validators
 use super::validators::{
-    parse_batch_size, parse_confidence, parse_latitude, parse_longitude, parse_overlap,
+    parse_batch_size, parse_confidence, parse_day_of_year, parse_latitude, parse_longitude,
+    parse_overlap,
 };
 
 #[cfg(test)]

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -2,7 +2,7 @@
 //!
 //! Shared validation functions for CLI argument parsing.
 
-use crate::constants::{MAX_BATCH_SIZE, confidence};
+use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, day_of_year};
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -109,22 +109,65 @@ pub fn parse_overlap(s: &str) -> Result<f32, String> {
     Ok(value)
 }
 
-/// Parse and validate batch size (must be between 1 and `MAX_BATCH_SIZE`).
+/// Parse and validate batch size (must be between `MIN_BATCH_SIZE` and
+/// `MAX_BATCH_SIZE`).
+///
+/// The same range is applied to `defaults.batch_size` by
+/// `config::validate::validate_defaults`, and
+/// `test_parse_batch_size_matches_the_config_file_rule` drives both and
+/// compares their verdicts. Before #312 only this side carried the upper
+/// bound, so `--batch-size 100000` was refused while the same value in
+/// config.toml reached the inference path.
 pub fn parse_batch_size(s: &str) -> Result<usize, String> {
     let value: usize = s
         .trim()
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
-    if value < 1 {
-        return Err(format!("batch_size must be at least 1, got {value}"));
+    if value < MIN_BATCH_SIZE {
+        return Err(format!(
+            "batch_size must be at least {MIN_BATCH_SIZE}, got {value}"
+        ));
     }
 
     if value > MAX_BATCH_SIZE {
         return Err(format!(
-            "batch_size must be between 1 and {MAX_BATCH_SIZE}, got {value}\n\n\
+            "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}, got {value}\n\n\
              This limit prevents GPU memory exhaustion.\n\
              If processing fails with batch_size={MAX_BATCH_SIZE}, try reducing it further or use --cpu."
+        ));
+    }
+
+    Ok(value)
+}
+
+/// Parse and validate the day of year used for BSG SDM adjustment (1-366).
+///
+/// Shared with the config-file rule in `validate_defaults` for the reason
+/// `parse_overlap` documents: `--day-of-year` and `BIRDA_DAY_OF_YEAR` both win
+/// over `defaults.day_of_year`, so a bound enforced on one route left the
+/// routes disagreeing about one setting.
+///
+/// This replaces an inline `clap::value_parser!(u32).range(1..=366)` on the
+/// argument. That bounded the flag, but the bound was a literal only clap could
+/// read, so neither `handle_config_set` nor `validate_defaults` could apply it.
+pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
+    // Trimmed; see `parse_confidence`. This one backs `--day-of-year` and
+    // `BIRDA_DAY_OF_YEAR`.
+    //
+    // A negative input fails here rather than at the range check, so it is
+    // reported as "not a valid number" rather than as an out-of-range day. That
+    // is what the clap range parser did too.
+    let value: u32 = s
+        .trim()
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+
+    if !(day_of_year::MIN..=day_of_year::MAX).contains(&value) {
+        return Err(format!(
+            "day_of_year must be between {} and {}, got {value}",
+            day_of_year::MIN,
+            day_of_year::MAX
         ));
     }
 
@@ -330,5 +373,94 @@ mod tests {
         assert_eq!(parse_batch_size("32 ").ok(), Some(32));
         assert_eq!(parse_batch_size(" 32 ").ok(), Some(32));
         assert_eq!(parse_batch_size("  64  ").ok(), Some(64));
+    }
+
+    #[test]
+    fn test_parse_batch_size_matches_the_config_file_rule() {
+        // #312, and deliberately the same shape as
+        // `test_parse_overlap_matches_the_config_file_rule` above.
+        //
+        // Driving both rules and comparing verdicts is what makes this catch
+        // the defect. A list-based test written from the CLI's point of view
+        // ("512 ok, 513 rejected") passes against `parse_batch_size` alone and
+        // says nothing about the config file, which is precisely where the
+        // upper bound was missing: `--batch-size 100000` was refused while
+        // `batch_size = 100000` in config.toml reached the inference path.
+        for input in [
+            "1", "8", "512", // accepted by both
+            "0", "513", "100000", // rejected by both
+        ] {
+            let cli = parse_batch_size(input);
+
+            let mut config = crate::config::Config::default();
+            config.defaults.batch_size =
+                Some(input.trim().parse().expect("input must parse as usize"));
+            let file = crate::config::validate_config(&config);
+
+            assert_eq!(
+                cli.is_ok(),
+                file.is_ok(),
+                "'{input}': the flag says {}, config.toml says {}. The two rules must agree.",
+                if cli.is_ok() { "ok" } else { "rejected" },
+                if file.is_ok() { "ok" } else { "rejected" },
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_day_of_year_valid() {
+        assert_eq!(parse_day_of_year("1").ok(), Some(day_of_year::MIN));
+        assert_eq!(parse_day_of_year("200").ok(), Some(200));
+        assert_eq!(parse_day_of_year("366").ok(), Some(day_of_year::MAX));
+        // Trimmed like every sibling, because `BIRDA_DAY_OF_YEAR` can pick up a
+        // space from a shell profile or a Docker env file.
+        assert_eq!(parse_day_of_year(" 200 ").ok(), Some(200));
+    }
+
+    #[test]
+    fn test_parse_day_of_year_invalid() {
+        assert!(parse_day_of_year("0").is_err(), "the range is 1-based");
+        assert!(parse_day_of_year("367").is_err());
+        assert!(parse_day_of_year("999").is_err(), "the value from #312");
+        assert!(parse_day_of_year("-1").is_err());
+        assert!(parse_day_of_year("abc").is_err());
+
+        let err = parse_day_of_year("367").unwrap_err();
+        assert!(
+            err.contains(&format!(
+                "day_of_year must be between {} and {}",
+                day_of_year::MIN,
+                day_of_year::MAX
+            )),
+            "the message should name the bound it enforces, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_day_of_year_matches_the_config_file_rule() {
+        // The other half of #312. `--day-of-year` carried an inline
+        // `range(1..=366)`, `validate_defaults` looked at the field at all, and
+        // `config set` had no arm for the key, so config.toml was both the only
+        // route to the setting and the only unchecked one.
+        //
+        // Inputs are restricted to ones that parse as `u32`, since the config
+        // side is already typed and cannot be handed "abc" or "-1"; those are
+        // covered against the parser in `test_parse_day_of_year_invalid`.
+        for input in ["1", "200", "366", "0", "367", "100000"] {
+            let cli = parse_day_of_year(input);
+
+            let mut config = crate::config::Config::default();
+            config.defaults.day_of_year =
+                Some(input.trim().parse().expect("input must parse as u32"));
+            let file = crate::config::validate_config(&config);
+
+            assert_eq!(
+                cli.is_ok(),
+                file.is_ok(),
+                "'{input}': the flag says {}, config.toml says {}. The two rules must agree.",
+                if cli.is_ok() { "ok" } else { "rejected" },
+                if file.is_ok() { "ok" } else { "rejected" },
+            );
+        }
     }
 }

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -155,15 +155,24 @@ pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
     // Trimmed; see `parse_confidence`. This one backs `--day-of-year` and
     // `BIRDA_DAY_OF_YEAR`.
     //
-    // A negative input fails here rather than at the range check, so it is
-    // reported as "not a valid number" rather than as an out-of-range day. That
-    // is what the clap range parser did too.
-    let value: u32 = s
+    // Parsed as `i64` and then range-checked, rather than straight to `u32`,
+    // because that is what the clap parser this replaced did: `value_parser!(u32)`
+    // resolves to `RangedI64ValueParser<u32>`, which parses to `i64` first
+    // (clap_builder 4.6.2, src/builder/value_parser.rs:2362 and :1418, read this
+    // session). A negative therefore reached its bounds check and was reported as
+    // out of range.
+    //
+    // Parsing straight to `u32` looks equivalent and is not: `-1` fails at the
+    // parse step and gets reported as "not a valid number", which is false on its
+    // face. That was measured against this branch before the `i64` step was put
+    // back, and `--week` still shows the original behaviour for comparison.
+    let value: i64 = s
         .trim()
         .parse()
         .map_err(|_| format!("'{s}' is not a valid number"))?;
 
-    if !(day_of_year::MIN..=day_of_year::MAX).contains(&value) {
+    let range = i64::from(day_of_year::MIN)..=i64::from(day_of_year::MAX);
+    if !range.contains(&value) {
         return Err(format!(
             "day_of_year must be between {} and {}, got {value}",
             day_of_year::MIN,
@@ -171,7 +180,8 @@ pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
         ));
     }
 
-    Ok(value)
+    // Infallible: the range check above bounds `value` to 1..=366, which fits.
+    u32::try_from(value).map_err(|_| format!("'{s}' is not a valid number"))
 }
 
 #[cfg(test)]
@@ -280,16 +290,24 @@ mod tests {
     #[test]
     fn test_env_backed_validators_all_tolerate_whitespace() {
         // Environment variables pick up stray whitespace easily, and every one
-        // of these is reachable through a `BIRDA_*` variable. Asserted across
-        // all four together rather than for overlap alone, because the failure
-        // this pins is the crate holding two spellings of one rule: for a while
+        // of these is reachable through a `BIRDA_*` variable. Asserted over the
+        // whole set rather than for overlap alone, because the failure this
+        // pins is the crate holding two spellings of one rule: for a while
         // `BIRDA_OVERLAP=" 1.5 "` was accepted and `BIRDA_LATITUDE=" 60.1 "`
         // was not.
+        //
+        // Deliberately not stated as a count. This test said "all four" while
+        // asserting five, and #312 then added a sixth (`parse_day_of_year`,
+        // reached through `BIRDA_DAY_OF_YEAR`) without the number moving. Every
+        // env-backed parser belongs in this list; the way to check is
+        // `grep -rhoE 'env = "BIRDA_[A-Z_]+"' src/` against the ones that carry
+        // a `value_parser`.
         assert_eq!(parse_overlap(" 1.5 ").ok(), Some(1.5));
         assert_eq!(parse_confidence(" 0.5 ").ok(), Some(0.5));
         assert_eq!(parse_latitude(" 60.17 ").ok(), Some(60.17));
         assert_eq!(parse_longitude(" 24.94 ").ok(), Some(24.94));
         assert_eq!(parse_batch_size(" 32 ").ok(), Some(32));
+        assert_eq!(parse_day_of_year(" 200 ").ok(), Some(200));
     }
 
     #[test]
@@ -327,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_parse_batch_size_valid() {
-        assert_eq!(parse_batch_size("1").ok(), Some(1));
+        assert_eq!(parse_batch_size("1").ok(), Some(MIN_BATCH_SIZE));
         assert_eq!(parse_batch_size("8").ok(), Some(8));
         assert_eq!(parse_batch_size("128").ok(), Some(128));
     }
@@ -350,7 +368,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains(&format!(
-            "batch_size must be between 1 and {MAX_BATCH_SIZE}"
+            "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}"
         )));
         assert!(err.contains("GPU memory exhaustion"));
     }
@@ -361,7 +379,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains(&format!(
-            "batch_size must be between 1 and {MAX_BATCH_SIZE}"
+            "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}"
         )));
         assert!(err.contains("GPU memory exhaustion"));
     }
@@ -386,9 +404,21 @@ mod tests {
         // says nothing about the config file, which is precisely where the
         // upper bound was missing: `--batch-size 100000` was refused while
         // `batch_size = 100000` in config.toml reached the inference path.
+        // The boundaries are derived from the constants rather than spelled
+        // out. Agreement would still be checked either way, since both rules
+        // read the same constants, but with "512"/"513" written in, raising
+        // `MAX_BATCH_SIZE` would leave the inputs no longer straddling the
+        // bound, so the test would keep passing while covering less.
+        let below = (MIN_BATCH_SIZE - 1).to_string();
+        let at_max = MAX_BATCH_SIZE.to_string();
+        let above = (MAX_BATCH_SIZE + 1).to_string();
         for input in [
-            "1", "8", "512", // accepted by both
-            "0", "513", "100000", // rejected by both
+            "1",
+            "8",
+            at_max.as_str(), // accepted by both
+            below.as_str(),
+            above.as_str(),
+            "100000", // rejected by both
         ] {
             let cli = parse_batch_size(input);
 
@@ -422,8 +452,18 @@ mod tests {
         assert!(parse_day_of_year("0").is_err(), "the range is 1-based");
         assert!(parse_day_of_year("367").is_err());
         assert!(parse_day_of_year("999").is_err(), "the value from #312");
-        assert!(parse_day_of_year("-1").is_err());
         assert!(parse_day_of_year("abc").is_err());
+
+        // A negative is reported as OUT OF RANGE, not as a malformed number,
+        // because `-1` plainly is a number. Asserted rather than left to
+        // `is_err()`: parsing straight to `u32` also rejects it, but with
+        // "'-1' is not a valid number", and that is what this branch shipped
+        // until the gate caught it.
+        let negative = parse_day_of_year("-1").unwrap_err();
+        assert!(
+            negative.contains("must be between") && negative.contains("got -1"),
+            "a negative day should be reported as out of range, got: {negative}"
+        );
 
         let err = parse_day_of_year("367").unwrap_err();
         assert!(
@@ -439,14 +479,18 @@ mod tests {
     #[test]
     fn test_parse_day_of_year_matches_the_config_file_rule() {
         // The other half of #312. `--day-of-year` carried an inline
-        // `range(1..=366)`, `validate_defaults` looked at the field at all, and
-        // `config set` had no arm for the key, so config.toml was both the only
-        // route to the setting and the only unchecked one.
+        // `range(1..=366)`, `validate_defaults` did not look at the field at
+        // all, and `config set` had no arm for the key, so config.toml was the
+        // only route that could set `defaults.day_of_year` and the only one
+        // with no check. The flag and `BIRDA_DAY_OF_YEAR` could set the value
+        // for a single run, and both were bounded.
         //
         // Inputs are restricted to ones that parse as `u32`, since the config
         // side is already typed and cannot be handed "abc" or "-1"; those are
         // covered against the parser in `test_parse_day_of_year_invalid`.
-        for input in ["1", "200", "366", "0", "367", "100000"] {
+        let at_max = day_of_year::MAX.to_string();
+        let above = (day_of_year::MAX + 1).to_string();
+        for input in ["1", "200", at_max.as_str(), "0", above.as_str(), "100000"] {
             let cli = parse_day_of_year(input);
 
             let mut config = crate::config::Config::default();

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -66,7 +66,7 @@ fn validate_defaults(config: &Config) -> Result<()> {
     }
 
     // The upper bound is the half that was missing (#312). `parse_batch_size`
-    // has rejected anything above `MAX_BATCH_SIZE` since the flag existed and
+    // has rejected anything above `MAX_BATCH_SIZE` since #135 added the cap and
     // this side checked only `Some(0)`, so `--batch-size 100000` was refused
     // while `batch_size = 100000` hand-edited into config.toml went straight to
     // the inference path. The limit is there to prevent GPU memory exhaustion,
@@ -78,10 +78,17 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // compares their verdicts, so neither can be tightened alone.
     //
     // The wording deliberately stops short of the "reduce it or use --cpu"
-    // advice `parse_batch_size` adds. The two layers stay distinguishable in a
-    // test that way, which is what lets the `config set` and load-path tests
-    // each pin their own layer rather than being satisfied by the other's
-    // error.
+    // advice `parse_batch_size` adds. That is what keeps the two layers
+    // distinguishable, so `test_config_set_rejects_an_oversized_batch_size` can
+    // assert on the advice and fail if its arm falls through to this rule
+    // instead. The load-path test is pinned differently, by passing no flag at
+    // all, since this message is the only one reachable that way.
+    //
+    // The lower bound is the one place the two texts diverge without being
+    // designed to: `parse_batch_size` says "must be at least 1" while this says
+    // "must be between 1 and 512". Same verdict, different sentence, which is
+    // why `BATCH_SIZE_VIOLATION` in the integration suite matches the flag only
+    // at the upper bound.
     if let Some(batch_size) = defaults.batch_size
         && !(MIN_BATCH_SIZE..=MAX_BATCH_SIZE).contains(&batch_size)
     {
@@ -94,10 +101,12 @@ fn validate_defaults(config: &Config) -> Result<()> {
 
     // Same shape one field over. `--day-of-year` and `BIRDA_DAY_OF_YEAR` are
     // bounded by `parse_day_of_year`; the file was not, and `handle_config_set`
-    // had no arm for the key at all, so hand-editing config.toml was both the
-    // only way to set it and the one route with no check. `day_of_year = 999`
-    // then reached the BSG SDM path in `run()`, which rejects it from
-    // birdnet-onnx, far from the value that caused it.
+    // had no arm for the key at all, so hand-editing config.toml was the only
+    // way to set `defaults.day_of_year` and the only route with no check. (The
+    // flag and the environment variable set the value for one run, and both
+    // were bounded.) `day_of_year = 999` then reached the BSG SDM path in
+    // `run()`, which rejects it from birdnet-onnx, far from the value that
+    // caused it.
     if let Some(day) = defaults.day_of_year
         && !(day_of_year::MIN..=day_of_year::MAX).contains(&day)
     {

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1,7 +1,7 @@
 //! Configuration validation.
 
 use crate::config::{Config, ModelConfig};
-use crate::constants::confidence;
+use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, day_of_year};
 use crate::error::{Error, Result};
 
 /// Validate the entire configuration.
@@ -65,10 +65,48 @@ fn validate_defaults(config: &Config) -> Result<()> {
         });
     }
 
-    // Validate batch_size is at least 1 (if explicitly set)
-    if defaults.batch_size == Some(0) {
+    // The upper bound is the half that was missing (#312). `parse_batch_size`
+    // has rejected anything above `MAX_BATCH_SIZE` since the flag existed and
+    // this side checked only `Some(0)`, so `--batch-size 100000` was refused
+    // while `batch_size = 100000` hand-edited into config.toml went straight to
+    // the inference path. The limit is there to prevent GPU memory exhaustion,
+    // so the route that skipped it was the one most likely to carry a value
+    // nobody had checked.
+    //
+    // Both sides read `MIN_BATCH_SIZE`/`MAX_BATCH_SIZE`, and
+    // `test_parse_batch_size_matches_the_config_file_rule` drives the two and
+    // compares their verdicts, so neither can be tightened alone.
+    //
+    // The wording deliberately stops short of the "reduce it or use --cpu"
+    // advice `parse_batch_size` adds. The two layers stay distinguishable in a
+    // test that way, which is what lets the `config set` and load-path tests
+    // each pin their own layer rather than being satisfied by the other's
+    // error.
+    if let Some(batch_size) = defaults.batch_size
+        && !(MIN_BATCH_SIZE..=MAX_BATCH_SIZE).contains(&batch_size)
+    {
         return Err(Error::ConfigValidation {
-            message: "batch_size must be at least 1".to_string(),
+            message: format!(
+                "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}, got {batch_size}"
+            ),
+        });
+    }
+
+    // Same shape one field over. `--day-of-year` and `BIRDA_DAY_OF_YEAR` are
+    // bounded by `parse_day_of_year`; the file was not, and `handle_config_set`
+    // had no arm for the key at all, so hand-editing config.toml was both the
+    // only way to set it and the one route with no check. `day_of_year = 999`
+    // then reached the BSG SDM path in `run()`, which rejects it from
+    // birdnet-onnx, far from the value that caused it.
+    if let Some(day) = defaults.day_of_year
+        && !(day_of_year::MIN..=day_of_year::MAX).contains(&day)
+    {
+        return Err(Error::ConfigValidation {
+            message: format!(
+                "day_of_year must be between {} and {}, got {day}",
+                day_of_year::MIN,
+                day_of_year::MAX
+            ),
         });
     }
 
@@ -242,6 +280,101 @@ mod tests {
         let mut config = Config::default();
         config.defaults.batch_size = Some(0);
         assert!(validate_config(&config).is_err());
+    }
+
+    /// Build a config carrying nothing but the batch size under test.
+    fn config_with_batch_size(batch_size: usize) -> Config {
+        let mut config = Config::default();
+        config.defaults.batch_size = Some(batch_size);
+        config
+    }
+
+    #[test]
+    fn test_validate_rejects_oversized_batch_size() {
+        // #312. This is the case the old `== Some(0)` check let through, and
+        // the reason it matters is in `parse_batch_size`: the cap exists to
+        // prevent GPU memory exhaustion, and config.toml was the route that
+        // skipped it.
+        let err = validate_config(&config_with_batch_size(100_000)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConfigValidation { .. }),
+            "an oversized batch size is a config error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains(&format!(
+                "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}"
+            )),
+            "the message should name the bound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_the_batch_size_boundaries() {
+        // The control. Without it the rule above passes just as well when
+        // written with an exclusive upper bound, which would refuse the largest
+        // batch size the CLI accepts and make the two routes disagree in the
+        // other direction.
+        assert!(validate_config(&config_with_batch_size(MIN_BATCH_SIZE)).is_ok());
+        assert!(validate_config(&config_with_batch_size(MAX_BATCH_SIZE)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_accepts_an_unset_batch_size() {
+        // `None` means "pick a default from the model and provider", which
+        // `determine_default_batch_size` does at run time. A range check
+        // written over `unwrap_or_default()` would turn that into a rejected
+        // zero, so the absent case is pinned separately.
+        let mut config = Config::default();
+        config.defaults.batch_size = None;
+        assert!(validate_config(&config).is_ok());
+    }
+
+    /// Build a config carrying nothing but the day of year under test.
+    fn config_with_day_of_year(day: u32) -> Config {
+        let mut config = Config::default();
+        config.defaults.day_of_year = Some(day);
+        config
+    }
+
+    #[test]
+    fn test_validate_rejects_out_of_range_day_of_year() {
+        // The field `validate_defaults` did not look at at all (#312). 999 is
+        // the value from the issue; it reached the BSG SDM path and was
+        // rejected there by birdnet-onnx, far from the config key that set it.
+        let err = validate_config(&config_with_day_of_year(999)).unwrap_err();
+
+        assert!(
+            matches!(err, Error::ConfigValidation { .. }),
+            "an out-of-range day of year is a config error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains(&format!(
+                "day_of_year must be between {} and {}",
+                day_of_year::MIN,
+                day_of_year::MAX
+            )),
+            "the message should name the bound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_day_of_year_zero() {
+        // The 1-based half. An off-by-one written as `0..=366` accepts this and
+        // passes every other test here.
+        assert!(validate_config(&config_with_day_of_year(0)).is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_the_day_of_year_boundaries() {
+        // 366 is deliberately included: the last day of a leap year is legal,
+        // and a bound written as 365 would reject a real date.
+        assert!(validate_config(&config_with_day_of_year(day_of_year::MIN)).is_ok());
+        assert!(validate_config(&config_with_day_of_year(day_of_year::MAX)).is_ok());
+        assert!(
+            validate_config(&Config::default()).is_ok(),
+            "unset is legal"
+        );
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -20,6 +20,14 @@ pub const DEFAULT_OVERLAP: f32 = 0.0;
 /// See `determine_default_batch_size()` in `lib.rs` for dynamic batch size selection.
 pub const DEFAULT_BATCH_SIZE: usize = 8;
 
+/// Minimum allowed batch size.
+///
+/// One segment per inference call. Zero means "run inference on nothing", and
+/// it was the only batch size the config-file route rejected before #312: the
+/// upper bound lived in `cli::validators::parse_batch_size` alone. Both routes
+/// read this constant now, so neither can be tightened without the other.
+pub const MIN_BATCH_SIZE: usize = 1;
+
 /// Maximum allowed batch size to prevent GPU memory exhaustion.
 ///
 /// This hard limit prevents users from specifying absurdly large batch sizes
@@ -47,6 +55,22 @@ pub mod batch_size {
 
     /// Conservative default for unknown/other GPU providers.
     pub const OTHER_GPU: usize = 16;
+}
+
+/// Valid range for the day of year used by BSG SDM seasonal adjustment.
+///
+/// A calendar position rather than an offset, so it is 1-based, and the upper
+/// bound is 366 so the last day of a leap year is reachable.
+///
+/// Read by `cli::validators::parse_day_of_year` and by `config::validate`, for
+/// the reason above: the bound used to be an inline `range(1..=366)` on the
+/// clap argument, which nothing else could see.
+pub mod day_of_year {
+    /// First day of the year.
+    pub const MIN: u32 = 1;
+
+    /// Last day of a leap year.
+    pub const MAX: u32 = 366;
 }
 
 /// Default number of top predictions to return per segment.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1331,11 +1331,14 @@ fn handle_config_command(action: cli::ConfigAction, output_mode: OutputMode) -> 
 /// Apply a `cli::validators` parser to a `config set` value, naming the key.
 ///
 /// These are the same parsers clap runs for the matching flags, so a value
-/// typed at `config set` is refused for the same reason, and with the same
-/// wording, as `--batch-size` or `--day-of-year`. Each arm used to call a bare
+/// typed at `config set` is refused for the same reason, and carries the same
+/// rule message, as `--batch-size` or `--day-of-year`; this adds the key name
+/// in front of it. The numeric arms this serves used to call a bare
 /// `value.parse()` and lean on the whole-config validation inside
 /// `save_config`, which knows nothing about the key the user typed and, for
-/// `batch_size`, did not carry the upper bound at all (#312).
+/// `batch_size`, did not carry the upper bound at all (#312). The
+/// `defaults.day_of_year` arm is new. The arms that store a string, a path or
+/// an enum do not come through here and never parsed.
 ///
 /// The key prefix is not only for the reader. It is what tells this layer's
 /// rejection apart from `validate_defaults`', so a test for this arm cannot be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1328,6 +1328,28 @@ fn handle_config_command(action: cli::ConfigAction, output_mode: OutputMode) -> 
     }
 }
 
+/// Apply a `cli::validators` parser to a `config set` value, naming the key.
+///
+/// These are the same parsers clap runs for the matching flags, so a value
+/// typed at `config set` is refused for the same reason, and with the same
+/// wording, as `--batch-size` or `--day-of-year`. Each arm used to call a bare
+/// `value.parse()` and lean on the whole-config validation inside
+/// `save_config`, which knows nothing about the key the user typed and, for
+/// `batch_size`, did not carry the upper bound at all (#312).
+///
+/// The key prefix is not only for the reader. It is what tells this layer's
+/// rejection apart from `validate_defaults`', so a test for this arm cannot be
+/// satisfied by the save-side check firing instead.
+fn parse_config_value<T>(
+    key: &str,
+    value: &str,
+    parse: impl Fn(&str) -> std::result::Result<T, String>,
+) -> Result<T> {
+    parse(value).map_err(|message| Error::ConfigValidation {
+        message: format!("invalid value for '{key}': {message}"),
+    })
+}
+
 fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<()> {
     let mut config = load_default_config()?;
     let config_path = config_file_path()?;
@@ -1344,58 +1366,73 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
             config.defaults.min_confidence = if value.is_empty() {
                 config::DefaultsConfig::default().min_confidence
             } else {
-                value.parse::<f32>().map_err(|_| Error::ConfigValidation {
-                    message: format!("invalid float value for '{key}': {value}"),
-                })?
+                parse_config_value(key, value, cli::validators::parse_confidence)?
             };
         }
         "defaults.overlap" => {
             config.defaults.overlap = if value.is_empty() {
                 config::DefaultsConfig::default().overlap
             } else {
-                value.parse::<f32>().map_err(|_| Error::ConfigValidation {
-                    message: format!("invalid float value for '{key}': {value}"),
-                })?
+                parse_config_value(key, value, cli::validators::parse_overlap)?
             };
         }
         "defaults.latitude" => {
             config.defaults.latitude = if value.is_empty() {
                 None
             } else {
-                Some(value.parse::<f64>().map_err(|_| Error::ConfigValidation {
-                    message: format!("invalid float value for '{key}': {value}"),
-                })?)
+                Some(parse_config_value(
+                    key,
+                    value,
+                    cli::validators::parse_latitude,
+                )?)
             };
         }
         "defaults.longitude" => {
             config.defaults.longitude = if value.is_empty() {
                 None
             } else {
-                Some(value.parse::<f64>().map_err(|_| Error::ConfigValidation {
-                    message: format!("invalid float value for '{key}': {value}"),
-                })?)
+                Some(parse_config_value(
+                    key,
+                    value,
+                    cli::validators::parse_longitude,
+                )?)
             };
         }
         "defaults.batch_size" => {
             config.defaults.batch_size = if value.is_empty() {
                 None
             } else {
-                Some(
-                    value
-                        .parse::<usize>()
-                        .map_err(|_| Error::ConfigValidation {
-                            message: format!("invalid integer value for '{key}': {value}"),
-                        })?,
-                )
+                Some(parse_config_value(
+                    key,
+                    value,
+                    cli::validators::parse_batch_size,
+                )?)
+            };
+        }
+        // No arm existed for this key, so hand-editing config.toml was the only
+        // way to set it, and that was the one route `validate_defaults` did not
+        // check either (#312). Both halves are closed now.
+        "defaults.day_of_year" => {
+            config.defaults.day_of_year = if value.is_empty() {
+                None
+            } else {
+                Some(parse_config_value(
+                    key,
+                    value,
+                    cli::validators::parse_day_of_year,
+                )?)
             };
         }
         "defaults.range_threshold" => {
             config.defaults.range_threshold = if value.is_empty() {
                 config::DefaultsConfig::default().range_threshold
             } else {
-                value.parse::<f32>().map_err(|_| Error::ConfigValidation {
-                    message: format!("invalid float value for '{key}': {value}"),
-                })?
+                // `parse_confidence` rather than a threshold-specific parser
+                // because `--range-threshold` already uses it: both are bounded
+                // by `confidence::MIN`/`MAX`, and a second parser would be a
+                // second copy of one rule. The message it produces says
+                // "confidence", which the key prefix disambiguates.
+                parse_config_value(key, value, cli::validators::parse_confidence)?
             };
         }
         // The three keys below are siblings of range_threshold above. They were

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -1,5 +1,6 @@
-//! Integration tests for configuration validation on load (#295), and for the
-//! overlap rule reaching every input channel rather than only the file (#306).
+//! Integration tests for configuration validation on load (#295), for the
+//! overlap rule reaching every input channel rather than only the file (#306),
+//! and for the same parity on `batch_size` and `day_of_year` (#312).
 //!
 //! These drive the real binary rather than calling `validate_config` directly,
 //! and that is the point. Every rule in `src/config/validate.rs` already
@@ -210,7 +211,13 @@ fn assert_validation_did_not_reject(home: &Path) {
     let input = dummy_input(home);
     let stderr = stderr_of(&run_in(home, &[input.to_str().unwrap()]));
 
-    for message in [LATITUDE_VIOLATION, THRESHOLD_VIOLATION, OVERLAP_VIOLATION] {
+    for message in [
+        LATITUDE_VIOLATION,
+        THRESHOLD_VIOLATION,
+        OVERLAP_VIOLATION,
+        BATCH_SIZE_VIOLATION,
+        DAY_OF_YEAR_VIOLATION,
+    ] {
         assert!(
             !stderr.contains(message),
             "a valid config must not be rejected ({message}), got: {stderr}"
@@ -227,6 +234,24 @@ fn assert_validation_did_not_reject(home: &Path) {
 const LATITUDE_VIOLATION: &str = "invalid latitude";
 const THRESHOLD_VIOLATION: &str = "invalid range threshold";
 const OVERLAP_VIOLATION: &str = "overlap must be a finite non-negative number";
+const BATCH_SIZE_VIOLATION: &str = "batch_size must be between";
+const DAY_OF_YEAR_VIOLATION: &str = "day_of_year must be between";
+
+/// The tail `cli::validators::parse_batch_size` adds and the config-file rule
+/// does not.
+///
+/// Asserted on so the `config set` test pins its own layer. Both layers reject
+/// an oversized batch size and both exit 1, so a test that only checked for
+/// [`BATCH_SIZE_VIOLATION`] would pass just as well when the arm falls through
+/// to the whole-config validation inside `save_config`, which is the state
+/// before #312.
+const BATCH_SIZE_CLI_ADVICE: &str = "GPU memory exhaustion";
+
+/// The prefix `handle_config_set` puts on a value it refused itself.
+///
+/// Same purpose as [`BATCH_SIZE_CLI_ADVICE`]: it names the key the user typed,
+/// which neither `validate_defaults` nor clap can do.
+const CONFIG_SET_REJECTION: &str = "invalid value for";
 
 /// The exit code birda uses for an application error, as opposed to a clap
 /// parse failure (2) or a panic (101). Pinned so a rejection test cannot be
@@ -451,12 +476,16 @@ fn test_a_dangling_default_model_does_not_block_the_models_commands() {
     assert_command_succeeds(home.path(), &["models", "check"]);
 }
 
-/// Assert clap refused the run, naming the offending overlap value.
+/// Assert clap refused the run, naming the offending value.
 ///
-/// Takes the whole invocation rather than just the value, because #306 is about
-/// two input channels agreeing, and the flag and the environment variable reach
-/// clap by different routes.
-fn assert_overlap_rejected(home: &Path, env: &[(&str, &str)], args: &[&str]) {
+/// Takes the whole invocation rather than just the value, because #306 and #312
+/// are both about input channels agreeing, and the flag and the environment
+/// variable reach clap by different routes.
+///
+/// `expected` is the rule message, which is the same string the config-file
+/// rule emits. That is the claim being made: one rule, whichever route the
+/// value arrives by.
+fn assert_flag_rejected(home: &Path, env: &[(&str, &str)], args: &[&str], expected: &str) {
     let input = dummy_input(home);
     let mut full: Vec<&str> = args.to_vec();
     let input = input.to_str().unwrap();
@@ -467,14 +496,14 @@ fn assert_overlap_rejected(home: &Path, env: &[(&str, &str)], args: &[&str]) {
     assert_eq!(
         output.status.code(),
         Some(CLAP_USAGE_ERROR),
-        "an invalid overlap must be refused by the value parser, got: {}",
+        "an invalid value must be refused by the value parser, got: {}",
         stderr_of(&output)
     );
     let stderr = stderr_of(&output);
     assert!(
-        stderr.contains(OVERLAP_VIOLATION),
+        stderr.contains(expected),
         "the flag and the config file should give the same diagnostic \
-         ({OVERLAP_VIOLATION}), got: {stderr}"
+         ({expected}), got: {stderr}"
     );
 }
 
@@ -487,7 +516,7 @@ fn test_a_nan_overlap_flag_is_rejected() {
     // non-overlapping segments and said nothing.
     let home = tempfile::tempdir().unwrap();
 
-    assert_overlap_rejected(home.path(), &[], &["--overlap", "nan"]);
+    assert_flag_rejected(home.path(), &[], &["--overlap", "nan"], OVERLAP_VIOLATION);
 }
 
 #[test]
@@ -499,7 +528,7 @@ fn test_an_infinite_overlap_flag_is_rejected() {
     // no diagnostic.
     let home = tempfile::tempdir().unwrap();
 
-    assert_overlap_rejected(home.path(), &[], &["--overlap", "inf"]);
+    assert_flag_rejected(home.path(), &[], &["--overlap", "inf"], OVERLAP_VIOLATION);
 }
 
 #[test]
@@ -512,7 +541,7 @@ fn test_a_negative_overlap_flag_is_rejected() {
     // the same reason.
     let home = tempfile::tempdir().unwrap();
 
-    assert_overlap_rejected(home.path(), &[], &["--overlap", "-1"]);
+    assert_flag_rejected(home.path(), &[], &["--overlap", "-1"], OVERLAP_VIOLATION);
 }
 
 #[test]
@@ -525,7 +554,12 @@ fn test_the_overlap_env_var_is_validated() {
     // parser to both sources and only an end-to-end run proves it.
     let home = tempfile::tempdir().unwrap();
 
-    assert_overlap_rejected(home.path(), &[("BIRDA_OVERLAP", "-1")], &[]);
+    assert_flag_rejected(
+        home.path(),
+        &[("BIRDA_OVERLAP", "-1")],
+        &[],
+        OVERLAP_VIOLATION,
+    );
 }
 
 #[test]
@@ -565,6 +599,196 @@ fn test_a_valid_overlap_flag_is_accepted() {
         !stderr_of(&output).contains(OVERLAP_VIOLATION),
         "a finite non-negative overlap must not be rejected, got: {}",
         stderr_of(&output)
+    );
+}
+
+#[test]
+fn test_an_oversized_batch_size_is_rejected_on_load() {
+    // #312. `parse_batch_size` has capped the flag at 512 since it existed and
+    // this file was checked for `Some(0)` and nothing else, so `--batch-size
+    // 100000` was refused while this exact value, hand-edited, reached the
+    // inference path. The cap is there to prevent GPU memory exhaustion, so the
+    // unchecked route was the one that could hang the machine.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nbatch_size = 100000\n");
+
+    assert_analysis_rejected(home.path(), BATCH_SIZE_VIOLATION);
+}
+
+#[test]
+fn test_an_out_of_range_day_of_year_is_rejected_on_load() {
+    // The other #312 field, and the wider hole of the two: `validate_defaults`
+    // did not look at it at all and `config set` had no arm for it, so
+    // config.toml was both the only way to set it and the only route with no
+    // check. 999 reached the BSG SDM path and was rejected there by
+    // birdnet-onnx, a long way from the key that carried it.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nday_of_year = 999\n");
+
+    assert_analysis_rejected(home.path(), DAY_OF_YEAR_VIOLATION);
+}
+
+#[test]
+fn test_the_day_of_year_flag_is_rejected_by_the_value_parser() {
+    // The flag was already bounded, by an inline `range(1..=366)`. This pins
+    // that swapping it for `parse_day_of_year` did not loosen it, which is what
+    // makes the shared parser safe to depend on: clap's range and the config
+    // rule were two literals, and only one of them existed.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_flag_rejected(
+        home.path(),
+        &[],
+        &["--day-of-year", "999"],
+        DAY_OF_YEAR_VIOLATION,
+    );
+}
+
+#[test]
+fn test_the_day_of_year_env_var_is_validated() {
+    // `BIRDA_DAY_OF_YEAR` wins over the config value the same way
+    // `BIRDA_OVERLAP` does, so it gets the same treatment. clap applies the
+    // value parser to both sources and only an end-to-end run proves it.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_flag_rejected(
+        home.path(),
+        &[("BIRDA_DAY_OF_YEAR", "0")],
+        &[],
+        DAY_OF_YEAR_VIOLATION,
+    );
+}
+
+#[test]
+fn test_a_valid_day_of_year_flag_is_accepted() {
+    // The control for the two above, which would both pass against a parser
+    // that rejected everything. 366 is deliberate: the last day of a leap year
+    // is a real date, and a bound written as 365 would refuse it.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    let input = dummy_input(home.path());
+
+    let output = run_in(
+        home.path(),
+        &["--day-of-year", "366", input.to_str().unwrap()],
+    );
+
+    // "Not a usage error" rather than the absence of the message, for the
+    // reason `test_a_valid_overlap_flag_is_accepted` documents: absence alone
+    // also passes when the flag does not exist at all, and clap returns 2 for
+    // both "invalid value" and "unexpected argument".
+    assert_ne!(
+        output.status.code(),
+        Some(CLAP_USAGE_ERROR),
+        "a day of year inside the range must be accepted, got: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        !stderr_of(&output).contains(DAY_OF_YEAR_VIOLATION),
+        "a day of year inside the range must not be rejected, got: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn test_config_set_rejects_an_oversized_batch_size() {
+    // The third route to the same setting, and the one #312 names explicitly:
+    // the arm parsed a bare `usize` and left the bound to the whole-config
+    // validation inside `save_config`, which did not carry it.
+    //
+    // Asserted on the parser's own wording rather than on "rejected", because
+    // the save-side rule now refuses this value too and exits the same way.
+    // Without pinning CONFIG_SET_REJECTION and BATCH_SIZE_CLI_ADVICE, both of
+    // which only the arm can produce, this test passes with the arm reverted to
+    // `value.parse::<usize>()` and proves nothing about the layer it names.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.batch_size", "100000"],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "`config set` must reject an oversized batch size as an application \
+         error, got: {}",
+        stderr_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains(CONFIG_SET_REJECTION) && stderr.contains(BATCH_SIZE_CLI_ADVICE),
+        "the rejection should come from the shared value parser, naming the key \
+         and carrying its advice, got: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a rejected `config set` must leave the file untouched"
+    );
+}
+
+#[test]
+fn test_config_set_writes_a_valid_day_of_year() {
+    // A new route rather than a repaired one: the key had no arm, so this
+    // failed with "invalid configuration key" and hand-editing config.toml was
+    // the only way in.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.day_of_year", "200"],
+    );
+    assert!(
+        output.status.success(),
+        "`config set defaults.day_of_year` must be accepted: {}",
+        stderr_of(&output)
+    );
+
+    // Pin the value that landed, not just the exit code. An arm that parsed the
+    // value and then stored a default would satisfy a success assertion.
+    let shown = run_in(home.path(), &["config", "show", "--output-mode", "json"]);
+    let envelope: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&shown.stdout))
+        .expect("`config show` must emit a parseable envelope");
+    assert_eq!(
+        envelope["payload"]["config"]["defaults"]["day_of_year"], 200,
+        "the stored day of year should be the one that was set"
+    );
+}
+
+#[test]
+fn test_config_set_rejects_an_out_of_range_day_of_year() {
+    // The rejecting half of the arm above. Pinned on CONFIG_SET_REJECTION
+    // because `validate_defaults` now emits the same rule message with the same
+    // exit code, so the key prefix is the only thing that tells the two apart.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.day_of_year", "999"],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "`config set` must reject an out-of-range day of year as an \
+         application error, got: {}",
+        stderr_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains(CONFIG_SET_REJECTION) && stderr.contains(DAY_OF_YEAR_VIOLATION),
+        "the rejection should name the key and the rule, got: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a rejected `config set` must leave the file untouched"
     );
 }
 

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -155,6 +155,28 @@ fn seed_config(home: &Path, contents: &str) -> PathBuf {
     path
 }
 
+/// Read one `[defaults]` key back through the structured envelope.
+///
+/// Asserted through JSON rather than by parsing config.toml, for the reason
+/// `test_config_show_still_works_with_an_invalid_config` gives: this payload is
+/// what birda-gui consumes, so it is the surface worth pinning.
+///
+/// Returns `Value::Null` for a cleared key, whichever way it is cleared:
+/// `day_of_year` carries `skip_serializing_if` so it disappears from the
+/// payload, `batch_size` carries no serde attribute so it appears as an
+/// explicit null, and indexing yields `Value::Null` either way.
+fn config_value(home: &Path, key: &str) -> serde_json::Value {
+    let shown = run_in(home, &["config", "show", "--output-mode", "json"]);
+    assert!(
+        shown.status.success(),
+        "`config show` failed: {}",
+        stderr_of(&shown)
+    );
+    let envelope: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&shown.stdout))
+        .expect("`config show` must emit a parseable envelope");
+    envelope["payload"]["config"]["defaults"][key].clone()
+}
+
 /// An input path that makes the run take the analyze branch.
 ///
 /// Analysis is the only gated command, so every "must be rejected" assertion
@@ -224,6 +246,16 @@ fn assert_validation_did_not_reject(home: &Path) {
         );
     }
 }
+
+/// A config that passes validation, for tests whose subject is not the file.
+///
+/// Named rather than repeated inline because the call to `seed_config` is
+/// load-bearing even when the contents are irrelevant: it carries the assertion
+/// that the temp HOME actually redirected the config directory. Without it a
+/// test reaches the developer's real config.toml on any platform where the
+/// redirection does not work. `test_a_valid_overlap_flag_is_accepted` explains
+/// this at length; the constant keeps the next reader from having to find it.
+const VALID_SEED: &str = "[defaults]\nbatch_size = 8\n";
 
 /// The rule messages this suite drives, exactly as the user sees them.
 ///
@@ -482,9 +514,15 @@ fn test_a_dangling_default_model_does_not_block_the_models_commands() {
 /// are both about input channels agreeing, and the flag and the environment
 /// variable reach clap by different routes.
 ///
-/// `expected` is the rule message, which is the same string the config-file
-/// rule emits. That is the claim being made: one rule, whichever route the
-/// value arrives by.
+/// `expected` is the rule message. For `OVERLAP_VIOLATION` and
+/// `DAY_OF_YEAR_VIOLATION` it is the same string the config-file rule emits,
+/// which is the claim being made: one rule, whichever route the value arrives
+/// by.
+///
+/// `BATCH_SIZE_VIOLATION` matches on the upper bound only. At the lower bound
+/// the flag says "`batch_size` must be at least 1" where the file says "must be
+/// between 1 and 512", so passing it here with `--batch-size 0` would fail.
+/// Same verdict, different sentence; `src/config/validate.rs` records why.
 fn assert_flag_rejected(home: &Path, env: &[(&str, &str)], args: &[&str], expected: &str) {
     let input = dummy_input(home);
     let mut full: Vec<&str> = args.to_vec();
@@ -604,11 +642,12 @@ fn test_a_valid_overlap_flag_is_accepted() {
 
 #[test]
 fn test_an_oversized_batch_size_is_rejected_on_load() {
-    // #312. `parse_batch_size` has capped the flag at 512 since it existed and
-    // this file was checked for `Some(0)` and nothing else, so `--batch-size
-    // 100000` was refused while this exact value, hand-edited, reached the
-    // inference path. The cap is there to prevent GPU memory exhaustion, so the
-    // unchecked route was the one that could hang the machine.
+    // #312. `parse_batch_size` has capped the flag at 512 since #135 added the
+    // cap, and config.toml was checked for `Some(0)` and nothing else, so
+    // `--batch-size 100000` was refused while this exact value, hand-edited,
+    // reached the inference path. The cap is there to prevent GPU memory
+    // exhaustion, so the unchecked route was the one that could hang the
+    // machine.
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), "[defaults]\nbatch_size = 100000\n");
 
@@ -619,9 +658,10 @@ fn test_an_oversized_batch_size_is_rejected_on_load() {
 fn test_an_out_of_range_day_of_year_is_rejected_on_load() {
     // The other #312 field, and the wider hole of the two: `validate_defaults`
     // did not look at it at all and `config set` had no arm for it, so
-    // config.toml was both the only way to set it and the only route with no
-    // check. 999 reached the BSG SDM path and was rejected there by
-    // birdnet-onnx, a long way from the key that carried it.
+    // config.toml was the only route to `defaults.day_of_year` and the only one
+    // with no check. (`--day-of-year` and `BIRDA_DAY_OF_YEAR` set it for a
+    // single run and were both bounded.) 999 reached the BSG SDM path and was
+    // rejected there by birdnet-onnx, a long way from the key that carried it.
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), "[defaults]\nday_of_year = 999\n");
 
@@ -665,7 +705,7 @@ fn test_a_valid_day_of_year_flag_is_accepted() {
     // that rejected everything. 366 is deliberate: the last day of a leap year
     // is a real date, and a bound written as 365 would refuse it.
     let home = tempfile::tempdir().unwrap();
-    seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    seed_config(home.path(), VALID_SEED);
     let input = dummy_input(home.path());
 
     let output = run_in(
@@ -702,7 +742,7 @@ fn test_config_set_rejects_an_oversized_batch_size() {
     // which only the arm can produce, this test passes with the arm reverted to
     // `value.parse::<usize>()` and proves nothing about the layer it names.
     let home = tempfile::tempdir().unwrap();
-    let path = seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    let path = seed_config(home.path(), VALID_SEED);
     let before = std::fs::read_to_string(&path).unwrap();
 
     let output = run_in(
@@ -736,7 +776,7 @@ fn test_config_set_writes_a_valid_day_of_year() {
     // failed with "invalid configuration key" and hand-editing config.toml was
     // the only way in.
     let home = tempfile::tempdir().unwrap();
-    seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    seed_config(home.path(), VALID_SEED);
 
     let output = run_in(
         home.path(),
@@ -750,11 +790,9 @@ fn test_config_set_writes_a_valid_day_of_year() {
 
     // Pin the value that landed, not just the exit code. An arm that parsed the
     // value and then stored a default would satisfy a success assertion.
-    let shown = run_in(home.path(), &["config", "show", "--output-mode", "json"]);
-    let envelope: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&shown.stdout))
-        .expect("`config show` must emit a parseable envelope");
     assert_eq!(
-        envelope["payload"]["config"]["defaults"]["day_of_year"], 200,
+        config_value(home.path(), "day_of_year"),
+        200,
         "the stored day of year should be the one that was set"
     );
 }
@@ -765,7 +803,7 @@ fn test_config_set_rejects_an_out_of_range_day_of_year() {
     // because `validate_defaults` now emits the same rule message with the same
     // exit code, so the key prefix is the only thing that tells the two apart.
     let home = tempfile::tempdir().unwrap();
-    let path = seed_config(home.path(), "[defaults]\nbatch_size = 8\n");
+    let path = seed_config(home.path(), VALID_SEED);
     let before = std::fs::read_to_string(&path).unwrap();
 
     let output = run_in(
@@ -793,15 +831,139 @@ fn test_config_set_rejects_an_out_of_range_day_of_year() {
 }
 
 #[test]
+fn test_the_batch_size_flag_is_rejected_by_the_value_parser() {
+    // The route README's "agree across their routes" claim rested on with no
+    // test behind it: `batch_size` had end-to-end coverage for the file and for
+    // `config set`, and none for the flag or the environment variable.
+    //
+    // Driven at the UPPER bound deliberately. That is where the two routes
+    // share wording, so `BATCH_SIZE_VIOLATION` matches both; at the lower bound
+    // they diverge, which `assert_flag_rejected`'s doc records.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_flag_rejected(
+        home.path(),
+        &[],
+        &["--batch-size", "100000"],
+        BATCH_SIZE_VIOLATION,
+    );
+}
+
+#[test]
+fn test_the_batch_size_env_var_is_validated() {
+    // `BIRDA_BATCH_SIZE` wins over the config value, so it gets the same
+    // treatment as `BIRDA_OVERLAP` and `BIRDA_DAY_OF_YEAR`. clap applies the
+    // value parser to both sources and only an end-to-end run proves it.
+    let home = tempfile::tempdir().unwrap();
+
+    assert_flag_rejected(
+        home.path(),
+        &[("BIRDA_BATCH_SIZE", "100000")],
+        &[],
+        BATCH_SIZE_VIOLATION,
+    );
+}
+
+#[test]
+fn test_config_set_writes_a_valid_batch_size() {
+    // The accept side its day_of_year twin already had. Without it the arm is
+    // only ever driven with a value it must refuse, so an arm that rejected
+    // everything would pass the suite.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), VALID_SEED);
+
+    let output = run_in(home.path(), &["config", "set", "defaults.batch_size", "32"]);
+    assert!(
+        output.status.success(),
+        "`config set defaults.batch_size 32` must be accepted: {}",
+        stderr_of(&output)
+    );
+
+    assert_eq!(
+        config_value(home.path(), "batch_size"),
+        32,
+        "the stored batch size should be the one that was set"
+    );
+}
+
+#[test]
+fn test_config_set_clears_the_day_of_year() {
+    // The empty-value branch of the new arm, which is the half that decides
+    // between `None` and a parsed value. Nothing else drives it, and it is the
+    // only way to get back to "auto-detect from the file timestamp" without
+    // hand-editing.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), "[defaults]\nday_of_year = 200\n");
+
+    let output = run_in(home.path(), &["config", "set", "defaults.day_of_year", ""]);
+    assert!(
+        output.status.success(),
+        "clearing the key must be accepted: {}",
+        stderr_of(&output)
+    );
+
+    assert!(
+        config_value(home.path(), "day_of_year").is_null(),
+        "an empty value must clear the key, not store a zero or a default"
+    );
+}
+
+#[test]
+fn test_config_set_rejects_an_out_of_range_min_confidence() {
+    // A rewired arm that is neither of the two #312 fields. Five of the seven
+    // numeric arms moved from a bare `value.parse()` to the shared validators
+    // in this change, and without this only `batch_size`, `day_of_year` and
+    // `latitude` were driven at all.
+    //
+    // Pinned on CONFIG_SET_REJECTION because `save_config`'s whole-config
+    // validation rejects 1.5 as well, with `min_confidence must be between`;
+    // only the arm names the key the user typed. So this fails if the arm is
+    // reverted to a bare parse, which is the layer it is here to cover.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), VALID_SEED);
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.min_confidence", "1.5"],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "`config set` must reject an out-of-range confidence as an application \
+         error, got: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains(CONFIG_SET_REJECTION),
+        "the arm should refuse it and name the key, got: {}",
+        stderr_of(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a rejected `config set` must leave the file untouched"
+    );
+}
+
+#[test]
 fn test_a_valid_config_still_loads() {
     // The control. Without it every assertion above would pass just as well if
     // the new check rejected every config it was handed. Analysis may still
     // fail further on (no model is configured here), so this asserts only that
     // it got past validation.
+    // `batch_size` and `day_of_year` are set at their inclusive maxima rather
+    // than left out. Omitted, `validate_defaults` short-circuits on `None` and
+    // the two rule messages this control asserts absent could never have
+    // appeared, so those assertions held by construction. At 512 and 366 they
+    // are real, and the upper bounds get end-to-end coverage they otherwise
+    // have only at unit level.
     let home = tempfile::tempdir().unwrap();
     seed_config(
         home.path(),
-        "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n",
+        "[defaults]\nlatitude = 60.17\nlongitude = 24.94\nrange_threshold = 0.03\n\
+         batch_size = 512\nday_of_year = 366\n",
     );
 
     assert_validation_did_not_reject(home.path());

--- a/tests/cuda_detection_test.rs
+++ b/tests/cuda_detection_test.rs
@@ -48,7 +48,13 @@ fn test_cuda_library_patterns_platform_specific() {
     {
         assert_eq!(patterns, &["libcudart.*.dylib"]);
         assert!(patterns[0].starts_with("lib"));
-        assert!(patterns[0].ends_with(".dylib"));
+        // `contains` rather than `ends_with`, matching the Linux arm above.
+        // The value is a glob pattern, not a path, so
+        // `case_sensitive_file_extension_comparisons` fires on `ends_with` and
+        // suggests `Path::extension`, which would be the wrong question to ask
+        // of a pattern. Linux CI never compiled this arm, which is how it
+        // survived the `--all-targets` sweep in #338.
+        assert!(patterns[0].contains(".dylib"));
         assert!(patterns[0].contains('*'));
     }
 }

--- a/tests/cuda_detection_test.rs
+++ b/tests/cuda_detection_test.rs
@@ -32,7 +32,10 @@ fn test_cuda_library_patterns_platform_specific() {
     #[cfg(target_os = "windows")]
     {
         assert_eq!(patterns, &["cudart64_*.dll"]);
-        assert!(patterns[0].ends_with(".dll"));
+        // `contains`, not `ends_with`: see the macOS arm below. The lint is
+        // extension-agnostic, so this arm trips it too, and nothing in CI
+        // compiles either one.
+        assert!(patterns[0].contains(".dll"));
         assert!(patterns[0].contains('*'));
     }
 
@@ -49,11 +52,13 @@ fn test_cuda_library_patterns_platform_specific() {
         assert_eq!(patterns, &["libcudart.*.dylib"]);
         assert!(patterns[0].starts_with("lib"));
         // `contains` rather than `ends_with`, matching the Linux arm above.
-        // The value is a glob pattern, not a path, so
-        // `case_sensitive_file_extension_comparisons` fires on `ends_with` and
-        // suggests `Path::extension`, which would be the wrong question to ask
-        // of a pattern. Linux CI never compiled this arm, which is how it
-        // survived the `--all-targets` sweep in #338.
+        // `case_sensitive_file_extension_comparisons` fires on `ends_with` with
+        // an extension literal and suggests `Path::extension`, which is the
+        // wrong question to ask of a glob pattern. Every job in
+        // .github/workflows/ci.yml runs on ubuntu-latest, so neither this arm
+        // nor the Windows one is ever linted there, which is how both survived
+        // the `--all-targets` sweep in #338; they surface for a developer
+        // running the gate on that platform.
         assert!(patterns[0].contains(".dylib"));
         assert!(patterns[0].contains('*'));
     }

--- a/tests/tensorrt_detection_test.rs
+++ b/tests/tensorrt_detection_test.rs
@@ -29,7 +29,8 @@ fn test_tensorrt_library_name_platform_specific() {
     #[cfg(target_os = "windows")]
     {
         assert_eq!(lib_name, "nvinfer_10.dll");
-        assert!(lib_name.ends_with(".dll"));
+        // `contains`, not `ends_with`: see the macOS arm below.
+        assert!(lib_name.contains(".dll"));
     }
 
     #[cfg(target_os = "linux")]
@@ -43,9 +44,12 @@ fn test_tensorrt_library_name_platform_specific() {
     {
         assert_eq!(lib_name, "libnvinfer.10.dylib");
         assert!(lib_name.starts_with("lib"));
-        // `contains` rather than `ends_with`, matching the Linux arm above and
-        // `tests/cuda_detection_test.rs`. See the comment there: Linux CI never
-        // compiled this arm, so the lint survived the sweep in #338.
+        // `contains` rather than `ends_with`, matching the Linux arm above.
+        // Not for the reason `tests/cuda_detection_test.rs` gives: this value is
+        // a plain filename, so `Path::extension` would work on it. The reason
+        // here is consistency with the Linux arm, whose `libnvinfer.so.10` has
+        // extension "10". Either way `case_sensitive_file_extension_comparisons`
+        // fires on `ends_with`, and no CI job compiles this arm.
         assert!(lib_name.contains(".dylib"));
     }
 }

--- a/tests/tensorrt_detection_test.rs
+++ b/tests/tensorrt_detection_test.rs
@@ -42,6 +42,10 @@ fn test_tensorrt_library_name_platform_specific() {
     #[cfg(target_os = "macos")]
     {
         assert_eq!(lib_name, "libnvinfer.10.dylib");
-        assert!(lib_name.ends_with(".dylib"));
+        assert!(lib_name.starts_with("lib"));
+        // `contains` rather than `ends_with`, matching the Linux arm above and
+        // `tests/cuda_detection_test.rs`. See the comment there: Linux CI never
+        // compiled this arm, so the lint survived the sweep in #338.
+        assert!(lib_name.contains(".dylib"));
     }
 }


### PR DESCRIPTION
Closes #312. Also closes the `day_of_year` half of #309 item 4; the `species_list_file` half is deliberately left open, with reasoning on that issue.

## What was wrong

Two settings in `[defaults]` were bounded on some routes and not on the config file, which is the shape #306 closed for `overlap`.

`batch_size` is capped at 512 by `cli::validators::parse_batch_size`, and the cap has a stated reason: it stops a run exhausting GPU memory. `validate_defaults` checked the field for `Some(0)` and nothing else. So `--batch-size 100000` and `BIRDA_BATCH_SIZE=100000` were both refused with an explanation, while the identical value hand-edited into `config.toml` went straight to the inference path.

`day_of_year` was worse placed. It carried an inline `clap::value_parser!(u32).range(1..=366)`, `validate_defaults` never looked at the field, and `birda config set` had no arm for the key at all. Editing the file was therefore the only way to set the stored default and the only route with nothing checking it, and `day_of_year = 999` reached the BSG SDM call to be rejected by birdnet-onnx, a long way from the key that carried it.

## What changed

Both bounds now live in `src/constants.rs` (`MIN_BATCH_SIZE`, and a `day_of_year { MIN, MAX }` module) and are read by one parser in `cli::validators` and by `config::validate`. `--day-of-year` uses `parse_day_of_year` instead of the inline clap range, so the flag, `BIRDA_DAY_OF_YEAR`, `config set` and the file all apply one rule rather than four literals in three places.

`handle_config_set` routes its numeric arms through those same parsers via a small `parse_config_value` helper, instead of a bare `value.parse()` leaning on the whole-config validation inside `save_config`. A value typed at `config set` is now refused for the same reason and with the same rule message as the matching flag, prefixed with the key that was typed. `defaults.day_of_year` gains the arm it never had.

`--week`, `--month` and `--day` keep their inline clap ranges on purpose: they have no config-file counterpart to disagree with.

## This tightens behaviour, so it needs a release note

A `config.toml` with `batch_size` above 512, or a `day_of_year` outside 1 to 366, used to load. It now fails, and so does any command that saves the configuration. The `day_of_year` case is the one most likely to bite: the key had no `config set` arm, so by definition everyone who set it is a hand-editor, which is also the population most likely to have raised `batch_size`. Those two faults together are the case `config set` cannot repair one key at a time (#305), and the user has to edit the file.

Full suggested wording is on #289, which already owns the 1.10.0 notes. The README now documents the refusal and the repair commands, both verified against the binary.

## Verification

Every new test was driven against the deletion of the production line it names, rather than trusted because the suite is green. Seventeen mutations across two waves, all caught. The ones worth naming:

- Reverting only the `config set` arm turns its own test red, rather than letting the save-side validation satisfy it. Three layers can reject the same value, so each test is pinned on wording only its own layer emits.
- Reading an unset `batch_size` as zero via `unwrap_or_default()` reddens 22 tests, because `None` means "choose at run time" and every default config in the tree relies on it.
- Removing the `--batch-size` value parser reddens the flag and env-var tests, which did not exist before this branch.

Local: `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test` 629 passed, 0 failed.

## The second commit

The pre-push gate ran nine review agents plus an independent cross-check over the first commit. It found one user-visible defect and one regression I had introduced, and neither was visible by reading the diff:

**The rationale I wrote on `--day-of-year` was rendered into `birda --help`.** A `///` comment on a clap field is the help text. An agent built the binary and ran it; users were being shown a paragraph about validator plumbing. `--overlap` already had the same defect, so both are fixed. This file already documents the convention on its `yes` field.

**Replacing clap's parser silently dropped its widening.** `clap::value_parser!(u32)` is `RangedI64ValueParser<u32>`, which parses to `i64` and then bounds-checks, so a negative reaches the range check and is reported as out of range. Parsing straight to `u32` looks equivalent and is not: `--day-of-year=-1` began reporting "'-1' is not a valid number", which is false on its face. Restored, and pinned by a test.

The rest was prose asserting things a single command disproves. `git log -S` showed the batch-size cap arrived in #135, weeks after the flag, so "since the flag existed" was invented; both environment variables were bounded all along, because clap applies value parsers to env values, so the README misdescribed what used to disagree. Seven sites corrected or deleted.

The review also proved four test gaps rather than asserting them: five of seven rewired `config set` arms had no test, `batch_size` had no end-to-end coverage on the flag or the environment variable, and two new absence assertions in the load-path control could never fire because the control config set neither field. The control now carries 512 and 366, which makes those assertions real and covers the inclusive bounds end to end.

A fresh reviewer over that fix wave then found six further inaccuracies, every one in prose the wave had just written. Those are corrected in the same commit. Three `config set` arms (`overlap`, `longitude`, `range_threshold`) remain untested and are left that way deliberately, below the round's bar; `range_threshold` is the one worth a follow-up, since it borrows `parse_confidence` and so reports "confidence" under a differently named key.

## Folded in

Four `--all-targets` clippy failures in platform-gated test arms (`tests/cuda_detection_test.rs`, `tests/tensorrt_detection_test.rs`). Every CI job runs on `ubuntu-latest`, so neither the macOS nor the Windows arm is ever compiled or linted there; they surface only when the gate is run on that platform. I fixed the macOS pair first and left the Windows pair, which three reviewers correctly called the same miss.

## Filed, not fixed

- #339: `defaults.formats = []` makes every input file report "Skipping (output exists)" and exit 0 with no output. Same one-route-only shape as this issue, but it fails silently, so it is the more serious of the two.
- #340: latitude, longitude and the week/month/day ranges are still duplicate literals with no shared constant and no parity test.
- #292: CI enforces `--all-targets` since #338, but `Taskfile.yml` and CLAUDE.md still describe the narrower command, so the documented local gate passes where CI would not.
