### PR TITLE
fix: reject an empty defaults.formats, and give the remaining bounds one home

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Arguments:
 
 Options:
   -m, --model <MODEL>           Model name from configuration
-  -f, --format <FORMAT>         Output formats (csv,raven,audacity,kaleidoscope,json,parquet)
+  -f, --format <FORMAT>         Output formats, comma-separated
       --output-mode <MODE>      CLI output mode (human,json,ndjson)
   -o, --output-dir <DIR>        Output directory (default: same as input)
   -c, --min-confidence <VALUE>  Minimum confidence threshold (0.0-1.0)
@@ -379,9 +379,9 @@ birda config set defaults.batch_size ""    # or a size in 1-512; empty restores 
 birda config set defaults.day_of_year ""   # or a day in 1-366; empty restores auto-detection
 ```
 
-An empty `formats` and an unrecognised CSV column are refused the same way, and neither has a `config set` arm, so both are fixed by editing `config.toml`: give `formats` at least one of `csv`, `raven`, `audacity`, `kaleidoscope`, `json` or `parquet`, and leave `csv_columns.include` holding only names from `lat`, `lon`, `week`, `model`, `overlap`, `sensitivity`, `min_conf` and `species_list`. The error names the offending key, lists the accepted values where there is a list, and points at `birda config path` for the file.
+An empty `formats` and an unrecognised CSV column are refused the same way, and neither has a `config set` arm, so both are fixed by editing `config.toml`: give `formats` at least one of `csv`, `raven`, `audacity`, `kaleidoscope`, `json` or `parquet`, and leave `csv_columns.include` holding only names from `lat`, `lon`, `week`, `model`, `overlap`, `sensitivity`, `min_conf` and `species_list`. Both errors name the offending key and point at `birda config path` for the file; the CSV one also lists the eight accepted column names, since a typo is the only way to reach it.
 
-Validation reads the file as a document, so a stored value is checked whether or not the run would have used it. `--format csv` does not get you past an empty `formats`, `--stdout` does not get you past it either even though that mode writes no files, and a `csv_columns.include` typo stops a `--format json` run that would never have opened a CSV writer. That is how every rule here has always behaved: a `batch_size` of 9999 in the file stops `birda --batch-size 32` too. The upside is that you learn the file is broken on the next run rather than on the day you leave the flag off; the cost is that the repair is not optional. For a `--stdout` user the repair is free, since naming a format writes no file in that mode anyway.
+Validation reads the file as a document, so a stored value is checked whether or not the run would have used it. `--format csv` does not get you past an empty `formats`, `--stdout` does not get you past it either even though that mode writes no files, and a `csv_columns.include` typo stops a `--format json` run that would never have opened a CSV writer. That is how every rule here behaves, and has since `batch_size` and `day_of_year` gained their file-side checks: a `batch_size` of 9999 in the file stops `birda --batch-size 32` too. The upside is that you learn the file is broken on the next run rather than on the day you leave the flag off; the cost is that the repair is not optional. For a `--stdout` user the repair is free, since naming a format writes no file in that mode anyway.
 
 If more than one value is out of range, each write is rejected by the other fault and you will need to edit `config.toml` directly; that limitation is described below.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Arguments:
 
 Options:
   -m, --model <MODEL>           Model name from configuration
-  -f, --format <FORMAT>         Output formats (csv,json,raven,audacity,kaleidoscope)
+  -f, --format <FORMAT>         Output formats (csv,raven,audacity,kaleidoscope,json,parquet)
       --output-mode <MODE>      CLI output mode (human,json,ndjson)
   -o, --output-dir <DIR>        Output directory (default: same as input)
   -c, --min-confidence <VALUE>  Minimum confidence threshold (0.0-1.0)
@@ -364,13 +364,13 @@ combined_prefix = "BirdNET"
 
 ### Configuration Validation
 
-An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (1 to 512), `day_of_year` (1 to 366), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), `formats` (at least one output format), `csv_columns.include` (every name one birda recognises), and `defaults.model`, which must name a model that exists in the file.
+An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (1 to 512), `day_of_year` (1 to 366), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), `formats` (at least one output format), `csv_columns.include` (only names birda recognises), and `defaults.model`, which must name a model that exists in the file.
 
 For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude`, `longitude`, `batch_size` and `day_of_year` agree across their routes too.
 
 `batch_size` and `day_of_year` were the last two to disagree, and in both cases the config file was the route without the rule. The 512 cap on `batch_size` exists to keep a run from exhausting GPU memory, and it applied to `--batch-size` and `BIRDA_BATCH_SIZE` but not to the file, so a larger value hand-edited into `config.toml` went straight to the inference path. `day_of_year` was bounded on the flag and the environment variable, and `birda config set defaults.day_of_year` did not exist, so editing the file was the only way to set the stored default and the only route with nothing checking it.
 
-`formats` and `csv_columns.include` are the two keys the command line cannot reach at all. `--format` accepts only the format names it knows, and neither key has a `birda config set` arm, so hand-editing `config.toml` was the only route to either and the only one with nothing checking it. An empty `formats` was the more expensive of the two: an analysis run asked whether the outputs already existed, got "yes" for a list with nothing in it, and so treated every input file as already done. It logged `Skipping (output exists)` against files that had no output, finished with `0 processed`, and exited 0 having written nothing. An unrecognised name in `csv_columns.include` was quieter and inconsistent between formats: CSV grew a column that was empty in every row, Parquet dropped it.
+`formats` and `csv_columns.include` are the two keys where the config file is the only route that can carry a bad value. `--format` and `BIRDA_FORMAT` do reach `formats`, and win over the file, but they go through a fixed list of names, so neither can produce an empty or unknown one; `csv_columns.include` has no command-line route at all. Neither key has a `birda config set` arm either, so a hand edit was the only way to set either one and the only route with nothing checking it. An empty `formats` was the more expensive of the two: an analysis run asked whether the outputs already existed, got "yes" for a list with nothing in it, and so treated every input file as already done. It logged `Skipping (output exists)` against files that had no output, finished with `0 processed`, and exited 0 having written nothing. An unrecognised name in `csv_columns.include` was quieter and inconsistent between formats: CSV grew a column that was empty in every row, Parquet dropped it.
 
 If you already have a `config.toml` with `batch_size` above 512 or a `day_of_year` outside 1 to 366, this release starts refusing it: an analysis run stops with an error naming the key, and so does any command that saves the configuration. Bring the value into range to get going again:
 
@@ -379,7 +379,9 @@ birda config set defaults.batch_size ""    # or a size in 1-512; empty restores 
 birda config set defaults.day_of_year ""   # or a day in 1-366; empty restores auto-detection
 ```
 
-An empty `formats` and an unrecognised CSV column are refused the same way, and neither has a `config set` arm, so both are fixed by editing `config.toml`: give `formats` at least one of `csv`, `raven`, `audacity`, `kaleidoscope`, `json` or `parquet`, and leave `csv_columns.include` holding only names from `lat`, `lon`, `week`, `model`, `overlap`, `sensitivity`, `min_conf` and `species_list`. The error names the column it did not recognise and lists the ones it does.
+An empty `formats` and an unrecognised CSV column are refused the same way, and neither has a `config set` arm, so both are fixed by editing `config.toml`: give `formats` at least one of `csv`, `raven`, `audacity`, `kaleidoscope`, `json` or `parquet`, and leave `csv_columns.include` holding only names from `lat`, `lon`, `week`, `model`, `overlap`, `sensitivity`, `min_conf` and `species_list`. The error names the offending key, lists the accepted values where there is a list, and points at `birda config path` for the file.
+
+Validation reads the file as a document, so a stored value is checked whether or not the run would have used it. `--format csv` does not get you past an empty `formats`, `--stdout` does not get you past it either even though that mode writes no files, and a `csv_columns.include` typo stops a `--format json` run that would never have opened a CSV writer. That is how every rule here has always behaved: a `batch_size` of 9999 in the file stops `birda --batch-size 32` too. The upside is that you learn the file is broken on the next run rather than on the day you leave the flag off; the cost is that the repair is not optional. For a `--stdout` user the repair is free, since naming a format writes no file in that mode anyway.
 
 If more than one value is out of range, each write is rejected by the other fault and you will need to edit `config.toml` directly; that limitation is described below.
 

--- a/README.md
+++ b/README.md
@@ -364,11 +364,13 @@ combined_prefix = "BirdNET"
 
 ### Configuration Validation
 
-An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (1 to 512), `day_of_year` (1 to 366), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), and `defaults.model`, which must name a model that exists in the file.
+An analysis run validates the configuration file before it starts, so a bad value is reported once, up front, instead of turning into odd results later in the run. The rules cover `min_confidence` and `range_threshold` (both 0.0 to 1.0), `overlap` (finite and non-negative), `batch_size` (1 to 512), `day_of_year` (1 to 366), `latitude` (-90.0 to 90.0), `longitude` (-180.0 to 180.0), `formats` (at least one output format), `csv_columns.include` (every name one birda recognises), and `defaults.model`, which must name a model that exists in the file.
 
 For `overlap` the rule also applies to the command-line flag and the environment variable, not just to the file: `--overlap`, `BIRDA_OVERLAP` and `defaults.overlap` are three routes to one setting, and all three reject a negative, NaN or infinite value. Previously only the file did, and the other two silently became zero overlap. `min_confidence`, `range_threshold`, `latitude`, `longitude`, `batch_size` and `day_of_year` agree across their routes too.
 
 `batch_size` and `day_of_year` were the last two to disagree, and in both cases the config file was the route without the rule. The 512 cap on `batch_size` exists to keep a run from exhausting GPU memory, and it applied to `--batch-size` and `BIRDA_BATCH_SIZE` but not to the file, so a larger value hand-edited into `config.toml` went straight to the inference path. `day_of_year` was bounded on the flag and the environment variable, and `birda config set defaults.day_of_year` did not exist, so editing the file was the only way to set the stored default and the only route with nothing checking it.
+
+`formats` and `csv_columns.include` are the two keys the command line cannot reach at all. `--format` accepts only the format names it knows, and neither key has a `birda config set` arm, so hand-editing `config.toml` was the only route to either and the only one with nothing checking it. An empty `formats` was the more expensive of the two: an analysis run asked whether the outputs already existed, got "yes" for a list with nothing in it, and so treated every input file as already done. It logged `Skipping (output exists)` against files that had no output, finished with `0 processed`, and exited 0 having written nothing. An unrecognised name in `csv_columns.include` was quieter and inconsistent between formats: CSV grew a column that was empty in every row, Parquet dropped it.
 
 If you already have a `config.toml` with `batch_size` above 512 or a `day_of_year` outside 1 to 366, this release starts refusing it: an analysis run stops with an error naming the key, and so does any command that saves the configuration. Bring the value into range to get going again:
 
@@ -376,6 +378,8 @@ If you already have a `config.toml` with `batch_size` above 512 or a `day_of_yea
 birda config set defaults.batch_size ""    # or a size in 1-512; empty restores the smart default
 birda config set defaults.day_of_year ""   # or a day in 1-366; empty restores auto-detection
 ```
+
+An empty `formats` and an unrecognised CSV column are refused the same way, and neither has a `config set` arm, so both are fixed by editing `config.toml`: give `formats` at least one of `csv`, `raven`, `audacity`, `kaleidoscope`, `json` or `parquet`, and leave `csv_columns.include` holding only names from `lat`, `lon`, `week`, `model`, `overlap`, `sensitivity`, `min_conf` and `species_list`. The error names the column it did not recognise and lists the ones it does.
 
 If more than one value is out of range, each write is rejected by the other fault and you will need to edit `config.toml` directly; that limitation is described below.
 

--- a/docs/windows-guide.md
+++ b/docs/windows-guide.md
@@ -281,7 +281,7 @@ birda species --lat 60.17 --lon 24.94 --week 24 --output species.txt
 # Analysis options
 birda [OPTIONS] <FILES>
   -m, --model <NAME>        # Use specific model
-  -f, --format <FORMATS>    # Output formats (csv,raven,audacity,kaleidoscope)
+  -f, --format <FORMATS>    # Output formats, comma-separated; birda --help lists them
   -o, --output-dir <DIR>    # Output directory
   -c, --min-confidence <N>  # Confidence threshold (0.0-1.0)
   -b, --batch-size <N>      # Inference batch size

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -545,7 +545,7 @@ use super::validators::{
 )]
 mod tests {
     use super::*;
-    use crate::constants::coordinates;
+    use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, coordinates, day_of_year};
     use clap::CommandFactory;
     use std::path::Path;
 
@@ -630,6 +630,30 @@ mod tests {
         }
     }
 
+    /// Assert the help block introduced by `flag` states `bound`.
+    ///
+    /// The block is the window after the flag's own line, which is where clap
+    /// renders its description. Long enough to clear the `[env: ..]` and
+    /// `[possible values: ..]` trailers, short enough not to reach the next
+    /// flag's description.
+    fn assert_flag_states(help: &str, surface: &str, flag: &str, bound: &str) {
+        // Search only the options list. The usage synopsis above it names the
+        // same flags with no description, and on the `species` surface that is
+        // the FIRST match, so an unanchored search reads a window that could
+        // never contain a bound.
+        let body = help
+            .split_once("Options:")
+            .map_or(help, |(_usage, options)| options);
+        let at = body
+            .find(flag)
+            .unwrap_or_else(|| panic!("{surface} does not render {flag} at all"));
+        let block = &body[at..body.len().min(at + 240)];
+        assert!(
+            block.contains(bound),
+            "{surface} must state {bound} on {flag}, got: {block}"
+        );
+    }
+
     #[test]
     fn test_help_text_states_the_enforced_bounds() {
         // A `///` comment on an `#[arg]` field is rendered into `birda --help`,
@@ -652,39 +676,83 @@ mod tests {
             .to_string()
             .replace('\n', " ");
 
-        // Latitude and longitude are here for the same reason, and they are the
-        // pair this change created constants for: each is declared twice, on
-        // `species` and on the analyze arguments, and each states its bounds in
-        // help text no `value_parser` change can reach. They render in a
-        // different shape from the calendar bounds, hence the two formats.
-        let mut stated: Vec<String> = [
-            (range_filter::WEEK_MIN, range_filter::WEEKS_PER_YEAR),
-            (calendar::MONTH_MIN, calendar::MONTH_MAX),
-            (calendar::DAY_MIN, calendar::DAY_MAX),
-        ]
-        .iter()
-        .map(|(min, max)| format!("({min}-{max})"))
-        .collect();
-        stated.push(format!(
-            "({:.1} to {:.1})",
-            coordinates::LATITUDE_MIN,
-            coordinates::LATITUDE_MAX
-        ));
-        stated.push(format!(
-            "({:.1} to {:.1})",
-            coordinates::LONGITUDE_MIN,
-            coordinates::LONGITUDE_MAX
-        ));
+        // The rule is every bound a constant owns that is ALSO stated in help
+        // text, not a list someone remembered to extend. Latitude and longitude
+        // are the pair this change created constants for; day-of-year,
+        // batch size and the two confidence bounds already had them from #312
+        // and #341, and were just as unpinned. They render in three different
+        // shapes, hence the three formats below.
+        // Each bound is checked against ITS OWN flag's help block, not against
+        // the whole page. Searching the page lets one flag cover for another:
+        // written that way, `--min-confidence` drifting to (0.0-2.0) stayed
+        // green, because `--range-threshold` still rendered (0.0-1.0) elsewhere
+        // on the page. The second name is the flag on the `species` surface,
+        // `None` where `species` does not declare it.
+        let checks: [(&str, Option<&str>, String); 9] = [
+            (
+                "--week <",
+                Some("--week <"),
+                format!(
+                    "({}-{})",
+                    range_filter::WEEK_MIN,
+                    range_filter::WEEKS_PER_YEAR
+                ),
+            ),
+            (
+                "--month <",
+                Some("--month <"),
+                format!("({}-{})", calendar::MONTH_MIN, calendar::MONTH_MAX),
+            ),
+            (
+                "--day <",
+                Some("--day <"),
+                format!("({}-{})", calendar::DAY_MIN, calendar::DAY_MAX),
+            ),
+            (
+                "--day-of-year <",
+                None,
+                format!("({}-{})", day_of_year::MIN, day_of_year::MAX),
+            ),
+            (
+                "--batch-size <",
+                None,
+                format!("({MIN_BATCH_SIZE}-{MAX_BATCH_SIZE})"),
+            ),
+            (
+                "--min-confidence <",
+                None,
+                format!("({:.1}-{:.1})", confidence::MIN, confidence::MAX),
+            ),
+            (
+                "--range-threshold <",
+                Some("--threshold <"),
+                format!("({:.1}-{:.1})", confidence::MIN, confidence::MAX),
+            ),
+            (
+                "--lat <",
+                Some("--lat <"),
+                format!(
+                    "({:.1} to {:.1})",
+                    coordinates::LATITUDE_MIN,
+                    coordinates::LATITUDE_MAX
+                ),
+            ),
+            (
+                "--lon <",
+                Some("--lon <"),
+                format!(
+                    "({:.1} to {:.1})",
+                    coordinates::LONGITUDE_MIN,
+                    coordinates::LONGITUDE_MAX
+                ),
+            ),
+        ];
 
-        for stated in stated {
-            assert!(
-                root.contains(&stated),
-                "`birda --help` must state the enforced range {stated}"
-            );
-            assert!(
-                species.contains(&stated),
-                "`birda species --help` must state the enforced range {stated}"
-            );
+        for (root_flag, species_flag, bound) in checks {
+            assert_flag_states(&root, "`birda --help`", root_flag, &bound);
+            if let Some(flag) = species_flag {
+                assert_flag_states(&species, "`birda species --help`", flag, &bound);
+            }
         }
     }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,7 @@
 //! CLI argument definitions.
 
 use crate::config::{ModelType, OutputFormat, OutputMode};
+use crate::constants::{calendar, range_filter};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
@@ -13,6 +14,32 @@ pub enum SortOrder {
     Freq,
     /// Sort alphabetically.
     Alpha,
+}
+
+/// Accepted range for `--week`, read from `constants::range_filter`.
+///
+/// Both `--week` declarations call this: the one on `species` and the one on
+/// the analyze arguments. Each used to spell out `1..=48`, restating
+/// `WEEKS_PER_YEAR`, which `utils::date::date_to_week` clamps its result to, so
+/// changing the `BirdNET` week count would have moved the clamp and left both
+/// declarations behind (#340).
+fn week_range() -> impl clap::builder::TypedValueParser<Value = u32> {
+    clap::value_parser!(u32)
+        .range(i64::from(range_filter::WEEK_MIN)..=i64::from(range_filter::WEEKS_PER_YEAR))
+}
+
+/// Accepted range for `--month`, read from `constants::calendar`.
+fn month_range() -> impl clap::builder::TypedValueParser<Value = u32> {
+    clap::value_parser!(u32).range(i64::from(calendar::MONTH_MIN)..=i64::from(calendar::MONTH_MAX))
+}
+
+/// Accepted range for `--day`, read from `constants::calendar`.
+///
+/// The upper bound is the longest month, not the month given alongside it:
+/// clap validates each argument on its own, and `--month 2 --day 31` is
+/// resolved by `date` rather than rejected here.
+fn day_of_month_range() -> impl clap::builder::TypedValueParser<Value = u32> {
+    clap::value_parser!(u32).range(i64::from(calendar::DAY_MIN)..=i64::from(calendar::DAY_MAX))
 }
 
 /// Bird species detection using `BirdNET` and Perch models.
@@ -83,17 +110,17 @@ pub enum Command {
         lon: f64,
 
         /// Week number (1-48).
-        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=48),
+        #[arg(long, value_parser = week_range(),
               conflicts_with_all = ["month", "day"])]
         week: Option<u32>,
 
         /// Month (1-12).
-        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=12),
+        #[arg(long, value_parser = month_range(),
               requires = "day", conflicts_with = "week")]
         month: Option<u32>,
 
         /// Day of month (1-31).
-        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=31),
+        #[arg(long, value_parser = day_of_month_range(),
               requires = "month", conflicts_with = "week")]
         day: Option<u32>,
 
@@ -264,7 +291,15 @@ pub struct AnalyzeArgs {
     #[arg(long, value_name = "REGION")]
     pub bat: Option<crate::config::BatRegion>,
 
-    /// Output formats (comma-separated: csv,raven,audacity,kaleidoscope).
+    // Kept as a `//` comment for the reason spelled out on `yes` below: clap
+    // renders `///` into `--help`, and this is rationale for the code rather
+    // than guidance for the user.
+    //
+    // The names used to be spelled out in the line below and had drifted: it
+    // read `csv,raven,audacity,kaleidoscope` long after `json` and `parquet`
+    // were added. clap already prints the full set under "Possible values",
+    // which cannot go stale, so the list is gone rather than corrected.
+    /// Output formats, comma-separated. At least one is required.
     #[arg(short, long, value_delimiter = ',', env = "BIRDA_FORMAT")]
     pub format: Option<Vec<OutputFormat>>,
 
@@ -391,17 +426,17 @@ pub struct AnalyzeArgs {
     pub lon: Option<f64>,
 
     /// Week number for range filtering (1-48).
-    #[arg(long, value_parser = clap::value_parser!(u32).range(1..=48),
+    #[arg(long, value_parser = week_range(),
           conflicts_with_all = ["month", "day"])]
     pub week: Option<u32>,
 
     /// Month for range filtering (1-12).
-    #[arg(long, value_parser = clap::value_parser!(u32).range(1..=12),
+    #[arg(long, value_parser = month_range(),
           requires = "day", conflicts_with = "week")]
     pub month: Option<u32>,
 
     /// Day of month for range filtering (1-31).
-    #[arg(long, value_parser = clap::value_parser!(u32).range(1..=31),
+    #[arg(long, value_parser = day_of_month_range(),
           requires = "month", conflicts_with = "week")]
     pub day: Option<u32>,
 
@@ -506,7 +541,110 @@ use super::validators::{
 )]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
     use std::path::Path;
+
+    #[test]
+    fn test_week_month_and_day_bounds_are_the_same_on_both_subcommands() {
+        // #340. `--week`, `--month` and `--day` are declared twice each, on
+        // `species` and on the analyze arguments, and each pair used to spell
+        // out its own `1..=48`, `1..=12` and `1..=31`. Driving clap at the
+        // boundary on both is what pins the two copies together; asserting the
+        // helper functions alone would pass while one declaration still carried
+        // a literal.
+        //
+        // The boundaries come from the constants, so raising one leaves the
+        // inputs still straddling it rather than quietly testing less.
+        let cases = [
+            ("week", range_filter::WEEK_MIN, range_filter::WEEKS_PER_YEAR),
+            ("month", calendar::MONTH_MIN, calendar::MONTH_MAX),
+            ("day", calendar::DAY_MIN, calendar::DAY_MAX),
+        ];
+
+        for (flag, min, max) in cases {
+            // `--month` and `--day` require each other, and both conflict with
+            // `--week`, so each is exercised with the partner it needs.
+            let partner: &[String] = match flag {
+                "month" => &[format!("--day={}", calendar::DAY_MIN)],
+                "day" => &[format!("--month={}", calendar::MONTH_MIN)],
+                _ => &[],
+            };
+
+            for (value, expected_ok) in [(min, true), (max, true), (max + 1, false)] {
+                let arg = format!("--{flag}={value}");
+
+                let analyze = Cli::try_parse_from(
+                    ["birda", "in.wav", &arg]
+                        .into_iter()
+                        .chain(partner.iter().map(String::as_str)),
+                );
+                assert_eq!(
+                    analyze.is_ok(),
+                    expected_ok,
+                    "analyze {arg}: expected ok={expected_ok}"
+                );
+
+                let species = Cli::try_parse_from(
+                    ["birda", "species", "--lat=60.0", "--lon=25.0", &arg]
+                        .into_iter()
+                        .chain(partner.iter().map(String::as_str)),
+                );
+                assert_eq!(
+                    species.is_ok(),
+                    expected_ok,
+                    "species {arg}: expected ok={expected_ok}, and it must agree with analyze"
+                );
+            }
+
+            // `min - 1` is checked only where the minimum leaves room for it;
+            // all three are 1-based, so 0 is the case, and it must be rejected.
+            let zero = format!("--{flag}=0");
+            assert!(
+                Cli::try_parse_from(["birda", "in.wav", &zero]).is_err(),
+                "{zero} must be rejected: the range is 1-based"
+            );
+            let _ = min;
+        }
+    }
+
+    #[test]
+    fn test_calendar_help_text_states_the_enforced_bounds() {
+        // A `///` comment on an `#[arg]` field is rendered into `birda --help`,
+        // so the "(1-48)" in those doc comments is a user-facing statement of
+        // the rule, and the one copy of these numbers that no value_parser
+        // change can update. This fails if a bound moves and the help text is
+        // left behind.
+        //
+        // The two surfaces are asserted separately on purpose. Checking them
+        // concatenated lets either one drift while the other still carries the
+        // string, which is the two-copies problem #340 is about: written that
+        // way, this test stayed green when the `species` doc comment was
+        // mutated to (1-52), and covered only the analyze copy.
+        let mut command = Cli::command();
+        let root = command.render_long_help().to_string().replace('\n', " ");
+        let species = command
+            .find_subcommand_mut("species")
+            .expect("the species subcommand declares its own --week, --month and --day")
+            .render_long_help()
+            .to_string()
+            .replace('\n', " ");
+
+        for (min, max) in [
+            (range_filter::WEEK_MIN, range_filter::WEEKS_PER_YEAR),
+            (calendar::MONTH_MIN, calendar::MONTH_MAX),
+            (calendar::DAY_MIN, calendar::DAY_MAX),
+        ] {
+            let stated = format!("({min}-{max})");
+            assert!(
+                root.contains(&stated),
+                "`birda --help` must state the enforced range {stated}"
+            );
+            assert!(
+                species.contains(&stated),
+                "`birda species --help` must state the enforced range {stated}"
+            );
+        }
+    }
 
     #[test]
     fn test_cli_parse_simple() {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -35,9 +35,11 @@ fn month_range() -> impl clap::builder::TypedValueParser<Value = u32> {
 
 /// Accepted range for `--day`, read from `constants::calendar`.
 ///
-/// The upper bound is the longest month, not the month given alongside it:
-/// clap validates each argument on its own, and `--month 2 --day 31` is
-/// resolved by `date` rather than rejected here.
+/// The upper bound is the longest month, not the month given alongside it,
+/// because clap validates each argument on its own. Nothing downstream rejects
+/// the pair either: `utils::date::date_to_week` says in its own doc that it
+/// does not validate month and day together, so `--month 2 --day 31` is summed
+/// to day 62 and reported as the week of March 3.
 fn day_of_month_range() -> impl clap::builder::TypedValueParser<Value = u32> {
     clap::value_parser!(u32).range(i64::from(calendar::DAY_MIN)..=i64::from(calendar::DAY_MAX))
 }
@@ -299,7 +301,7 @@ pub struct AnalyzeArgs {
     // read `csv,raven,audacity,kaleidoscope` long after `json` and `parquet`
     // were added. clap already prints the full set under "Possible values",
     // which cannot go stale, so the list is gone rather than corrected.
-    /// Output formats, comma-separated. At least one is required.
+    /// Output formats, comma-separated. Defaults to `defaults.formats` in config.toml.
     #[arg(short, long, value_delimiter = ',', env = "BIRDA_FORMAT")]
     pub format: Option<Vec<OutputFormat>>,
 
@@ -451,8 +453,10 @@ pub struct AnalyzeArgs {
     // replaced an inline `clap::value_parser!(u32).range(1..=366)`, whose bound
     // no other route could read.
     //
-    // `--week`, `--month` and `--day` above keep their inline ranges because
-    // they have no config-file counterpart to disagree with.
+    // `--week`, `--month` and `--day` above have no config-file counterpart, so
+    // they need no parity rule the way this flag does. They stopped carrying
+    // inline ranges in #340 all the same, because each is declared twice, once
+    // per subcommand, and the two copies could disagree with each other.
     /// Day of year for BSG SDM adjustment (1-366).
     /// If not provided and BSG model is used, auto-detected from file timestamp.
     #[arg(long, value_parser = parse_day_of_year, env = "BIRDA_DAY_OF_YEAR")]
@@ -541,6 +545,7 @@ use super::validators::{
 )]
 mod tests {
     use super::*;
+    use crate::constants::coordinates;
     use clap::CommandFactory;
     use std::path::Path;
 
@@ -596,19 +601,37 @@ mod tests {
                 );
             }
 
-            // `min - 1` is checked only where the minimum leaves room for it;
-            // all three are 1-based, so 0 is the case, and it must be rejected.
+            // All three are 1-based, so `min - 1` is 0, and it must be refused
+            // BY THE RANGE. Asserting only `is_err()` does not establish that:
+            // `--month` and `--day` require each other, so `--month=0` alone
+            // fails on the missing `--day` whatever the range says, and
+            // lowering `MONTH_MIN` to 0 would leave such a test green. So the
+            // partner argv is supplied and the message is asserted on. Both
+            // surfaces are driven, since the name of this test claims both and
+            // a `species` declaration could drift on its own.
             let zero = format!("--{flag}=0");
-            assert!(
-                Cli::try_parse_from(["birda", "in.wav", &zero]).is_err(),
-                "{zero} must be rejected: the range is 1-based"
-            );
-            let _ = min;
+            for argv in [
+                vec!["birda", "in.wav", &zero],
+                vec!["birda", "species", "--lat=60.0", "--lon=25.0", &zero],
+            ] {
+                let err = Cli::try_parse_from(
+                    argv.clone()
+                        .into_iter()
+                        .chain(partner.iter().map(String::as_str)),
+                )
+                .expect_err(&format!("{argv:?} must be rejected: the range is 1-based"))
+                .to_string();
+
+                assert!(
+                    err.contains(&format!("0 is not in {min}..={max}")),
+                    "{argv:?} must be refused by the range itself, got: {err}"
+                );
+            }
         }
     }
 
     #[test]
-    fn test_calendar_help_text_states_the_enforced_bounds() {
+    fn test_help_text_states_the_enforced_bounds() {
         // A `///` comment on an `#[arg]` field is rendered into `birda --help`,
         // so the "(1-48)" in those doc comments is a user-facing statement of
         // the rule, and the one copy of these numbers that no value_parser
@@ -629,12 +652,31 @@ mod tests {
             .to_string()
             .replace('\n', " ");
 
-        for (min, max) in [
+        // Latitude and longitude are here for the same reason, and they are the
+        // pair this change created constants for: each is declared twice, on
+        // `species` and on the analyze arguments, and each states its bounds in
+        // help text no `value_parser` change can reach. They render in a
+        // different shape from the calendar bounds, hence the two formats.
+        let mut stated: Vec<String> = [
             (range_filter::WEEK_MIN, range_filter::WEEKS_PER_YEAR),
             (calendar::MONTH_MIN, calendar::MONTH_MAX),
             (calendar::DAY_MIN, calendar::DAY_MAX),
-        ] {
-            let stated = format!("({min}-{max})");
+        ]
+        .iter()
+        .map(|(min, max)| format!("({min}-{max})"))
+        .collect();
+        stated.push(format!(
+            "({:.1} to {:.1})",
+            coordinates::LATITUDE_MIN,
+            coordinates::LATITUDE_MAX
+        ));
+        stated.push(format!(
+            "({:.1} to {:.1})",
+            coordinates::LONGITUDE_MIN,
+            coordinates::LONGITUDE_MAX
+        ));
+
+        for stated in stated {
             assert!(
                 root.contains(&stated),
                 "`birda --help` must state the enforced range {stated}"

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -2,7 +2,7 @@
 //!
 //! Shared validation functions for CLI argument parsing.
 
-use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, day_of_year};
+use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, coordinates, day_of_year};
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -59,14 +59,31 @@ pub fn parse_bounded_float(s: &str, min: f64, max: f64, name: &str) -> Result<f6
     Ok(value)
 }
 
-/// Parse and validate latitude value (-90.0 to 90.0).
+/// Parse and validate a latitude in degrees.
+///
+/// Reads `coordinates::LATITUDE_MIN`/`MAX`, the same pair
+/// `config::validate::validate_range_filter` and `Error::InvalidLatitude` read.
+/// `test_parse_latitude_matches_the_config_file_rule` drives this and the file
+/// rule together and compares verdicts (#340).
 pub fn parse_latitude(s: &str) -> Result<f64, String> {
-    parse_bounded_float(s, -90.0, 90.0, "latitude")
+    parse_bounded_float(
+        s,
+        coordinates::LATITUDE_MIN,
+        coordinates::LATITUDE_MAX,
+        "latitude",
+    )
 }
 
-/// Parse and validate longitude value (-180.0 to 180.0).
+/// Parse and validate a longitude in degrees.
+///
+/// See [`parse_latitude`] for the shared-constant arrangement.
 pub fn parse_longitude(s: &str) -> Result<f64, String> {
-    parse_bounded_float(s, -180.0, 180.0, "longitude")
+    parse_bounded_float(
+        s,
+        coordinates::LONGITUDE_MIN,
+        coordinates::LONGITUDE_MAX,
+        "longitude",
+    )
 }
 
 /// Parse and validate segment overlap in seconds (finite and non-negative).
@@ -435,6 +452,101 @@ mod tests {
                 if file.is_ok() { "ok" } else { "rejected" },
             );
         }
+    }
+
+    #[test]
+    fn test_parse_latitude_matches_the_config_file_rule() {
+        // #340, the same shape as `test_parse_batch_size_matches_the_config_file_rule`
+        // above. Three routes reach `defaults.latitude`: the flag, `config set`
+        // (which routes through this parser), and a hand-edited config.toml.
+        // Before this the bound was written out in `cli::validators`, in
+        // `config::validate::validate_range_filter` and a third time in the
+        // `Error::InvalidLatitude` message, with nothing keeping the three
+        // equal. They agreed, so there was no live defect; this is what keeps
+        // that true.
+        //
+        // The inputs are derived from the constants rather than spelled out, so
+        // that moving a bound leaves them still straddling it.
+        let below = (coordinates::LATITUDE_MIN - 1.0).to_string();
+        let above = (coordinates::LATITUDE_MAX + 1.0).to_string();
+        for input in [
+            "0",
+            "60.1699",
+            &coordinates::LATITUDE_MIN.to_string(),
+            &coordinates::LATITUDE_MAX.to_string(),
+            &below,
+            &above,
+            "1000",
+        ] {
+            let cli = parse_latitude(input);
+
+            let mut config = crate::config::Config::default();
+            config.defaults.latitude = Some(input.trim().parse().expect("input must parse as f64"));
+            let file = crate::config::validate_config(&config);
+
+            assert_eq!(
+                cli.is_ok(),
+                file.is_ok(),
+                "'{input}': the flag says {}, config.toml says {}. The two rules must agree.",
+                if cli.is_ok() { "ok" } else { "rejected" },
+                if file.is_ok() { "ok" } else { "rejected" },
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_longitude_matches_the_config_file_rule() {
+        // See `test_parse_latitude_matches_the_config_file_rule`. Kept separate
+        // rather than folded into a loop over both, so a failure names which of
+        // the two bounds drifted.
+        let below = (coordinates::LONGITUDE_MIN - 1.0).to_string();
+        let above = (coordinates::LONGITUDE_MAX + 1.0).to_string();
+        for input in [
+            "0",
+            "24.9384",
+            &coordinates::LONGITUDE_MIN.to_string(),
+            &coordinates::LONGITUDE_MAX.to_string(),
+            &below,
+            &above,
+            "1000",
+        ] {
+            let cli = parse_longitude(input);
+
+            let mut config = crate::config::Config::default();
+            config.defaults.longitude =
+                Some(input.trim().parse().expect("input must parse as f64"));
+            let file = crate::config::validate_config(&config);
+
+            assert_eq!(
+                cli.is_ok(),
+                file.is_ok(),
+                "'{input}': the flag says {}, config.toml says {}. The two rules must agree.",
+                if cli.is_ok() { "ok" } else { "rejected" },
+                if file.is_ok() { "ok" } else { "rejected" },
+            );
+        }
+    }
+
+    #[test]
+    fn test_coordinate_error_messages_carry_the_enforced_bounds() {
+        // The third copy of the numbers, and the one no parity test can reach:
+        // `Error::InvalidLatitude` renders the bounds into text a user reads
+        // when their value is refused. It interpolates the constants, so this
+        // fails if the message is ever written back out as a literal that
+        // disagrees with the rule that produced it.
+        let latitude = crate::error::Error::InvalidLatitude { value: 91.0 }.to_string();
+        assert!(
+            latitude.contains(&format!("{:.1}", coordinates::LATITUDE_MIN))
+                && latitude.contains(&format!("{:.1}", coordinates::LATITUDE_MAX)),
+            "latitude message must state the enforced bounds, got '{latitude}'"
+        );
+
+        let longitude = crate::error::Error::InvalidLongitude { value: 181.0 }.to_string();
+        assert!(
+            longitude.contains(&format!("{:.1}", coordinates::LONGITUDE_MIN))
+                && longitude.contains(&format!("{:.1}", coordinates::LONGITUDE_MAX)),
+            "longitude message must state the enforced bounds, got '{longitude}'"
+        );
     }
 
     #[test]

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -467,6 +467,13 @@ mod tests {
         //
         // The inputs are derived from the constants rather than spelled out, so
         // that moving a bound leaves them still straddling it.
+        // `nan`, `inf` and `-inf` are carried over from
+        // `test_parse_overlap_matches_the_config_file_rule`, which drives them
+        // for the reason that applies here too: TOML admits them as float
+        // literals, so the config route can genuinely hold one, and both rules
+        // reject them only because `(min..=max).contains` is false for every
+        // NaN comparison. A hand-rolled `value < min || value > max` on either
+        // side would let NaN through and this is what would notice.
         let below = (coordinates::LATITUDE_MIN - 1.0).to_string();
         let above = (coordinates::LATITUDE_MAX + 1.0).to_string();
         for input in [
@@ -477,6 +484,9 @@ mod tests {
             &below,
             &above,
             "1000",
+            "nan",
+            "inf",
+            "-inf",
         ] {
             let cli = parse_latitude(input);
 
@@ -509,6 +519,9 @@ mod tests {
             &below,
             &above,
             "1000",
+            "nan",
+            "inf",
+            "-inf",
         ] {
             let cli = parse_longitude(input);
 
@@ -534,18 +547,22 @@ mod tests {
         // when their value is refused. It interpolates the constants, so this
         // fails if the message is ever written back out as a literal that
         // disagrees with the rule that produced it.
-        let latitude = crate::error::Error::InvalidLatitude { value: 91.0 }.to_string();
-        assert!(
-            latitude.contains(&format!("{:.1}", coordinates::LATITUDE_MIN))
-                && latitude.contains(&format!("{:.1}", coordinates::LATITUDE_MAX)),
-            "latitude message must state the enforced bounds, got '{latitude}'"
+        //
+        // Asserted as the whole rendered string, the form `error.rs`'s own
+        // `test_invalid_padding_renders_the_value_and_the_ceiling` uses. A pair
+        // of `contains` checks is not enough here and the reason is specific:
+        // "90.0" is a substring of "-90.0", so a message that rendered the
+        // minimum at both ends would satisfy both of them.
+        let (min, max) = (coordinates::LATITUDE_MIN, coordinates::LATITUDE_MAX);
+        assert_eq!(
+            crate::error::Error::InvalidLatitude { value: 91.0 }.to_string(),
+            format!("invalid latitude: 91 (must be {min:.1} to {max:.1})")
         );
 
-        let longitude = crate::error::Error::InvalidLongitude { value: 181.0 }.to_string();
-        assert!(
-            longitude.contains(&format!("{:.1}", coordinates::LONGITUDE_MIN))
-                && longitude.contains(&format!("{:.1}", coordinates::LONGITUDE_MAX)),
-            "longitude message must state the enforced bounds, got '{longitude}'"
+        let (min, max) = (coordinates::LONGITUDE_MIN, coordinates::LONGITUDE_MAX);
+        assert_eq!(
+            crate::error::Error::InvalidLongitude { value: 181.0 }.to_string(),
+            format!("invalid longitude: 181 (must be {min:.1} to {max:.1})")
         );
     }
 

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -13,6 +13,17 @@ pub fn validate_config(config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Recovery advice for the two keys `birda config set` cannot reach.
+///
+/// Every other rule in `validate_defaults` guards a key with a `config set`
+/// arm, so the tool can repair it and the message can stay short. `formats` and
+/// `csv_columns` have no arm, and a bad value in either is refused by
+/// `save_config` as well, so `config set` on any OTHER key is refused too until
+/// the file is fixed by hand. That makes this text the only pointer the user
+/// gets.
+const EDIT_THE_FILE: &str = "This key has no 'birda config set' arm, so edit config.toml directly; \
+     'birda config path' prints where it is.";
+
 /// Validate default settings.
 fn validate_defaults(config: &Config) -> Result<()> {
     let defaults = &config.defaults;
@@ -128,12 +139,14 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // "everything is already there": each file logged "Skipping (output
     // exists)", naming a reason that was not the real one, and the run exited 0.
     //
-    // config.toml is the only route to the value, which is the #312 and #306
-    // shape once more. `--format`/`BIRDA_FORMAT` is a `Vec<OutputFormat>` of
-    // `ValueEnum`s, so clap rejects an empty or unknown value, and
-    // `handle_config_set` has no `defaults.formats` arm. Unlike those two the
-    // failure was silent rather than loud, which is why it cost a whole run's
-    // output rather than an error message.
+    // config.toml is the only route that can carry an EMPTY list, which is the
+    // #312 and #306 shape once more. `--format` and `BIRDA_FORMAT` do reach
+    // this setting and win over the file, but they are a `Vec<OutputFormat>`
+    // of `ValueEnum`s, so clap refuses an empty or unknown value rather than
+    // producing an empty list; `handle_config_set` has no `defaults.formats`
+    // arm at all. Unlike those two predecessors the failure was silent rather
+    // than loud, which is why it cost a whole run's output rather than an
+    // error message.
     //
     // `DefaultsConfig::default()` sets `formats = ["csv"]`, so an empty list is
     // never what an untouched config carries and rejecting it cannot break one.
@@ -141,11 +154,28 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // The two guards are independent on purpose: this one keeps the value out of
     // the config, and that one keeps the vacuous branch closed for a library
     // caller passing the slice directly.
+    // The message describes the value, not the old symptom. "skips every input
+    // file" was true before the coordinator guard went in alongside this rule,
+    // and stating it here would have been this commit contradicting itself in
+    // text the user reads.
+    //
+    // The rule is unconditional, like every sibling above, even though
+    // `--stdout` never reads `formats` and an empty list is inert there. Making
+    // it mode-aware would mean handing the args to a validator that is
+    // deliberately blind to them, to preserve a setting whose only other mode
+    // it silently breaks; and the repair costs a `--stdout` user nothing, since
+    // naming a format writes no file in that mode either.
+    // Both new messages name the full key and point at the file, which the
+    // rules above deliberately do not. Those keys all have a `config set` arm,
+    // so the tool can repair them and the message can stay short; these two
+    // have none, so a hand edit is the only way out and the message is the only
+    // place to say so.
     if defaults.formats.is_empty() {
         return Err(Error::ConfigValidation {
-            message: "formats must list at least one output format; an empty list skips every \
-                      input file and writes nothing"
-                .to_string(),
+            message: format!(
+                "defaults.formats must list at least one output format; with an empty list a \
+                 run writes no output at all\n\n{EDIT_THE_FILE}"
+            ),
         });
     }
 
@@ -167,7 +197,8 @@ fn validate_defaults(config: &Config) -> Result<()> {
     {
         return Err(Error::ConfigValidation {
             message: format!(
-                "csv_columns.include has an unknown column '{unknown}'; the columns are {}",
+                "defaults.csv_columns.include has an unknown column '{unknown}'; the accepted \
+                 columns are {}\n\n{EDIT_THE_FILE}",
                 csv_columns::RECOGNISED.join(", ")
             ),
         });
@@ -240,8 +271,10 @@ pub fn get_model<'a>(config: &'a Config, name: &str) -> Result<&'a ModelConfig> 
 /// Validate range filter configuration.
 pub fn validate_range_filter(config: &Config) -> Result<()> {
     // Both bounds read `constants::coordinates`, which `cli::validators` and the
-    // `Error` message text also read (#340). Three routes reach one setting and
-    // each used to carry its own copy of the numbers.
+    // `Error` message text also read (#340). Those three were the copies of the
+    // numbers; the routes to the setting are a different set, being the flag
+    // and its environment variable, `config set`, and a hand-edited file.
+    // `config set` never held a copy, since it calls `parse_latitude`.
     if let Some(lat) = config.defaults.latitude
         && !(coordinates::LATITUDE_MIN..=coordinates::LATITUDE_MAX).contains(&lat)
     {
@@ -596,9 +629,11 @@ mod tests {
     #[test]
     fn test_validate_accepts_every_recognised_csv_column() {
         // Drives the whole of `csv_columns::RECOGNISED` through the rule that
-        // reads it, so a name added to the constant without the writers
-        // handling it is caught by `test_every_recognised_column_is_written`
-        // rather than by a user finding an empty column.
+        // reads it, so this rule cannot start refusing a name the writers
+        // handle. The converse, a name accepted here that a writer does not
+        // handle, is pinned separately and per writer, by
+        // `test_every_recognised_column_is_written` and
+        // `test_every_recognised_column_reaches_the_parquet_writer`.
         assert!(validate_config(&config_with_csv_columns(&csv_columns::RECOGNISED)).is_ok());
         assert!(validate_config(&config_with_csv_columns(&[])).is_ok());
     }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1,7 +1,9 @@
 //! Configuration validation.
 
 use crate::config::{Config, ModelConfig};
-use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, day_of_year};
+use crate::constants::{
+    MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, coordinates, csv_columns, day_of_year,
+};
 use crate::error::{Error, Result};
 
 /// Validate the entire configuration.
@@ -119,6 +121,58 @@ fn validate_defaults(config: &Config) -> Result<()> {
         });
     }
 
+    // An empty `formats` made an analysis run skip every file it was given,
+    // report success and write nothing (#339). `should_process` asks whether the
+    // outputs already exist with `formats.iter().all(..)`, and `all` over an
+    // empty slice is vacuously true, so "nothing to check" was answered as
+    // "everything is already there": each file logged "Skipping (output
+    // exists)", naming a reason that was not the real one, and the run exited 0.
+    //
+    // config.toml is the only route to the value, which is the #312 and #306
+    // shape once more. `--format`/`BIRDA_FORMAT` is a `Vec<OutputFormat>` of
+    // `ValueEnum`s, so clap rejects an empty or unknown value, and
+    // `handle_config_set` has no `defaults.formats` arm. Unlike those two the
+    // failure was silent rather than loud, which is why it cost a whole run's
+    // output rather than an error message.
+    //
+    // `DefaultsConfig::default()` sets `formats = ["csv"]`, so an empty list is
+    // never what an untouched config carries and rejecting it cannot break one.
+    // `should_process` no longer answers `SkipExists` for an empty slice either.
+    // The two guards are independent on purpose: this one keeps the value out of
+    // the config, and that one keeps the vacuous branch closed for a library
+    // caller passing the slice directly.
+    if defaults.formats.is_empty() {
+        return Err(Error::ConfigValidation {
+            message: "formats must list at least one output format; an empty list skips every \
+                      input file and writes nothing"
+                .to_string(),
+        });
+    }
+
+    // Same no-CLI-route, no-validation shape one field over, and the two writers
+    // that read the list disagree about an unrecognised name: `CsvWriter` emits
+    // it as a header over a column empty in every row, `parquet::build_schema`
+    // drops it. `handle_config_set` has no `defaults.csv_columns` arm either, so
+    // a hand-edited typo was the only way in and produced a phantom column in
+    // one format and nothing at all in the other.
+    //
+    // This rejects a config that was previously accepted, which is the point:
+    // the alternative to failing here is the phantom column, and a typo is the
+    // only way to reach it.
+    if let Some(unknown) = defaults
+        .csv_columns
+        .include
+        .iter()
+        .find(|column| !csv_columns::RECOGNISED.contains(&column.as_str()))
+    {
+        return Err(Error::ConfigValidation {
+            message: format!(
+                "csv_columns.include has an unknown column '{unknown}'; the columns are {}",
+                csv_columns::RECOGNISED.join(", ")
+            ),
+        });
+    }
+
     // Validate default model exists if specified
     if let Some(ref model_name) = defaults.model
         && !config.models.contains_key(model_name)
@@ -185,14 +239,17 @@ pub fn get_model<'a>(config: &'a Config, name: &str) -> Result<&'a ModelConfig> 
 
 /// Validate range filter configuration.
 pub fn validate_range_filter(config: &Config) -> Result<()> {
+    // Both bounds read `constants::coordinates`, which `cli::validators` and the
+    // `Error` message text also read (#340). Three routes reach one setting and
+    // each used to carry its own copy of the numbers.
     if let Some(lat) = config.defaults.latitude
-        && !(-90.0..=90.0).contains(&lat)
+        && !(coordinates::LATITUDE_MIN..=coordinates::LATITUDE_MAX).contains(&lat)
     {
         return Err(Error::InvalidLatitude { value: lat });
     }
 
     if let Some(lon) = config.defaults.longitude
-        && !(-180.0..=180.0).contains(&lon)
+        && !(coordinates::LONGITUDE_MIN..=coordinates::LONGITUDE_MAX).contains(&lon)
     {
         return Err(Error::InvalidLongitude { value: lon });
     }
@@ -478,6 +535,72 @@ mod tests {
         // an exclusive comparison is caught.
         assert!(validate_range_filter(&config_with_threshold(0.0)).is_ok());
         assert!(validate_range_filter(&config_with_threshold(1.0)).is_ok());
+    }
+
+    /// Build a config carrying nothing but the format list under test.
+    fn config_with_formats(formats: Vec<crate::config::OutputFormat>) -> Config {
+        let mut config = Config::default();
+        config.defaults.formats = formats;
+        config
+    }
+
+    #[test]
+    fn test_validate_rejects_an_empty_format_list() {
+        // #339. Reachable only by hand-editing config.toml, and the reason it
+        // cost a whole run rather than an error message: `should_process` asks
+        // `formats.iter().all(..)`, which is vacuously true over an empty
+        // slice, so every input file was reported as already having its output
+        // and the run exited 0 having written nothing.
+        let err = validate_config(&config_with_formats(vec![])).unwrap_err();
+
+        assert!(
+            matches!(&err, Error::ConfigValidation { message } if message.contains("at least one")),
+            "expected the empty-formats rule, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_the_default_format_list() {
+        // The control. `DefaultsConfig::default()` is `formats = ["csv"]`, so
+        // the new rule must not reject a config nobody has touched.
+        assert!(validate_config(&Config::default()).is_ok());
+        assert!(
+            validate_config(&config_with_formats(vec![
+                crate::config::OutputFormat::Json
+            ]))
+            .is_ok()
+        );
+    }
+
+    /// Build a config carrying nothing but the CSV column list under test.
+    fn config_with_csv_columns(columns: &[&str]) -> Config {
+        let mut config = Config::default();
+        config.defaults.csv_columns.include = columns.iter().map(|c| (*c).to_string()).collect();
+        config
+    }
+
+    #[test]
+    fn test_validate_rejects_an_unknown_csv_column() {
+        // Accepted before #339's fix, and then handled two different ways: the
+        // CSV writer emitted 'lattitude' as a header over a column empty in
+        // every row, the Parquet writer dropped it. Neither told the user.
+        let err = validate_config(&config_with_csv_columns(&["lat", "lattitude"])).unwrap_err();
+
+        assert!(
+            matches!(&err, Error::ConfigValidation { message }
+                if message.contains("lattitude") && message.contains("species_list")),
+            "the message must name the bad column and list the valid ones, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_every_recognised_csv_column() {
+        // Drives the whole of `csv_columns::RECOGNISED` through the rule that
+        // reads it, so a name added to the constant without the writers
+        // handling it is caught by `test_every_recognised_column_is_written`
+        // rather than by a user finding an empty column.
+        assert!(validate_config(&config_with_csv_columns(&csv_columns::RECOGNISED)).is_ok());
+        assert!(validate_config(&config_with_csv_columns(&[])).is_ok());
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -101,9 +101,11 @@ pub mod coordinates {
 pub mod parquet {
     /// Columns every Parquet file carries before the optional metadata ones.
     ///
-    /// `build_record_batch` skips exactly this many fields to reach the ones
-    /// `build_metadata_column` handles, so the two must agree. It was a bare
-    /// `6` at both sites.
+    /// Three things must agree on this number: the base `fields` vec in
+    /// `build_schema`, the base `columns` vec in `build_record_batch`, and the
+    /// `skip` that walks past them to reach the columns `build_metadata_column`
+    /// handles. The first two build their entries literally and cannot read a
+    /// constant; `test_schema_basic` is what pins them to it.
     pub const BASE_FIELD_COUNT: usize = 6;
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -73,6 +73,53 @@ pub mod day_of_year {
     pub const MAX: u32 = 366;
 }
 
+/// Geographic coordinate bounds, in degrees.
+///
+/// Three routes reach one setting: `--lat`/`--lon` and their `BIRDA_LATITUDE`/
+/// `BIRDA_LONGITUDE` variables, `birda config set defaults.latitude`, and a
+/// hand-edited config.toml. Before #340 each of `cli::validators`,
+/// `config::validate::validate_range_filter` and the `Error::InvalidLatitude`
+/// message text carried its own copy of these numbers, with nothing keeping
+/// them equal. `test_parse_latitude_matches_the_config_file_rule` and its
+/// longitude twin drive the flag and the file together and compare verdicts,
+/// so neither rule can be changed alone.
+pub mod coordinates {
+    /// Southernmost latitude.
+    pub const LATITUDE_MIN: f64 = -90.0;
+
+    /// Northernmost latitude.
+    pub const LATITUDE_MAX: f64 = 90.0;
+
+    /// Westernmost longitude.
+    pub const LONGITUDE_MIN: f64 = -180.0;
+
+    /// Easternmost longitude.
+    pub const LONGITUDE_MAX: f64 = 180.0;
+}
+
+/// Optional metadata columns for the CSV and Parquet writers.
+pub mod csv_columns {
+    /// Every name `defaults.csv_columns.include` accepts.
+    ///
+    /// `CsvWriter::write_detection` and `parquet::build_schema` each match on
+    /// these names, and each falls through silently on anything else in the
+    /// opposite direction: the CSV writer emits an unknown name as a header
+    /// over a column that is empty in every row, the Parquet writer drops it.
+    /// `config::validate` rejects an unrecognised name so neither behaviour is
+    /// reachable, and `test_every_recognised_column_is_written` drives the CSV
+    /// writer with each name here and fails if one stops being handled.
+    pub const RECOGNISED: [&str; 8] = [
+        "lat",
+        "lon",
+        "week",
+        "model",
+        "overlap",
+        "sensitivity",
+        "min_conf",
+        "species_list",
+    ];
+}
+
 /// Default number of top predictions to return per segment.
 pub const DEFAULT_TOP_K: usize = 5;
 
@@ -131,7 +178,16 @@ pub mod raven {
 
 /// Range filter constants.
 pub mod range_filter {
+    /// First week of the year, the lower bound for `--week`.
+    pub const WEEK_MIN: u32 = 1;
+
     /// `BirdNET` uses 48 weeks per year.
+    ///
+    /// Doubles as the upper bound for `--week`, which is why both `--week`
+    /// declarations in `cli::args` read this rather than restating 48 (#340).
+    /// `utils::date::date_to_week` clamps its result to the same value, so a
+    /// separately written CLI bound could have admitted a week that function
+    /// never returns.
     pub const WEEKS_PER_YEAR: u32 = 48;
 
     /// Days per `BirdNET` week (365.25 / 48).
@@ -200,6 +256,40 @@ pub mod obsolete_files {
 pub mod calendar {
     /// Days in each month (non-leap year).
     pub const DAYS_IN_MONTH: [u32; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+    /// First month of the year, the lower bound for `--month`.
+    pub const MONTH_MIN: u32 = 1;
+
+    /// Last month of the year, the upper bound for `--month`.
+    pub const MONTH_MAX: u32 = 12;
+
+    /// First day of any month, the lower bound for `--day`.
+    pub const DAY_MIN: u32 = 1;
+
+    /// Last day of the longest month, the upper bound for `--day`.
+    ///
+    /// `--day` is not checked against the month chosen alongside it, so the
+    /// bound is the longest month rather than the selected one.
+    pub const DAY_MAX: u32 = 31;
+
+    // Pin both upper bounds to the table they describe. A month added to or
+    // removed from `DAYS_IN_MONTH`, or a change to its longest entry, fails the
+    // build here rather than leaving `--month` and `--day` bounded by numbers
+    // the calendar they came from no longer supports.
+    const _: () = {
+        let mut months: u32 = 0;
+        let mut longest: u32 = 0;
+        let mut index = 0;
+        while index < DAYS_IN_MONTH.len() {
+            if DAYS_IN_MONTH[index] > longest {
+                longest = DAYS_IN_MONTH[index];
+            }
+            months += 1;
+            index += 1;
+        }
+        assert!(months == MONTH_MAX);
+        assert!(longest == DAY_MAX);
+    };
 }
 
 /// UTF-8 Byte Order Mark for Excel compatibility in CSV files.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -97,6 +97,16 @@ pub mod coordinates {
     pub const LONGITUDE_MAX: f64 = 180.0;
 }
 
+/// Apache Parquet output constants.
+pub mod parquet {
+    /// Columns every Parquet file carries before the optional metadata ones.
+    ///
+    /// `build_record_batch` skips exactly this many fields to reach the ones
+    /// `build_metadata_column` handles, so the two must agree. It was a bare
+    /// `6` at both sites.
+    pub const BASE_FIELD_COUNT: usize = 6;
+}
+
 /// Optional metadata columns for the CSV and Parquet writers.
 pub mod csv_columns {
     /// Every name `defaults.csv_columns.include` accepts.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -101,13 +101,25 @@ pub mod coordinates {
 pub mod csv_columns {
     /// Every name `defaults.csv_columns.include` accepts.
     ///
-    /// `CsvWriter::write_detection` and `parquet::build_schema` each match on
-    /// these names, and each falls through silently on anything else in the
-    /// opposite direction: the CSV writer emits an unknown name as a header
-    /// over a column that is empty in every row, the Parquet writer drops it.
-    /// `config::validate` rejects an unrecognised name so neither behaviour is
-    /// reachable, and `test_every_recognised_column_is_written` drives the CSV
-    /// writer with each name here and fails if one stops being handled.
+    /// Every writer that consumes `include` matches on these names, and a name
+    /// added here needs an arm in each of them. Today that is three arms, and
+    /// they disagree about what an unhandled name does: `CsvWriter::
+    /// write_detection` leaves the cell empty, so the name becomes a header
+    /// over a column empty in every row; `parquet::build_schema` drops it; and
+    /// `parquet::build_metadata_column` returns `Error::InvalidColumnName`,
+    /// which fails the write outright. The count is deliberately not the point
+    /// of this sentence: the invariant survives a fourth writer, a count does
+    /// not.
+    ///
+    /// `config::validate` rejects an unrecognised name, so none of those three
+    /// behaviours is reachable from an analyze run. It is not a guarantee for a
+    /// library caller: `CsvWriter::new` and `ParquetWriter::new` are public and
+    /// take the list directly, which is the same hole `should_process` keeps
+    /// its own guard for.
+    ///
+    /// `test_every_recognised_column_is_written` and
+    /// `test_every_recognised_column_reaches_the_parquet_writer` drive both
+    /// writers with every name here.
     pub const RECOGNISED: [&str; 8] = [
         "lat",
         "lon",

--- a/src/error.rs
+++ b/src/error.rs
@@ -408,7 +408,16 @@ pub enum Error {
     },
 
     /// Invalid range filter threshold.
-    #[error("invalid range threshold: {value} (must be 0.0 to 1.0)")]
+    ///
+    /// Reads the same constants as the rule that produces it, for the reason
+    /// given on `InvalidLatitude` above. It is the third variant rendering a
+    /// bound this way and was the one left behind when the coordinate pair was
+    /// converted in #340.
+    #[error(
+        "invalid range threshold: {value} (must be {:.1} to {:.1})",
+        crate::constants::confidence::MIN,
+        crate::constants::confidence::MAX
+    )]
     InvalidRangeThreshold {
         /// Invalid threshold value.
         value: f32,
@@ -771,6 +780,20 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "invalid confidence: NaN (must be a finite number from 0.0 to 1.0)"
+        );
+    }
+
+    #[test]
+    fn test_invalid_range_threshold_renders_the_value_and_the_range() {
+        // Added with the conversion of this variant to read `confidence::MIN`
+        // and `MAX` (#340). The literal text is spelled out here on purpose,
+        // the way its two siblings above are: interpolating the constants into
+        // the expectation as well would compare the message against itself and
+        // pass whatever it renders.
+        let err = Error::InvalidRangeThreshold { value: -1.0 };
+        assert_eq!(
+            err.to_string(),
+            "invalid range threshold: -1 (must be 0.0 to 1.0)"
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -382,14 +382,26 @@ pub enum Error {
     },
 
     /// Invalid latitude value.
-    #[error("invalid latitude: {value} (must be -90.0 to 90.0)")]
+    ///
+    /// The bounds are interpolated from `constants::coordinates` rather than
+    /// spelled out, so this message cannot drift from the rule that produced it
+    /// (#340). Same arrangement as `InvalidPadding` below.
+    #[error(
+        "invalid latitude: {value} (must be {:.1} to {:.1})",
+        crate::constants::coordinates::LATITUDE_MIN,
+        crate::constants::coordinates::LATITUDE_MAX
+    )]
     InvalidLatitude {
         /// Invalid latitude value.
         value: f64,
     },
 
     /// Invalid longitude value.
-    #[error("invalid longitude: {value} (must be -180.0 to 180.0)")]
+    #[error(
+        "invalid longitude: {value} (must be {:.1} to {:.1})",
+        crate::constants::coordinates::LONGITUDE_MIN,
+        crate::constants::coordinates::LONGITUDE_MAX
+    )]
     InvalidLongitude {
         /// Invalid longitude value.
         value: f64,

--- a/src/error.rs
+++ b/src/error.rs
@@ -410,9 +410,10 @@ pub enum Error {
     /// Invalid range filter threshold.
     ///
     /// Reads the same constants as the rule that produces it, for the reason
-    /// given on `InvalidLatitude` above. It is the third variant rendering a
-    /// bound this way and was the one left behind when the coordinate pair was
-    /// converted in #340.
+    /// given on `InvalidLatitude` above, and was the variant left behind when
+    /// the coordinate pair was converted in #340. Every variant in this enum
+    /// that renders a numeric bound should interpolate it rather than spell it
+    /// out; that invariant is the point, not how many of them there are.
     #[error(
         "invalid range threshold: {value} (must be {:.1} to {:.1})",
         crate::constants::confidence::MIN,

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -522,10 +522,13 @@ impl BirdClassifier {
                 birdnet_onnx::Error::BsgProcessing(msg) => Error::BsgConfig { message: msg },
                 // The bounds are read from `constants::day_of_year`, the pair
                 // `cli::validators::parse_day_of_year` and `config::validate`
-                // enforce (#340). This guard stays even though both of those
-                // now cover every route to the value: the error it renders
-                // comes from birdnet-onnx, so it is a library boundary rather
-                // than a duplicate of the input checks.
+                // enforce (#340). This guard stays for two reasons: the error
+                // it renders comes from birdnet-onnx, so it is a library
+                // boundary rather than a duplicate of the input checks, and
+                // those two rules do not cover every route anyway. When no day
+                // is given, `utils::date::auto_detect_day_of_year` supplies one
+                // from the file's modification time without passing through
+                // either.
                 birdnet_onnx::Error::InvalidDayOfYear { day_of_year } => Error::BsgConfig {
                     message: format!(
                         "invalid day of year: {day_of_year} (must be {}-{})",

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -520,8 +520,18 @@ impl BirdClassifier {
             // Apply calibration + SDM
             bsg.process(&result, lat, lon, day).map_err(|e| match e {
                 birdnet_onnx::Error::BsgProcessing(msg) => Error::BsgConfig { message: msg },
+                // The bounds are read from `constants::day_of_year`, the pair
+                // `cli::validators::parse_day_of_year` and `config::validate`
+                // enforce (#340). This guard stays even though both of those
+                // now cover every route to the value: the error it renders
+                // comes from birdnet-onnx, so it is a library boundary rather
+                // than a duplicate of the input checks.
                 birdnet_onnx::Error::InvalidDayOfYear { day_of_year } => Error::BsgConfig {
-                    message: format!("invalid day of year: {day_of_year} (must be 1-366)"),
+                    message: format!(
+                        "invalid day of year: {day_of_year} (must be {}-{})",
+                        crate::constants::day_of_year::MIN,
+                        crate::constants::day_of_year::MAX
+                    ),
                 },
                 other => Error::Inference {
                     reason: other.to_string(),

--- a/src/inference/classifier.rs
+++ b/src/inference/classifier.rs
@@ -522,13 +522,9 @@ impl BirdClassifier {
                 birdnet_onnx::Error::BsgProcessing(msg) => Error::BsgConfig { message: msg },
                 // The bounds are read from `constants::day_of_year`, the pair
                 // `cli::validators::parse_day_of_year` and `config::validate`
-                // enforce (#340). This guard stays for two reasons: the error
-                // it renders comes from birdnet-onnx, so it is a library
-                // boundary rather than a duplicate of the input checks, and
-                // those two rules do not cover every route anyway. When no day
-                // is given, `utils::date::auto_detect_day_of_year` supplies one
-                // from the file's modification time without passing through
-                // either.
+                // enforce (#340). This guard stays because the error it renders
+                // comes from birdnet-onnx, so it is a library boundary rather
+                // than a duplicate of the input checks.
                 birdnet_onnx::Error::InvalidDayOfYear { day_of_year } => Error::BsgConfig {
                     message: format!(
                         "invalid day of year: {day_of_year} (must be {}-{})",

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -161,6 +161,65 @@ mod tests {
     }
 
     #[test]
+    fn test_every_recognised_column_is_written() {
+        // Pins `csv_columns::RECOGNISED`, which `config::validate` accepts, to
+        // what this writer actually handles. The two are matched on strings in
+        // arms the compiler cannot connect to the constant, and the fall-through
+        // is silent: an unhandled name becomes a header over a column empty in
+        // every row. Adding a name to the constant without an arm here, or
+        // removing an arm, fails this test rather than shipping that column.
+        let columns: Vec<String> = crate::constants::csv_columns::RECOGNISED
+            .iter()
+            .map(|c| (*c).to_string())
+            .collect();
+
+        let file = NamedTempFile::new().unwrap();
+        let mut writer = CsvWriter::new(file.path(), columns.clone(), false).unwrap();
+
+        let mut detection = Detection::from_label(
+            "Passer domesticus_House Sparrow",
+            0.85,
+            0.0,
+            3.0,
+            PathBuf::from("/path/to/audio.wav"),
+        );
+        // Every optional field set, so an empty cell can only mean the writer
+        // did not handle the column.
+        detection.metadata = crate::output::DetectionMetadata {
+            lat: Some(60.1699),
+            lon: Some(24.9384),
+            week: Some(24),
+            model: Some("birdnet-v24".to_string()),
+            overlap: Some(1.5),
+            sensitivity: Some(1.25),
+            min_conf: Some(0.1),
+            species_list: Some("finland.txt".to_string()),
+        };
+
+        writer.write_header().unwrap();
+        writer.write_detection(&detection).unwrap();
+        writer.finalize().unwrap();
+
+        let contents = std::fs::read_to_string(file.path()).unwrap();
+        let mut lines = contents.lines();
+        let header: Vec<&str> = lines.next().unwrap().split(',').collect();
+        let row: Vec<&str> = lines.next().unwrap().split(',').collect();
+        assert_eq!(header.len(), row.len(), "header and row must line up");
+
+        for column in &columns {
+            let index = header
+                .iter()
+                .position(|h| h == column)
+                .unwrap_or_else(|| panic!("'{column}' is missing from the header"));
+            assert!(
+                !row[index].is_empty(),
+                "'{column}' is a recognised column but write_detection left it empty, \
+                 so it has no arm in the match"
+            );
+        }
+    }
+
+    #[test]
     fn test_escape_csv() {
         assert_eq!(escape_csv("simple"), "simple");
         assert_eq!(escape_csv("with,comma"), "\"with,comma\"");

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -206,15 +206,39 @@ mod tests {
         let row: Vec<&str> = lines.next().unwrap().split(',').collect();
         assert_eq!(header.len(), row.len(), "header and row must line up");
 
-        for column in &columns {
+        // Each cell is asserted against the value that column is FOR, not
+        // merely against being non-empty. Non-emptiness alone passes when an
+        // arm emits the wrong field: rewriting the `lat` arm to write
+        // `metadata.lon` leaves a populated `lat` column carrying a longitude,
+        // and a presence check cannot see it. Every value here is comma-free,
+        // which is what keeps the naive `split(',')` above honest; the
+        // `header.len() == row.len()` assertion fails loudly rather than
+        // silently misaligning if that ever stops being true.
+        let expected = [
+            ("lat", "60.1699"),
+            ("lon", "24.9384"),
+            ("week", "24"),
+            ("model", "birdnet-v24"),
+            ("overlap", "1.5"),
+            ("sensitivity", "1.25"),
+            ("min_conf", "0.1"),
+            ("species_list", "finland.txt"),
+        ];
+        assert_eq!(
+            expected.len(),
+            columns.len(),
+            "every name in RECOGNISED needs an expected value here"
+        );
+
+        for (column, want) in expected {
             let index = header
                 .iter()
-                .position(|h| h == column)
+                .position(|h| *h == column)
                 .unwrap_or_else(|| panic!("'{column}' is missing from the header"));
-            assert!(
-                !row[index].is_empty(),
-                "'{column}' is a recognised column but write_detection left it empty, \
-                 so it has no arm in the match"
+            assert_eq!(
+                row[index], want,
+                "'{column}' must carry its own metadata field; an empty cell means no arm in \
+                 the match, a wrong value means the arm reads the wrong field"
             );
         }
     }

--- a/src/output/parquet.rs
+++ b/src/output/parquet.rs
@@ -13,6 +13,7 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::constants::parquet::BASE_FIELD_COUNT;
 use crate::error::Result;
 use crate::output::OutputWriter;
 use crate::output::types::Detection;
@@ -140,13 +141,6 @@ impl OutputWriter for ParquetWriter {
         Ok(())
     }
 }
-
-/// Columns every Parquet file carries before the optional metadata ones.
-///
-/// `build_record_batch` skips exactly this many fields to reach the columns
-/// `build_metadata_column` handles, so the two must agree. It was written out
-/// as a bare `6` at both sites.
-const BASE_FIELD_COUNT: usize = 6;
 
 /// Build Arrow schema based on included columns.
 ///

--- a/src/output/parquet.rs
+++ b/src/output/parquet.rs
@@ -141,6 +141,13 @@ impl OutputWriter for ParquetWriter {
     }
 }
 
+/// Columns every Parquet file carries before the optional metadata ones.
+///
+/// `build_record_batch` skips exactly this many fields to reach the columns
+/// `build_metadata_column` handles, so the two must agree. It was written out
+/// as a bare `6` at both sites.
+const BASE_FIELD_COUNT: usize = 6;
+
 /// Build Arrow schema based on included columns.
 ///
 /// Creates a schema with core detection columns plus any additional metadata columns.
@@ -227,7 +234,7 @@ fn build_record_batch(detections: &[Detection], schema: &Arc<Schema>) -> Result<
     ];
 
     // Add optional metadata columns based on schema
-    for field in schema.fields().iter().skip(6) {
+    for field in schema.fields().iter().skip(BASE_FIELD_COUNT) {
         let array = build_metadata_column(field, detections)?;
         columns.push(array);
     }
@@ -456,9 +463,93 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn test_every_recognised_column_reaches_the_parquet_writer() {
+        // The Parquet twin of `csv::tests::test_every_recognised_column_is_written`.
+        // `config::validate` admits exactly `csv_columns::RECOGNISED`, and this
+        // module matches those names TWICE, in opposite failure directions:
+        // `build_schema` drops an unhandled name silently, so the column just
+        // vanishes from the file, while `build_metadata_column` returns
+        // `Error::InvalidColumnName`, which `?` propagates and fails the entire
+        // write. Neither had a test driving the constant, so a name added to
+        // `RECOGNISED` with only a CSV arm shipped green.
+        //
+        // Both arms are exercised here rather than only the schema, because the
+        // two disagree and the loud one is the one a user would hit at the end
+        // of a long run.
+        let columns: Vec<String> = crate::constants::csv_columns::RECOGNISED
+            .iter()
+            .map(|c| (*c).to_string())
+            .collect();
+
+        let schema = build_schema(&columns);
+        assert_eq!(
+            schema.fields().len(),
+            BASE_FIELD_COUNT + columns.len(),
+            "build_schema dropped a recognised column, so it has no arm for it"
+        );
+
+        // Every field carries a DISTINCT value, and each column is asserted
+        // against its own. `is_ok()` over an empty `DetectionMetadata` would
+        // not be enough, for the reason the CSV twin spells out: an arm reading
+        // the wrong field of the right type still returns `Ok`, and the three
+        // `Option<f32>` fields here are freely interchangeable without the
+        // compiler noticing. Asserting on the rendered array rather than
+        // downcasting keeps this from restating the name-to-type mapping the
+        // schema already owns, which is the thing under test.
+        let mut detection = Detection::from_label(
+            "Passer domesticus_House Sparrow",
+            0.85,
+            0.0,
+            3.0,
+            PathBuf::from("/path/to/audio.wav"),
+        );
+        detection.metadata = crate::output::DetectionMetadata {
+            lat: Some(60.1699),
+            lon: Some(24.9384),
+            week: Some(24),
+            model: Some("birdnet-v24".to_string()),
+            overlap: Some(1.5),
+            sensitivity: Some(1.25),
+            min_conf: Some(0.1),
+            species_list: Some("finland.txt".to_string()),
+        };
+        let detections = [detection];
+
+        let expected = [
+            ("lat", "60.1699"),
+            ("lon", "24.9384"),
+            ("week", "24"),
+            ("model", "birdnet-v24"),
+            ("overlap", "1.5"),
+            ("sensitivity", "1.25"),
+            ("min_conf", "0.1"),
+            ("species_list", "finland.txt"),
+        ];
+        assert_eq!(expected.len(), columns.len());
+
+        for (name, want) in expected {
+            let field = schema
+                .field_with_name(name)
+                .unwrap_or_else(|_| panic!("build_schema has no arm for '{name}'"));
+            let column = build_metadata_column(field, &detections).unwrap_or_else(|e| {
+                panic!(
+                    "build_metadata_column has no arm for the recognised column '{name}', which \
+                     fails every Parquet write rather than dropping the column: {e}"
+                )
+            });
+
+            let rendered = format!("{column:?}");
+            assert!(
+                rendered.contains(want),
+                "'{name}' must carry its own metadata field, expected {want} in: {rendered}"
+            );
+        }
+    }
+
+    #[test]
     fn test_schema_basic() {
         let schema = build_schema(&[]);
-        assert_eq!(schema.fields().len(), 6);
+        assert_eq!(schema.fields().len(), BASE_FIELD_COUNT);
         assert_eq!(schema.field(0).name(), "start_s");
         assert_eq!(schema.field(1).name(), "end_s");
         assert_eq!(schema.field(2).name(), "scientific_name");

--- a/src/output/parquet.rs
+++ b/src/output/parquet.rs
@@ -482,14 +482,24 @@ mod tests {
             "build_schema dropped a recognised column, so it has no arm for it"
         );
 
-        // Every field carries a DISTINCT value, and each column is asserted
-        // against its own. `is_ok()` over an empty `DetectionMetadata` would
-        // not be enough, for the reason the CSV twin spells out: an arm reading
-        // the wrong field of the right type still returns `Ok`, and the three
-        // `Option<f32>` fields here are freely interchangeable without the
-        // compiler noticing. Asserting on the rendered array rather than
-        // downcasting keeps this from restating the name-to-type mapping the
-        // schema already owns, which is the thing under test.
+        // Every field carries a value that is not a substring of any other, and
+        // each column is asserted to contain its own AND none of the rest.
+        //
+        // Both halves are load-bearing. `is_ok()` over an empty
+        // `DetectionMetadata` proves nothing, because an arm reading a
+        // different field still returns `Ok`; `build_metadata_column` returns
+        // `ArrayRef`, so no pair of arms is protected by types, whatever their
+        // field types are. And a bare `contains` is not enough either: an
+        // earlier version of this test used week 24 and min_conf 0.1, which are
+        // substrings of the longitude 24.9384 and the latitude 60.1699, so
+        // swapping those two arms left every test green while any run with
+        // `week` configured failed at `RecordBatch::try_new` with a schema type
+        // mismatch. The exclusion loop is what makes the check independent of
+        // how lucky the fixture values are.
+        //
+        // Asserting on the rendered array rather than downcasting keeps this
+        // from restating the name-to-type mapping the schema already owns,
+        // which is the thing under test.
         let mut detection = Detection::from_label(
             "Passer domesticus_House Sparrow",
             0.85,
@@ -498,26 +508,26 @@ mod tests {
             PathBuf::from("/path/to/audio.wav"),
         );
         detection.metadata = crate::output::DetectionMetadata {
-            lat: Some(60.1699),
-            lon: Some(24.9384),
-            week: Some(24),
-            model: Some("birdnet-v24".to_string()),
-            overlap: Some(1.5),
-            sensitivity: Some(1.25),
-            min_conf: Some(0.1),
-            species_list: Some("finland.txt".to_string()),
+            lat: Some(11.0625),
+            lon: Some(22.1875),
+            week: Some(37),
+            model: Some("model-name".to_string()),
+            overlap: Some(33.5),
+            sensitivity: Some(44.75),
+            min_conf: Some(55.25),
+            species_list: Some("species-list".to_string()),
         };
         let detections = [detection];
 
         let expected = [
-            ("lat", "60.1699"),
-            ("lon", "24.9384"),
-            ("week", "24"),
-            ("model", "birdnet-v24"),
-            ("overlap", "1.5"),
-            ("sensitivity", "1.25"),
-            ("min_conf", "0.1"),
-            ("species_list", "finland.txt"),
+            ("lat", "11.0625"),
+            ("lon", "22.1875"),
+            ("week", "37"),
+            ("model", "model-name"),
+            ("overlap", "33.5"),
+            ("sensitivity", "44.75"),
+            ("min_conf", "55.25"),
+            ("species_list", "species-list"),
         ];
         assert_eq!(expected.len(), columns.len());
 
@@ -537,6 +547,13 @@ mod tests {
                 rendered.contains(want),
                 "'{name}' must carry its own metadata field, expected {want} in: {rendered}"
             );
+            for (other, unwanted) in expected {
+                assert!(
+                    other == name || !rendered.contains(unwanted),
+                    "'{name}' rendered {unwanted}, which belongs to '{other}', so its arm reads \
+                     the wrong field: {rendered}"
+                );
+            }
         }
     }
 
@@ -576,7 +593,7 @@ mod tests {
         let batch = build_record_batch(&detections, &schema).ok().unwrap();
 
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(batch.num_columns(), 6);
+        assert_eq!(batch.num_columns(), BASE_FIELD_COUNT);
     }
 
     #[test]
@@ -584,6 +601,6 @@ mod tests {
         let schema = build_schema(&[]);
         let batch = build_record_batch(&[], &schema).ok().unwrap();
         assert_eq!(batch.num_rows(), 0);
-        assert_eq!(batch.num_columns(), 6);
+        assert_eq!(batch.num_columns(), BASE_FIELD_COUNT);
     }
 }

--- a/src/pipeline/coordinator.rs
+++ b/src/pipeline/coordinator.rs
@@ -113,16 +113,17 @@ pub fn should_process(
 
     // Check if all outputs exist (unless force)
     //
-    // The list has to be non-empty for the question to mean anything: `all` over
-    // an empty slice is vacuously true, so an empty `formats` answered "every
-    // output already exists" when there was nothing to check, and every input
-    // file was skipped with a reason naming a file that did not exist (#339).
+    // The list has to be non-empty for the question to mean anything, since
+    // `all` over an empty slice is vacuously true (#339).
     //
     // `config::validate` rejects an empty `defaults.formats`, so the analyze
     // path cannot arrive here with one. This guard is for the direct caller:
     // `should_process` is public and takes the slice, so it should not depend on
     // a rule enforced two layers up. Returning `Process` is the honest answer;
-    // no output can be found to already exist when none was asked for.
+    // no output can be found to already exist when none was asked for. It is
+    // not free, though: such a caller now decodes and runs inference over every
+    // file and still writes nothing, where before it did nothing quickly. Both
+    // are silent, which is why the config rule is the one that matters.
     if !force && !formats.is_empty() {
         let all_exist = formats.iter().all(|fmt| {
             output_path_for(input, output_dir, *fmt).map_or_else(
@@ -199,10 +200,11 @@ mod tests {
         // whose outputs did not exist and could not, and the caller logged
         // "Skipping (output exists)" naming a reason that was never true.
         //
-        // The directory has to exist for the lock check to behave, and the
-        // input deliberately does not: with no format requested there is no
-        // output path to test, so nothing about the filesystem can make the
-        // answer `SkipExists`.
+        // The input deliberately does not exist: with no format requested there
+        // is no output path to test, so nothing about the filesystem can make
+        // the answer `SkipExists`. The tempdir is for a unique path, not for
+        // the lock check, which is a bare `Path::exists` and answers false for
+        // a path under a directory that is not there either.
         let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("recording.wav");
 

--- a/src/pipeline/coordinator.rs
+++ b/src/pipeline/coordinator.rs
@@ -112,7 +112,18 @@ pub fn should_process(
     }
 
     // Check if all outputs exist (unless force)
-    if !force {
+    //
+    // The list has to be non-empty for the question to mean anything: `all` over
+    // an empty slice is vacuously true, so an empty `formats` answered "every
+    // output already exists" when there was nothing to check, and every input
+    // file was skipped with a reason naming a file that did not exist (#339).
+    //
+    // `config::validate` rejects an empty `defaults.formats`, so the analyze
+    // path cannot arrive here with one. This guard is for the direct caller:
+    // `should_process` is public and takes the slice, so it should not depend on
+    // a rule enforced two layers up. Returning `Process` is the honest answer;
+    // no output can be found to already exist when none was asked for.
+    if !force && !formats.is_empty() {
         let all_exist = formats.iter().all(|fmt| {
             output_path_for(input, output_dir, *fmt).map_or_else(
                 |e| {
@@ -180,6 +191,46 @@ fn is_audio_file(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_should_process_does_not_skip_when_no_formats_are_requested() {
+        // #339, at the layer that has the information. `all` over an empty
+        // slice is vacuously true, so this returned `SkipExists` for a file
+        // whose outputs did not exist and could not, and the caller logged
+        // "Skipping (output exists)" naming a reason that was never true.
+        //
+        // The directory has to exist for the lock check to behave, and the
+        // input deliberately does not: with no format requested there is no
+        // output path to test, so nothing about the filesystem can make the
+        // answer `SkipExists`.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("recording.wav");
+
+        let check = should_process(&input, dir.path(), &[], false, false);
+
+        assert!(
+            matches!(check, ProcessCheck::Process),
+            "an empty format list must not read as 'every output already exists', got {check:?}"
+        );
+    }
+
+    #[test]
+    fn test_should_process_still_skips_when_the_only_output_exists() {
+        // The other half of the pair: the empty-slice guard must not stop the
+        // existence check doing its job for a list that has something in it.
+        // Without this, deleting the whole `if` block passes the test above.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("recording.wav");
+        let existing = output_path_for(&input, dir.path(), OutputFormat::Csv).unwrap();
+        std::fs::write(&existing, "").unwrap();
+
+        let check = should_process(&input, dir.path(), &[OutputFormat::Csv], false, false);
+
+        assert!(
+            matches!(check, ProcessCheck::SkipExists),
+            "an existing output must still be skipped, got {check:?}"
+        );
+    }
 
     #[test]
     fn test_output_dir_for_with_explicit() {

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -31,7 +31,13 @@ pub fn date_to_week(month: u32, day: u32) -> u32 {
     week.min(WEEKS_PER_YEAR)
 }
 
-/// Convert day of year (1-365) to (month, day).
+/// Convert a day of year to (month, day) on a non-leap calendar.
+///
+/// The stated domain used to be "1-365", which disagreed with the 1-366 the
+/// rest of the crate bounds a day of year to (#340). Neither number is a
+/// precondition, because this function bounds nothing: a day past the end of
+/// the table saturates to December 31, which is where day 366 of a leap year
+/// lands.
 pub fn day_of_year_to_date(day_of_year: u32) -> (u32, u32) {
     let mut remaining = day_of_year;
     for (month_idx, &days_in_month) in DAYS_IN_MONTH.iter().enumerate() {

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -33,11 +33,10 @@ pub fn date_to_week(month: u32, day: u32) -> u32 {
 
 /// Convert a day of year to (month, day) on a non-leap calendar.
 ///
-/// The stated domain used to be "1-365", which disagreed with the 1-366 the
-/// rest of the crate bounds a day of year to (#340). Neither number is a
-/// precondition, because this function bounds nothing: a day past the end of
-/// the table saturates to December 31, which is where day 366 of a leap year
-/// lands.
+/// Bounds nothing at either end, so the "1-365" this once claimed was never a
+/// precondition. A day past the end of the table saturates to December 31,
+/// which is where day 366 of a leap year lands; a day of 0 returns `(1, 0)`,
+/// which is not a date.
 pub fn day_of_year_to_date(day_of_year: u32) -> (u32, u32) {
     let mut remaining = day_of_year;
     for (month_idx, &days_in_month) in DAYS_IN_MONTH.iter().enumerate() {

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -45,6 +45,18 @@ const OUT_OF_RANGE_LATITUDE: &str = "[defaults]\nlatitude = 200.0\n";
 /// "0 species in range".
 const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
 
+/// An empty output-format list (#339).
+///
+/// The reason this rule needs a binary-level test more than its siblings do:
+/// the symptom it fixes was an exit code, not a message. Before the rule, this
+/// config made a run log "Skipping (output exists)" for every input file and
+/// exit 0 having written nothing, so a unit test on `validate_config` can show
+/// the rule fires but not that the run now stops.
+const EMPTY_FORMATS: &str = "[defaults]\nformats = []\n";
+
+/// A CSV column name no writer has an arm for (#339).
+const UNKNOWN_CSV_COLUMN: &str = "[defaults.csv_columns]\ninclude = [\"lattitude\"]\n";
+
 /// Every `BIRDA_*` variable clap binds to an argument.
 ///
 /// All of them are cleared per run. These tests assert on what the config file
@@ -239,6 +251,8 @@ fn assert_validation_did_not_reject(home: &Path) {
         OVERLAP_VIOLATION,
         BATCH_SIZE_VIOLATION,
         DAY_OF_YEAR_VIOLATION,
+        EMPTY_FORMATS_VIOLATION,
+        UNKNOWN_CSV_COLUMN_VIOLATION,
     ] {
         assert!(
             !stderr.contains(message),
@@ -268,6 +282,8 @@ const THRESHOLD_VIOLATION: &str = "invalid range threshold";
 const OVERLAP_VIOLATION: &str = "overlap must be a finite non-negative number";
 const BATCH_SIZE_VIOLATION: &str = "batch_size must be between";
 const DAY_OF_YEAR_VIOLATION: &str = "day_of_year must be between";
+const EMPTY_FORMATS_VIOLATION: &str = "defaults.formats must list at least one output format";
+const UNKNOWN_CSV_COLUMN_VIOLATION: &str = "has an unknown column 'lattitude'";
 
 /// The tail `cli::validators::parse_batch_size` adds and the config-file rule
 /// does not.
@@ -324,6 +340,60 @@ fn test_out_of_range_latitude_is_rejected_on_load() {
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
 
     assert_analysis_rejected(home.path(), LATITUDE_VIOLATION);
+}
+
+#[test]
+fn test_an_empty_format_list_is_rejected_on_load() {
+    // #339. The failure this replaces was silent: every input file was reported
+    // as "Skipping (output exists)", the run summary said "0 processed", and
+    // the exit code was 0. `assert_analysis_rejected` pins the exit code as
+    // well as the message, which is the half a unit test cannot reach and the
+    // half that was actually wrong.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), EMPTY_FORMATS);
+
+    assert_analysis_rejected(home.path(), EMPTY_FORMATS_VIOLATION);
+}
+
+#[test]
+fn test_an_unknown_csv_column_is_rejected_on_load() {
+    // #339, the same no-CLI-route shape one key over. 'lattitude' reached the
+    // CSV header verbatim and produced a column empty in every row, while the
+    // Parquet writer dropped it, so the same config gave two different answers.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), UNKNOWN_CSV_COLUMN);
+
+    assert_analysis_rejected(home.path(), UNKNOWN_CSV_COLUMN_VIOLATION);
+}
+
+#[test]
+fn test_neither_new_rule_has_a_config_set_arm_to_repair_it() {
+    // Pins the reason both messages carry recovery advice that the sibling
+    // rules do not. `config set` cannot reach either key, and because
+    // `save_config` validates the whole file, the fault also blocks `config
+    // set` on every OTHER key. Hand-editing config.toml is the only way out,
+    // and the README says so; this is what stops that becoming untrue quietly.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), EMPTY_FORMATS);
+
+    let direct = run_in(home.path(), &["config", "set", "defaults.formats", "csv"]);
+    assert_eq!(direct.status.code(), Some(APPLICATION_ERROR));
+    assert!(
+        stderr_of(&direct).contains("unknown configuration key"),
+        "there is no arm for defaults.formats, got: {}",
+        stderr_of(&direct)
+    );
+
+    let other = run_in(
+        home.path(),
+        &["config", "set", "defaults.min_confidence", "0.2"],
+    );
+    assert_eq!(other.status.code(), Some(APPLICATION_ERROR));
+    assert!(
+        stderr_of(&other).contains(EMPTY_FORMATS_VIOLATION),
+        "an unrelated key must also be refused while the file is invalid, got: {}",
+        stderr_of(&other)
+    );
 }
 
 #[test]

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -376,13 +376,19 @@ fn test_neither_new_rule_has_a_config_set_arm_to_repair_it() {
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), EMPTY_FORMATS);
 
-    let direct = run_in(home.path(), &["config", "set", "defaults.formats", "csv"]);
-    assert_eq!(direct.status.code(), Some(APPLICATION_ERROR));
-    assert!(
-        stderr_of(&direct).contains("unknown configuration key"),
-        "there is no arm for defaults.formats, got: {}",
-        stderr_of(&direct)
-    );
+    // Both keys, because the name says both and the advice covers both. Written
+    // with only `defaults.formats` first, this stayed green if someone added a
+    // `defaults.csv_columns` arm, which would make half of `EDIT_THE_FILE`
+    // false while nothing noticed.
+    for key in ["defaults.formats", "defaults.csv_columns"] {
+        let direct = run_in(home.path(), &["config", "set", key, "csv"]);
+        assert_eq!(direct.status.code(), Some(APPLICATION_ERROR));
+        assert!(
+            stderr_of(&direct).contains("unknown configuration key"),
+            "there is no arm for {key}, got: {}",
+            stderr_of(&direct)
+        );
+    }
 
     let other = run_in(
         home.path(),
@@ -392,6 +398,14 @@ fn test_neither_new_rule_has_a_config_set_arm_to_repair_it() {
     assert!(
         stderr_of(&other).contains(EMPTY_FORMATS_VIOLATION),
         "an unrelated key must also be refused while the file is invalid, got: {}",
+        stderr_of(&other)
+    );
+
+    // The recovery advice itself is user-facing output with nothing else
+    // asserting a word of it.
+    assert!(
+        stderr_of(&other).contains("birda config path"),
+        "the message must point at the file, got: {}",
         stderr_of(&other)
     );
 }


### PR DESCRIPTION
Closes #339. Closes #340.

## The bug

`defaults.formats = []` hand-edited into config.toml made an analysis run skip every file it was given, report success, and write nothing. Reproduced before the fix:

```
INFO Skipping (output exists): .../test.wav
INFO Complete: 0 processed, 1 skipped, 0 errors, 0 total detections in 0.13s
$ echo $?
0
```

Nothing existed. `should_process` asks whether the outputs are already present with `formats.iter().all(|fmt| path.exists())`, and `all` over an empty slice is vacuously true, so "nothing to check" was answered as "everything is already there". The log line named a reason that was not the real one and the run exited 0.

config.toml is the only route that can carry an empty list. `--format` and `BIRDA_FORMAT` do reach the setting and win over the file, but they go through a `ValueEnum`, so clap refuses an empty or unknown value; `handle_config_set` has no arm for the key at all. That is the same asymmetry as #306 and #312, except those failed loudly and this one cost a whole run's output in silence.

After:

```
error: configuration validation failed: defaults.formats must list at least one output format; with an empty list a run writes no output at all

This key has no 'birda config set' arm, so edit config.toml directly; 'birda config path' prints where it is.
$ echo $?
1
```

## What changed

`validate_defaults` rejects an empty list, and `should_process` no longer answers `SkipExists` for an empty slice. The two guards are independent on purpose: the first keeps the value out of the config, the second stops a library caller of a `pub` function depending on a rule enforced two layers up.

`csv_columns.include` had the same no-CLI-route, no-validation shape, and the two writers reading it disagreed about an unrecognised name: the CSV writer emitted it as a header over a column empty in every row, the Parquet writer dropped it. The accepted names now live in `constants::csv_columns::RECOGNISED`, validation reads it, and both writers are driven by it in tests.

The #340 half gives the bounds still held as duplicate literals one home. Latitude and longitude had three copies each, in `cli::validators`, in `config::validate` and a third time in the `Error` message text; all three read `constants::coordinates` now, pinned by parity tests that drive the flag and the file with the same inputs and compare verdicts. The six week/month/day clap declarations, two per flag, read constants through three helpers, with compile-time assertions tying the month and day bounds to `DAYS_IN_MONTH`.

## Behaviour change

Two configurations that were accepted are now refused: an empty `formats`, and an unrecognised name in `csv_columns.include`. That is the point of the change; a typo is the only way to reach the phantom column, and an empty list is never what an untouched config carries, since `DefaultsConfig::default()` is `formats = ["csv"]`.

Validation reads the file as a document, so a stored value is checked whether or not this run would have used it: `--format csv` does not get you past an empty `formats`, `--stdout` does not either, and a `csv_columns` typo stops a `--format json` run that would never open a CSV writer. That is how every rule here has behaved since #341, where a `batch_size` of 9999 in the file already stops `birda --batch-size 32`. It is written down in the README now rather than discovered. Both new messages name the full key and point at `birda config path`, because neither key has a `config set` arm and a fault in either blocks `config set` on every other key too.

## Verification

Every test added here was checked by mutation: 26 mutations across the rules, both ends of every bound, both help surfaces, both writers and the binary-level tests, each reddening the test that names it. Three defects that found were tests passing for the wrong reason, and they are the reason this has two commits:

- `test_coordinate_error_messages` asserted `contains("-90.0")` and `contains("90.0")`, and the second is a substring of the first, so a message rendering the minimum at both ends passed.
- the zero case in the bounds test ran `--month=0` with no partner, and `--month` requires `--day`, so it failed on the missing partner whatever the range said; a widened lower bound stayed green.
- the first Parquet test asserted `is_ok()` over an all-`None` fixture, so an arm reading a sibling field of the same type survived.

The second commit also corrects five statements in the first that turned out to be false, including a comment claiming two match sites for `RECOGNISED` where there are three, and the third fails every Parquet write rather than dropping a column.

Reviewed by eleven agents plus Gemini. Findings that were real but out of scope are filed as #343, #344 and #345.

## Measured and rejected, so it does not resurface

- **A duplicate entry in `csv_columns.include`.** Two reviewers independently built standalone harnesses against the arrow/parquet 59.1.0 in `Cargo.lock`: duplicates produce a valid file with two identically-named columns in both writers, so the divergence that motivated the membership rule does not apply. Third-party reader behaviour (polars, duckdb) was not tested.
- **Deriving `MONTH_MAX` as `DAYS_IN_MONTH.len() as u32`.** Compiles under plain rustc, but is a hard error under this crate's lints: `cast_possible_truncation` is pedantic and CI runs `-D warnings`. The compile-time assertion stays.
- **Making the `formats` rule mode-aware so `--stdout` is exempt.** It would mean handing the args to a validator deliberately blind to them, to preserve a setting whose only other mode it silently breaks, and the repair costs a `--stdout` user nothing since naming a format writes no file in that mode either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Parquet as a supported output format.
  * Added validation for output formats, CSV columns, batch sizes, dates, and geographic coordinates.
  * Improved CLI help with supported formats and valid value ranges.

* **Bug Fixes**
  * Corrected processing behavior when no output formats are configured.
  * Improved consistency and clarity of validation errors.

* **Documentation**
  * Expanded configuration guidance, including invalid-value handling and repair instructions.
  * Clarified date conversion behavior for out-of-range values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->