### PR TITLE
fix: stop destroying a registry.json that could only not be read, and stop orphaning failed downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,9 @@ A configuration file birda creates for the first time is readable only by you (m
 
 `registry.json`, in the same directory, is written the same way, so the hardlink note above applies to it too, with three differences worth knowing. It is **not** created private: it holds the model catalogue, which ships inside the binary and is not secret, so it keeps whatever your umask gives it, exactly as before. A `registry.json` that is a **dangling** symlink is replaced by a regular file rather than written through, because only `config.toml` resolves a link whose target does not exist yet (an existing link is followed for both). And if it cannot be written at all, because the directory is read-only or the file itself is bind-mounted, birda warns and carries on with the built-in registry rather than failing the command; it will try again on the next run.
 
-It is rewritten whenever an upgrade ships a newer bundled registry, so any local edits to it are replaced at that point rather than merged.
+It is rewritten whenever an upgrade ships a newer bundled registry, so any local edits to it are replaced at that point rather than merged. It is also rewritten when it cannot be parsed, since a file birda cannot read as a registry holds nothing worth keeping.
+
+If it cannot be **read** at all, which is a different thing, birda leaves it exactly as it is and carries on with the built-in registry for that run. A permission or I/O error says nothing about the contents, so the file is very possibly intact and destroying it would take your local edits with it. The warning names the underlying cause, and birda tries again on every run, so fixing the permissions is enough to recover; note that while it persists, no registry upgrade is written either, and any tool reading `registry.json` off disk keeps seeing the old copy.
 
 ### Environment Variables
 

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -236,9 +236,11 @@ fn part_path(dest: &Path) -> Result<PathBuf> {
 
 /// Move a completed download onto its destination, consuming the part file.
 ///
-/// The part file is consumed whether or not the rename succeeds. It carries no
-/// value on its own, and `part_path` names it after this process, so a part file
-/// left behind by a failed publish is never reclaimed by anything.
+/// A failed publish also removes the part file, best effort via [`roll_back`], so
+/// the unlink failing is reported rather than guaranteed away. The part file
+/// carries no value on its own: nothing resumes from it, and `part_path` names it
+/// after this process, so in practice a retry is a new invocation that picks a
+/// different name and leaves the old one stranded for good.
 ///
 /// What the directory fsync buys here, stated precisely because it is easy to
 /// overclaim: it stops a crash costing the user the download again. `stream_to_file`
@@ -258,14 +260,21 @@ fn finalize_download(part: &Path, dest: &Path) -> Result<()> {
     // case: a destination bind-mounted as a file cannot be renamed over, and it is
     // the same failure this change documents for the registry one directory away.
     if let Err(source) = std::fs::rename(part, dest) {
-        // The part file is useless without the rename and nothing else will ever
-        // remove it: `part_path` qualifies the name with this process's id, so a
-        // retry picks a different one, and `find_obsolete_files` matches a fixed
-        // list of names that does not include it. Best effort, like the two
-        // cleanups on the earlier failure paths in `download_verified`: if the
-        // unlink also fails there is nothing useful left to say, and the rename
-        // error is the one the caller needs.
-        drop(std::fs::remove_file(part));
+        // The part file is useless without the rename, and nothing sweeps it up:
+        // `find_obsolete_files` matches a fixed list of names that does not include
+        // it, and `part_path` qualifies the name with this process's id, so the
+        // realistic retry (a second invocation, with a different pid) never
+        // reclaims it either. Within one process the name is stable and
+        // `stream_to_file` would truncate it, so the leak is across runs.
+        //
+        // Through `roll_back` rather than a bare `drop(remove_file(..))`, which is
+        // what the two earlier failure paths in `download_verified` use: it
+        // tolerates an already-absent file and WARNS with the path otherwise. The
+        // causes are correlated (whatever broke the rename in this directory,
+        // EACCES or a read-only remount, tends to break the unlink too), so the
+        // one case where the cleanup silently fails to happen is the one where the
+        // user most needs to be told which file to go and delete.
+        roll_back(&[part]);
         return Err(Error::DownloadInstallFailed {
             dest: dest.to_path_buf(),
             source,
@@ -634,11 +643,18 @@ mod tests {
         // attempt with no way to find it short of `find`.
         let dir = tempfile::tempdir().unwrap();
 
-        // A directory cannot be renamed over by a file: rename(2) gives EISDIR,
-        // and MoveFileEx fails the same way on Windows. It stands in for the real
-        // cases, which are awkward to provoke here but take this exact path: EXDEV
-        // when $TMPDIR is a different filesystem, and the documented EBUSY on a
-        // destination bind-mounted as a file.
+        // A directory cannot be renamed over by a file. The errno differs by
+        // platform and this test deliberately does not assert it: POSIX mandates
+        // EISDIR, while Windows `MoveFileExW` with MOVEFILE_REPLACE_EXISTING
+        // refuses a directory destination with ERROR_ACCESS_DENIED (verified on
+        // Windows 11, not inferred). Both are an Err, which is all this needs, so
+        // the fixture is portable even though CI only ever runs it on Linux.
+        //
+        // It stands in for the real case, which is awkward to provoke here: the
+        // EBUSY documented for a destination bind-mounted as a file. Not EXDEV,
+        // which cannot occur on this path at all, since `part_path` builds the
+        // part file with `with_file_name` and it is therefore always in the
+        // destination's own directory.
         let dest = dir.path().join("m.onnx");
         std::fs::create_dir(&dest).unwrap();
 
@@ -647,10 +663,18 @@ mod tests {
 
         let err = finalize_download(&part, &dest).unwrap_err();
 
-        assert!(
-            matches!(err, Error::DownloadInstallFailed { .. }),
-            "the caller must still be told the publish failed, got: {err}"
-        );
+        // The payload is asserted, not just the variant. `finalize_download` has
+        // one Err construction site, so `matches!` alone cannot fail, and the
+        // reason this variant exists at all is to name the path a bare
+        // `Error::Io` omitted: pointing it at the part file instead of the
+        // destination would restore the unhelpful message it replaced.
+        match &err {
+            Error::DownloadInstallFailed { dest: named, .. } => assert_eq!(
+                named, &dest,
+                "the error must name the destination it failed to publish onto"
+            ),
+            other => panic!("the caller must be told the publish failed, got: {other}"),
+        }
         assert!(
             !part.exists(),
             "a failed publish must consume its part file; nothing else ever \

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -236,6 +236,10 @@ fn part_path(dest: &Path) -> Result<PathBuf> {
 
 /// Move a completed download onto its destination, consuming the part file.
 ///
+/// The part file is consumed whether or not the rename succeeds. It carries no
+/// value on its own, and `part_path` names it after this process, so a part file
+/// left behind by a failed publish is never reclaimed by anything.
+///
 /// What the directory fsync buys here, stated precisely because it is easy to
 /// overclaim: it stops a crash costing the user the download again. `stream_to_file`
 /// has already `sync_all`ed the part file, so the data behind the new name is
@@ -253,10 +257,20 @@ fn finalize_download(part: &Path, dest: &Path) -> Result<()> {
     // resource busy (os error 16)" with neither path in it. That EBUSY is a real
     // case: a destination bind-mounted as a file cannot be renamed over, and it is
     // the same failure this change documents for the registry one directory away.
-    std::fs::rename(part, dest).map_err(|source| Error::DownloadInstallFailed {
-        dest: dest.to_path_buf(),
-        source,
-    })?;
+    if let Err(source) = std::fs::rename(part, dest) {
+        // The part file is useless without the rename and nothing else will ever
+        // remove it: `part_path` qualifies the name with this process's id, so a
+        // retry picks a different one, and `find_obsolete_files` matches a fixed
+        // list of names that does not include it. Best effort, like the two
+        // cleanups on the earlier failure paths in `download_verified`: if the
+        // unlink also fails there is nothing useful left to say, and the rename
+        // error is the one the caller needs.
+        drop(std::fs::remove_file(part));
+        return Err(Error::DownloadInstallFailed {
+            dest: dest.to_path_buf(),
+            source,
+        });
+    }
     crate::utils::fs::sync_parent_directory(dest);
     Ok(())
 }
@@ -607,6 +621,41 @@ mod tests {
 
         assert_eq!(std::fs::read(&dest).unwrap(), b"right");
         assert!(!part.exists(), "the part file must be consumed");
+    }
+
+    #[test]
+    fn test_a_failed_publish_does_not_orphan_its_part_file() {
+        // download_verified cleans up on its stream-failed and checksum-failed
+        // paths and did not on this one, so a rename that failed left the part
+        // file behind forever: part_path qualifies the name with this process's
+        // id, so the next attempt picks a different name, and find_obsolete_files
+        // matches a fixed list that does not include it. Model files are tens to
+        // hundreds of MB, so the user silently loses that much disk per failed
+        // attempt with no way to find it short of `find`.
+        let dir = tempfile::tempdir().unwrap();
+
+        // A directory cannot be renamed over by a file: rename(2) gives EISDIR,
+        // and MoveFileEx fails the same way on Windows. It stands in for the real
+        // cases, which are awkward to provoke here but take this exact path: EXDEV
+        // when $TMPDIR is a different filesystem, and the documented EBUSY on a
+        // destination bind-mounted as a file.
+        let dest = dir.path().join("m.onnx");
+        std::fs::create_dir(&dest).unwrap();
+
+        let part = part_path(&dest).unwrap();
+        std::fs::write(&part, b"a hundred megabytes, pretend").unwrap();
+
+        let err = finalize_download(&part, &dest).unwrap_err();
+
+        assert!(
+            matches!(err, Error::DownloadInstallFailed { .. }),
+            "the caller must still be told the publish failed, got: {err}"
+        );
+        assert!(
+            !part.exists(),
+            "a failed publish must consume its part file; nothing else ever \
+             reclaims it"
+        );
     }
 
     #[test]

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -50,10 +50,10 @@ fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registr
         // this arm is wider than malformed JSON. Nothing here sets
         // `deny_unknown_fields`, so a registry from a NEWER birda that ADDED a
         // field parses fine and is kept; what lands here is one that REMOVED or
-        // renamed a field this binary still requires, on a downgrade. Bytes in a
-        // text encoding other than UTF-8 land here too, since they cannot be a
-        // registry for any consumer. None of those is corruption, and all of them
-        // are replaced.
+        // renamed a field this binary still requires, on a downgrade. That is not
+        // corruption either, and it is replaced all the same. For where bytes in
+        // another text encoding land, and the one case that escapes this arm, see
+        // `load_from_file`.
         Err(e @ Error::RegistryParse { .. }) => {
             tracing::warn!(
                 "{e}{}. Replacing it with the bundled registry.",

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -10,27 +10,58 @@ use std::path::PathBuf;
 /// the user registry is replaced with the bundled version.
 pub fn load_registry() -> Result<Registry> {
     let registry_path = registry_file_path()?;
-
-    // Load bundled registry
     let bundled_registry = load_bundled_registry()?;
 
-    // If user registry doesn't exist, bootstrap and return
+    Ok(load_registry_from(&registry_path, bundled_registry))
+}
+
+/// Resolve the registry to use, given where the user's copy lives.
+///
+/// Split out from [`load_registry`] so it can be tested against a temporary
+/// directory. [`load_registry`] resolves its path through
+/// `crate::config::config_dir()`, so driving it directly in a test reads and
+/// writes the developer's real config directory.
+///
+/// Infallible on purpose: every failure below is already a degradation to the
+/// bundled registry, which is in hand before this is called, so there is nothing
+/// left that could justify aborting the command that asked for it.
+fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registry) -> Registry {
     if !registry_path.exists() {
-        return Ok(bootstrap_registry(&registry_path, &bundled_registry));
+        return bootstrap_registry(registry_path, &bundled_registry);
     }
 
-    // Load user registry, falling back to bundled on error
-    let user_registry = match load_from_file(&registry_path) {
+    let user_registry = match load_from_file(registry_path) {
         Ok(registry) => registry,
-        Err(e) => {
+        // Definitively corrupt: nothing can be recovered from the bytes on disk,
+        // so replacing them with the bundled copy is the repair rather than a
+        // loss. This is the behaviour that has always been here.
+        Err(e @ Error::RegistryParse { .. }) => {
             tracing::warn!(
-                "Failed to load user registry at {}: {}. Using bundled registry.",
+                "The model registry at {} could not be parsed: {}. Replacing it \
+                 with the bundled registry.",
                 registry_path.display(),
                 e
             );
-            // Overwrite corrupted file with bundled registry
-            persist_registry(&registry_path, &bundled_registry);
-            return Ok(bundled_registry);
+            persist_registry(registry_path, &bundled_registry);
+            return bundled_registry;
+        }
+        // Could not be READ, which says nothing about the contents: EACCES, EIO,
+        // EMFILE, a flaky network mount, fd exhaustion during a parallel batch.
+        // The file is very possibly intact, so it is used from the bundled copy
+        // in memory and left untouched on disk. Overwriting here was "could not
+        // determine, so assume the destructive answer", and it silently discarded
+        // hand-maintained registries that birda-gui also reads.
+        //
+        // The destructive branch is the one that has to name its variant, so an
+        // error variant added to `load_from_file` later defaults to this arm.
+        Err(e) => {
+            tracing::warn!(
+                "The model registry at {} could not be read: {}. Continuing with \
+                 the bundled registry; the file on disk is unchanged.",
+                registry_path.display(),
+                e
+            );
+            return bundled_registry;
         }
     };
 
@@ -41,10 +72,10 @@ pub fn load_registry() -> Result<Registry> {
             user_registry.registry_version,
             bundled_registry.registry_version
         );
-        persist_registry(&registry_path, &bundled_registry);
-        Ok(bundled_registry)
+        persist_registry(registry_path, &bundled_registry);
+        bundled_registry
     } else {
-        Ok(user_registry)
+        user_registry
     }
 }
 
@@ -298,6 +329,103 @@ mod tests {
             strays.is_empty(),
             "a successful write must not litter the config directory, found: {strays:?}"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_a_registry_that_could_not_be_read_is_left_alone() {
+        // #323. Every failure to LOAD used to be treated as grounds to overwrite
+        // the file with the bundled copy, and `load_from_file` returns two
+        // semantically different errors. An unreadable file (EACCES, EIO, a flaky
+        // network mount, fd exhaustion during a parallel batch) may be perfectly
+        // intact, and replacing it destroys any user-local edits with no message.
+        // birda-gui reads this file straight off disk, so a hand-maintained
+        // registry disappearing is a user-visible outcome, not a cache miss.
+        //
+        // Mode 0000 blocks the read but not the rename: rename needs write and
+        // execute on the DIRECTORY, not on the file. So the buggy version really
+        // does replace this file, and this assertion really does distinguish them.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let sentinel = serde_json::to_string_pretty(&versioned_registry(1)).unwrap();
+        std::fs::write(&path, &sentinel).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        if std::fs::read_to_string(&path).is_ok() {
+            eprintln!(
+                "skipped: this process can read a mode-0000 file (running as root, \
+                 or a filesystem that ignores modes), so the read-failure arm \
+                 cannot be reached here"
+            );
+            return;
+        }
+
+        let loaded = load_registry_from(&path, versioned_registry(99));
+
+        assert_eq!(
+            loaded.registry_version, 99,
+            "the caller must still get a usable registry, from the bundled copy"
+        );
+
+        // Widen it again so the assertion below can read it back.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            sentinel,
+            "an intact but unreadable registry must survive byte for byte; \
+             rewriting it destroys user-local edits for an error that says \
+             nothing about the file's contents"
+        );
+    }
+
+    #[test]
+    fn test_a_corrupt_registry_is_still_replaced() {
+        // The other half of #323, pinned so the fix cannot overshoot. A file that
+        // does not parse holds nothing worth keeping, and leaving it would wedge
+        // every run behind a permanent fallback that never repairs itself.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        std::fs::write(&path, b"{ this is not json").unwrap();
+
+        let loaded = load_registry_from(&path, versioned_registry(42));
+
+        assert_eq!(loaded.registry_version, 42);
+        assert_eq!(
+            version_at(&path),
+            42,
+            "a registry that cannot be parsed must be repaired on disk, not just \
+             in memory"
+        );
+    }
+
+    #[test]
+    fn test_a_newer_bundled_registry_replaces_the_cached_one() {
+        // The first launch after any upgrade that bumps the bundled registry
+        // takes this branch, so it is the most-travelled write path in the file.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        write_registry_file(&path, &versioned_registry(1)).unwrap();
+
+        let loaded = load_registry_from(&path, versioned_registry(2));
+
+        assert_eq!(loaded.registry_version, 2);
+        assert_eq!(version_at(&path), 2, "the cached copy must be updated too");
+    }
+
+    #[test]
+    fn test_a_registry_newer_than_the_bundled_one_is_kept() {
+        // The downgrade guard: a user whose registry.json is ahead of the binary
+        // (a newer birda ran, or they edited it) must not have it rolled back.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        write_registry_file(&path, &versioned_registry(9)).unwrap();
+
+        let loaded = load_registry_from(&path, versioned_registry(2));
+
+        assert_eq!(loaded.registry_version, 9);
+        assert_eq!(version_at(&path), 9, "the user's copy must survive");
     }
 
     #[test]

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -6,8 +6,18 @@ use std::path::PathBuf;
 
 /// Load registry from user config or bundled default.
 ///
-/// If a user registry exists but the bundled registry has a higher version,
-/// the user registry is replaced with the bundled version.
+/// Three outcomes, because the on-disk copy is a cache that can fail in two
+/// materially different ways:
+///
+/// - It is absent, older than the bundled registry, or not parseable by this
+///   binary: the bundled registry is written over it and returned.
+/// - It could not be READ (a permission or I/O failure, which says nothing about
+///   the contents): the bundled registry is returned and the file is left exactly
+///   as it is, so an intact registry survives a transient failure. Note the
+///   returned registry is then NOT what is on disk, and no version upgrade is
+///   persisted until the file becomes readable again.
+/// - Otherwise the user's copy is returned as is, including when it is NEWER than
+///   the bundled one.
 pub fn load_registry() -> Result<Registry> {
     let registry_path = registry_file_path()?;
     let bundled_registry = load_bundled_registry()?;
@@ -32,15 +42,20 @@ fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registr
 
     let user_registry = match load_from_file(registry_path) {
         Ok(registry) => registry,
-        // Definitively corrupt: nothing can be recovered from the bytes on disk,
-        // so replacing them with the bundled copy is the repair rather than a
-        // loss. This is the behaviour that has always been here.
+        // The bytes on disk are not a registry this binary can use, so replacing
+        // them with the bundled copy is the repair rather than a loss. This is the
+        // behaviour that has always been here.
+        //
+        // "Not usable by this binary" rather than "definitively corrupt", because
+        // this arm is wider than malformed JSON: every field of `ModelEntry` is
+        // required, so a registry.json written by a NEWER birda that added one
+        // also lands here and is replaced on a downgrade. That is the same
+        // outcome the version comparison below already gives an older binary, so
+        // it is consistent rather than surprising, but it is not corruption.
         Err(e @ Error::RegistryParse { .. }) => {
             tracing::warn!(
-                "The model registry at {} could not be parsed: {}. Replacing it \
-                 with the bundled registry.",
-                registry_path.display(),
-                e
+                "{e}{}. Replacing it with the bundled registry.",
+                cause_of(&e)
             );
             persist_registry(registry_path, &bundled_registry);
             return bundled_registry;
@@ -56,10 +71,9 @@ fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registr
         // error variant added to `load_from_file` later defaults to this arm.
         Err(e) => {
             tracing::warn!(
-                "The model registry at {} could not be read: {}. Continuing with \
-                 the bundled registry; the file on disk is unchanged.",
-                registry_path.display(),
-                e
+                "{e}{}. Continuing with the bundled registry; the file on disk is \
+                 left as it is and will be read again on the next run.",
+                cause_of(&e)
             );
             return bundled_registry;
         }
@@ -106,19 +120,51 @@ fn persist_registry(path: &std::path::Path, registry: &Registry) {
     }
 }
 
+/// The cause behind an error, rendered for a log line, or empty if it has none.
+///
+/// `thiserror` puts only the `#[error(...)]` string into `Display`, so `{e}` on
+/// these two variants names the path and stops. The `#[source]` is the part that
+/// tells the read arm's cases apart, and they want opposite responses: "Permission
+/// denied" is a chmod, "Input/output error" is a failing disk, "Too many open
+/// files" is a transient batch-run condition that will clear on its own. `main`
+/// walks this same chain for errors it returns (see its `caused by:` lines); these
+/// are warnings and never reach it, so they have to walk it themselves.
+fn cause_of(e: &Error) -> String {
+    std::error::Error::source(e).map_or_else(String::new, |source| format!(": {source}"))
+}
+
 /// Get path to registry file in user config.
 fn registry_file_path() -> Result<PathBuf> {
     Ok(crate::config::config_dir()?.join("registry.json"))
 }
 
 /// Load registry from existing file.
+///
+/// Bytes rather than `read_to_string`, and `from_slice` rather than `from_str`,
+/// because which of the two errors this returns is now a behavioural decision
+/// rather than a label: [`load_registry_from`] repairs a file it can only fail to
+/// PARSE and preserves one it could only fail to READ.
+///
+/// `read_to_string` breaks that split. It validates UTF-8 and reports a failure as
+/// `io::ErrorKind::InvalidData`, so bytes that are definitively not a registry
+/// arrived as a transport error and the file was never repaired: a warning on
+/// every run, no version upgrade, and no route back short of deleting the file by
+/// hand. The reachable sources are ordinary rather than exotic. A registry.json
+/// saved from Notepad as "Unicode" or written by PowerShell 5.1's `>` is UTF-16;
+/// one round-tripped through a cp1252 editor mangles the `ä` this project's own
+/// bundled registry carries; and a pre-atomic-write birda killed mid-write could
+/// truncate one mid-codepoint.
+///
+/// `from_slice` validates UTF-8 as part of parsing, so those all surface as the
+/// parse errors they are. `RegistryRead` is then only ever a failure to obtain the
+/// bytes, which is what the caller's non-destructive arm assumes.
 fn load_from_file(path: &std::path::Path) -> Result<Registry> {
-    let content = std::fs::read_to_string(path).map_err(|e| Error::RegistryRead {
+    let content = std::fs::read(path).map_err(|e| Error::RegistryRead {
         path: path.to_path_buf(),
         source: e,
     })?;
 
-    serde_json::from_str(&content).map_err(|e| Error::RegistryParse {
+    serde_json::from_slice(&content).map_err(|e| Error::RegistryParse {
         path: path.to_path_buf(),
         source: e,
     })
@@ -214,8 +260,21 @@ mod tests {
     }
 
     /// The `registry_version` recorded in the file at `path`.
+    ///
+    /// Panics with the load error and its cause rather than through a bare
+    /// `unwrap`, because for the repair tests the interesting failure IS the file
+    /// failing to load: an unwrap there reports this helper's frame and swallows
+    /// the caller's authored assertion message, which is the one that explains
+    /// what the test was pinning.
     fn version_at(path: &std::path::Path) -> u32 {
-        load_from_file(path).unwrap().registry_version
+        match load_from_file(path) {
+            Ok(registry) => registry.registry_version,
+            Err(e) => panic!(
+                "{} could not be loaded back{}",
+                path.display(),
+                super::cause_of(&e)
+            ),
+        }
     }
 
     #[test]
@@ -353,7 +412,17 @@ mod tests {
         std::fs::write(&path, &sentinel).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        if std::fs::read_to_string(&path).is_ok() {
+        if std::fs::read(&path).is_ok() {
+            // A silent skip here is a green test that asserted nothing. On a
+            // developer's machine (a root shell, or a filesystem that ignores
+            // modes) that is worth tolerating; on a runner it means this arm has
+            // zero coverage and nobody would ever find out, so fail loudly there.
+            assert!(
+                std::env::var_os("CI").is_none(),
+                "this runner can read a mode-0000 file, so the read-failure arm is \
+                 not being exercised at all; the fixture needs rethinking for this \
+                 environment rather than reporting a pass"
+            );
             eprintln!(
                 "skipped: this process can read a mode-0000 file (running as root, \
                  or a filesystem that ignores modes), so the read-failure arm \
@@ -377,6 +446,42 @@ mod tests {
             "an intact but unreadable registry must survive byte for byte; \
              rewriting it destroys user-local edits for an error that says \
              nothing about the file's contents"
+        );
+    }
+
+    #[test]
+    fn test_a_registry_whose_bytes_are_not_utf8_is_repaired() {
+        // The bytes being invalid UTF-8 is a verdict on the CONTENTS, so it has to
+        // reach the repair arm. It did not while `load_from_file` used
+        // `read_to_string`, which reports that as `io::ErrorKind::InvalidData` and
+        // therefore as `RegistryRead`: the file was left alone forever, warning on
+        // every run, never upgraded, with no route back except deleting it by hand.
+        //
+        // Deliberately NOT `#[cfg(unix)]`. The reachable ways to produce this file
+        // are mostly Windows ones (Notepad's "Unicode" is UTF-16, so is PowerShell
+        // 5.1's `>`), and CI runs tests on Linux only, so gating this would leave
+        // the platform that triggers it with no coverage at all.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+
+        // Valid JSON shape; one byte inside a string value is not valid UTF-8, so
+        // the ONLY reason this fails to load is the encoding.
+        let mut bytes = br#"{"schema_version":"1.0","registry_version":1,"models":[]}"#.to_vec();
+        bytes[20] = 0xFF;
+        assert!(
+            String::from_utf8(bytes.clone()).is_err(),
+            "the fixture must actually be invalid UTF-8, or this test proves nothing"
+        );
+        std::fs::write(&path, &bytes).unwrap();
+
+        let loaded = load_registry_from(&path, versioned_registry(42));
+
+        assert_eq!(loaded.registry_version, 42);
+        assert_eq!(
+            version_at(&path),
+            42,
+            "bytes that are not UTF-8 cannot be a registry, so the file must be \
+             repaired rather than preserved as possibly-intact"
         );
     }
 
@@ -412,6 +517,57 @@ mod tests {
 
         assert_eq!(loaded.registry_version, 2);
         assert_eq!(version_at(&path), 2, "the cached copy must be updated too");
+    }
+
+    #[test]
+    fn test_a_missing_registry_is_bootstrapped_onto_disk() {
+        // The first-run branch, and the only path through the resolver the other
+        // tests never reach. A bootstrap that returned the right registry without
+        // ever writing it would have passed every one of them.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        assert!(!path.exists(), "the fixture must start with no registry");
+
+        let loaded = load_registry_from(&path, versioned_registry(7));
+
+        assert_eq!(loaded.registry_version, 7);
+        assert_eq!(
+            version_at(&path),
+            7,
+            "a first run must leave the registry cached on disk, not only in memory"
+        );
+    }
+
+    #[test]
+    fn test_an_equal_version_is_not_an_upgrade_and_rewrites_nothing() {
+        // Two ways to break this are invisible to the newer/older pair, because
+        // neither of those lands on the boundary: widening `>` to `>=`, and a keep
+        // path that rewrites the file anyway. Both would rewrite the user's
+        // registry.json on EVERY run at steady state, which is the state nearly
+        // every install is in, discarding local edits each time.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        write_registry_file(&path, &versioned_registry(5)).unwrap();
+
+        // A byte the resolver has no reason to touch. The registry round-trips
+        // exactly, so a rewrite would be byte-identical and undetectable without
+        // one: trailing whitespace survives a read but not a re-serialize.
+        let marked = format!("{}\n\n", std::fs::read_to_string(&path).unwrap());
+        std::fs::write(&path, &marked).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        let loaded = load_registry_from(&path, versioned_registry(5));
+
+        assert_eq!(
+            loaded.registry_version, 5,
+            "the cached copy must be returned"
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "an equal version is not an upgrade, so the file must be left byte for \
+             byte alone"
+        );
     }
 
     #[test]

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -47,11 +47,13 @@ fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registr
         // behaviour that has always been here.
         //
         // "Not usable by this binary" rather than "definitively corrupt", because
-        // this arm is wider than malformed JSON: every field of `ModelEntry` is
-        // required, so a registry.json written by a NEWER birda that added one
-        // also lands here and is replaced on a downgrade. That is the same
-        // outcome the version comparison below already gives an older binary, so
-        // it is consistent rather than surprising, but it is not corruption.
+        // this arm is wider than malformed JSON. Nothing here sets
+        // `deny_unknown_fields`, so a registry from a NEWER birda that ADDED a
+        // field parses fine and is kept; what lands here is one that REMOVED or
+        // renamed a field this binary still requires, on a downgrade. Bytes in a
+        // text encoding other than UTF-8 land here too, since they cannot be a
+        // registry for any consumer. None of those is corruption, and all of them
+        // are replaced.
         Err(e @ Error::RegistryParse { .. }) => {
             tracing::warn!(
                 "{e}{}. Replacing it with the bundled registry.",
@@ -112,10 +114,15 @@ fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registr
 /// every single run because the file on disk never gets updated.
 fn persist_registry(path: &std::path::Path, registry: &Registry) {
     if let Err(e) = write_registry_file(path, registry) {
+        // Through `cause_of` like the two arms above, and this is the site that
+        // needs it most: the doc below names a read-only config directory and a
+        // bind-mounted registry.json as real layouts, and EROFS, EBUSY and EACCES
+        // want three different responses from the user. Without the cause the
+        // message named the path twice and the reason not at all.
         tracing::warn!(
-            "Could not save the model registry to {}: {e}. Continuing with the bundled \
-             registry; this will be retried on the next run.",
-            path.display()
+            "{e}{}. Continuing with the bundled registry; this will be retried on \
+             the next run.",
+            cause_of(&e)
         );
     }
 }
@@ -155,9 +162,13 @@ fn registry_file_path() -> Result<PathBuf> {
 /// bundled registry carries; and a pre-atomic-write birda killed mid-write could
 /// truncate one mid-codepoint.
 ///
-/// `from_slice` validates UTF-8 as part of parsing, so those all surface as the
-/// parse errors they are. `RegistryRead` is then only ever a failure to obtain the
-/// bytes, which is what the caller's non-destructive arm assumes.
+/// `from_slice` validates UTF-8 in every string it materialises, so all of those
+/// surface as the parse errors they are, and `RegistryRead` is left meaning a
+/// failure to obtain the bytes, which is what the caller's non-destructive arm
+/// assumes. Measured limit, stated rather than glossed: a string in a field the
+/// deserializer IGNORES is skipped without a UTF-8 check, so bad bytes there are
+/// accepted instead of repaired. That is the harmless direction (nothing is
+/// destroyed), but a field promoted from ignored to used would inherit it.
 fn load_from_file(path: &std::path::Path) -> Result<Registry> {
     let content = std::fs::read(path).map_err(|e| Error::RegistryRead {
         path: path.to_path_buf(),
@@ -261,19 +272,21 @@ mod tests {
 
     /// The `registry_version` recorded in the file at `path`.
     ///
-    /// Panics with the load error and its cause rather than through a bare
-    /// `unwrap`, because for the repair tests the interesting failure IS the file
-    /// failing to load: an unwrap there reports this helper's frame and swallows
-    /// the caller's authored assertion message, which is the one that explains
-    /// what the test was pinning.
+    /// For the repair tests the interesting failure IS the file failing to load
+    /// back, so the panic has to carry which of the two failures it was. `{e}`
+    /// gives that plus the path (once), and `cause_of` gives the errno or the
+    /// serde detail. A bare `unwrap` reported the variant but no cause; panicking
+    /// without `{e}` reported the cause but lost the classification this whole
+    /// module exists to draw.
+    ///
+    /// `#[track_caller]` because the panic location is otherwise this helper
+    /// rather than the assertion that called it, which is what makes an `unwrap`
+    /// in a shared test helper hard to place.
+    #[track_caller]
     fn version_at(path: &std::path::Path) -> u32 {
         match load_from_file(path) {
             Ok(registry) => registry.registry_version,
-            Err(e) => panic!(
-                "{} could not be loaded back{}",
-                path.display(),
-                super::cause_of(&e)
-            ),
+            Err(e) => panic!("{e}{}", super::cause_of(&e)),
         }
     }
 
@@ -413,16 +426,15 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         if std::fs::read(&path).is_ok() {
-            // A silent skip here is a green test that asserted nothing. On a
-            // developer's machine (a root shell, or a filesystem that ignores
-            // modes) that is worth tolerating; on a runner it means this arm has
-            // zero coverage and nobody would ever find out, so fail loudly there.
-            assert!(
-                std::env::var_os("CI").is_none(),
-                "this runner can read a mode-0000 file, so the read-failure arm is \
-                 not being exercised at all; the fixture needs rethinking for this \
-                 environment rather than reporting a pass"
-            );
+            // A silent skip: `cargo test` hides a passing test's output, so this
+            // reports ok while asserting nothing. Tolerated rather than made
+            // fatal, because the only discriminator available in here is ambient.
+            // Gating on `CI` was tried and reverted: act, GitLab, Drone and any
+            // `docker run -e CI=true` all set it AND run as root, so it reddened
+            // a contributor's suite over an environment fact that says nothing
+            // about their change, while never firing on this project's own
+            // ubuntu-latest runner, which is not root. Making the skip loud needs
+            // a marker this repo owns, set in ci.yml's test job.
             eprintln!(
                 "skipped: this process can read a mode-0000 file (running as root, \
                  or a filesystem that ignores modes), so the read-failure arm \
@@ -517,6 +529,39 @@ mod tests {
 
         assert_eq!(loaded.registry_version, 2);
         assert_eq!(version_at(&path), 2, "the cached copy must be updated too");
+    }
+
+    #[test]
+    fn test_cause_of_renders_the_source_rather_than_the_error_itself() {
+        // The three warnings in this file are the user's only account of what
+        // happened to their registry, and `thiserror` puts only the `#[error(..)]`
+        // string into Display, so without this the errno never reaches them:
+        // "Permission denied" wants a chmod and "Input/output error" wants a
+        // different disk. Asserted on the function, not on the emitted log line,
+        // because the crate carries no log-capture dev-dependency.
+        let source = || std::io::Error::from_raw_os_error(13);
+        let denied = Error::RegistryRead {
+            path: std::path::PathBuf::from("/tmp/registry.json"),
+            source: source(),
+        };
+
+        // Compared against a freshly built io::Error rather than a literal, so
+        // the assertion does not depend on the platform's wording for EACCES.
+        assert_eq!(
+            cause_of(&denied),
+            format!(": {}", source()),
+            "the cause must be the SOURCE, not the error's own Display, which \
+             names only the path"
+        );
+
+        // The empty branch, which nothing else reaches: an error with no
+        // `#[source]` must not leave a bare colon dangling on the message.
+        assert_eq!(
+            cause_of(&Error::Internal {
+                message: "no source behind this one".into()
+            }),
+            ""
+        );
     }
 
     #[test]

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -36,8 +36,32 @@ pub fn load_registry() -> Result<Registry> {
 /// bundled registry, which is in hand before this is called, so there is nothing
 /// left that could justify aborting the command that asked for it.
 fn load_registry_from(registry_path: &std::path::Path, bundled_registry: Registry) -> Registry {
-    if !registry_path.exists() {
-        return bootstrap_registry(registry_path, &bundled_registry);
+    // `try_exists` rather than `exists`, which folds every stat failure into
+    // "absent" and would hand an intact registry to the branch that REPLACES it.
+    // That is the same two-way collapse the error arms below exist to undo, three
+    // lines earlier in the same function, so it gets the same three outcomes:
+    // present, definitively absent, or could not determine and therefore do not
+    // act.
+    //
+    // Only the third outcome changes. `Ok(true)` and `Ok(false)` behave exactly as
+    // before, including for a dangling symlink, which reports `Ok(false)` and is
+    // still bootstrapped over (the pre-existing behaviour `write_registry_file`
+    // documents). The reachable permission case was already self-protecting: an
+    // EACCES that breaks the stat breaks the subsequent write too, so the old code
+    // was saved by the write failing rather than by the check. What it did not
+    // cover is a failure that breaks stat on the inode but not create-and-rename in
+    // its directory, such as an ESTALE after an NFS server restart.
+    match registry_path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return bootstrap_registry(registry_path, &bundled_registry),
+        Err(e) => {
+            tracing::warn!(
+                "Could not determine whether the model registry at {} exists: {e}. \
+                 Continuing with the bundled registry; nothing on disk is touched.",
+                registry_path.display()
+            );
+            return bundled_registry;
+        }
     }
 
     let user_registry = match load_from_file(registry_path) {


### PR DESCRIPTION
Closes #323.

Relates to #342: this fixes item 1 of that issue (a failed `finalize_download` orphaning its `.part` file) and nothing else. Items 2, 3 and 4 stay open, so #342 is deliberately not closed here. Both changes are the same defect class in the same module, `src/registry/`: a failure path that took the destructive or wasteful branch because it could not tell two situations apart.

Two failure paths that took the destructive or wasteful branch because they could not tell two situations apart.

## #323: a registry that could not be READ was replaced

`load_registry` treated every failure out of `load_from_file` as grounds to overwrite `registry.json` with the bundled copy. That function returns two semantically different errors and the arm could not distinguish them: `RegistryParse` means the file is not a registry, where replacing it is the repair, but `RegistryRead` is an I/O failure (EACCES, EIO, EMFILE, a flaky network mount, fd exhaustion during a parallel batch) that says nothing about the contents. The file was very possibly intact and was destroyed anyway, taking any local edits with it, with a warning as the only trace. birda-gui reads this file straight off disk, so a hand-maintained registry disappearing is user visible.

The parse arm keeps today behaviour. Everything else now uses the bundled registry in memory and leaves the file alone, so an error variant added later defaults to the non-destructive branch rather than the destructive one.

## #342 item 1: a failed publish orphaned its part file

`download_verified` has three failure paths after the temp file exists. The stream-failure and checksum-failure paths both remove it; the rename path propagated with no cleanup. `part_path` qualifies the name with the process id, so the next attempt picks a different name and never reclaims the old one, and `find_obsolete_files` matches a fixed list of names that does not include it. Model files are tens to hundreds of MB, so a user whose disk fills, or who hits the documented EBUSY on a bind-mounted destination, silently lost that much space per attempt with no way to find it short of `find`. Cleanup now runs through `roll_back`, which this file already uses for the same job and which reports the path when the unlink itself fails.

## A regression the review caught, and the fix for it

The first version of the #323 fix split on the error variant, but `read_to_string` validates UTF-8 and reports a failure as `io::ErrorKind::InvalidData`, so it arrived as `RegistryRead`. That put a definitively corrupt registry on the preserve side: never repaired, never upgraded, warning on every run, no route back but deleting the file by hand. The triggers are ordinary rather than exotic. Notepad "Unicode" and PowerShell 5.1 `>` both write UTF-16; a cp1252 round trip mangles the a-umlaut the bundled registry already carries; a pre-atomic-write birda killed mid-write could truncate one mid-codepoint.

Reading bytes and parsing bytes puts the split on the contents-versus-transport axis with no special case, so `RegistryRead` now means only a failure to obtain the bytes. One measured limit is stated in the code: `from_slice` does not validate UTF-8 inside a field the deserializer ignores, which is the harmless direction (such a file is accepted, not destroyed).

## Warnings

All three warnings in the file now render the error and its cause instead of a hand-built string, so the path appears once and the errno appears at all. `thiserror` puts only the `#[error(..)]` text into `Display`, so previously "could not be read" was the whole message and EACCES, EIO and EMFILE, which want three different responses, were indistinguishable. Verified against the built binary:

```
failed to read registry file X: Permission denied (os error 13). Continuing with the bundled registry; the file on disk is left as it is and will be read again on the next run.
failed to parse registry file X: key must be a string at line 1 column 3. Replacing it with the bundled registry.
failed to write registry file X: Permission denied (os error 13). Continuing with the bundled registry; this will be retried on the next run.
```

## Behaviour change worth a second opinion

Against `main` there is no on-disk state where this branch is worse; every state it replaces, `main` replaced too. Against the intermediate commit in this branch, a structurally intact hand-maintained registry in UTF-16 or cp1252 is now replaced rather than preserved. That is deliberate (those bytes are not JSON for any consumer, birda-gui included) and is documented in the README, but it is the one square where reasonable people could want the other answer.

Separately, rendering the parse error cause means serde can quote a value from the file into a warning, for example `invalid type: string "..." , expected u32`. `registry.json` is the model catalogue rather than a secret store, but it is hand-edited and private mirrors are supported, so it is worth knowing that stderr can now carry a fragment of the file.

## Tests

The two behavioural fixes were written test-first and each new test was confirmed to fail against the pre-fix code before the fix landed. The UTF-16 class is pinned by a test that is deliberately not `cfg(unix)`, because the ways to produce it are mostly Windows ones and CI runs tests on Linux only (#315). The Windows rename-onto-a-directory behaviour the installer test rests on was verified on a real Windows 11 VM (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` returns `ERROR_ACCESS_DENIED`) rather than inferred, so the test is portable even though nothing runs it there.

Also pinned, after mutation testing showed they survived: the equal-version boundary, a keep path that rewrites the file anyway, the first-run bootstrap write, an error naming the part file instead of the destination, and `cause_of` itself.

`cargo fmt --check`, `cargo clippy --no-default-features --all-targets -- -D warnings` and `cargo test --no-default-features` are clean; 658 tests pass.

## Filed rather than fixed here

Pre-existing findings from the same review, all out of scope: #347, #348, #349, #350 and the batched #351.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry recovery when cached files are unreadable, corrupted, invalidly encoded, or outdated.
  * Preserved unreadable registry files while using the bundled registry for the current run.
  * Added clearer warnings that include the underlying cause of registry loading or persistence failures.
  * Cleaned up temporary download files when installation publication fails.
  * Ensured failed downloads report the correct installation destination and can be retried safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
