### PR TITLE
fix: tell a geomodel read error apart from a checksum mismatch, and stop deleting a correct model

### DIFF
--- a/src/config/geomodel.rs
+++ b/src/config/geomodel.rs
@@ -123,14 +123,24 @@ pub fn resolve_geomodel(
         // A path pointing somewhere else is taken on trust: it may legitimately
         // be a different build of the geomodel, and its checksum is not ours to
         // police. The label-count check still guards the shape.
-        if !birda_managed || paths.verify(asset).is_ok() {
+        if !birda_managed {
             return Ok(GeomodelResolution::Ready(paths));
         }
 
-        warn!(
-            "Installed {} failed checksum verification and will be downloaded again",
-            asset.name
-        );
+        match paths.verify(asset) {
+            Ok(()) => return Ok(GeomodelResolution::Ready(paths)),
+            // A genuine mismatch: the cached bytes are wrong, re-download them.
+            Err(e) if crate::update::checksum::is_checksum_mismatch(&e) => {
+                warn!(
+                    "Installed {} failed checksum verification and will be downloaded again",
+                    asset.name
+                );
+            }
+            // A read error (permission/IO) is not a checksum failure. Naming it
+            // one is wrong, and re-downloading a file that is fine will not fix
+            // a failing disk. Surface the real error instead.
+            Err(e) => return Err(e),
+        }
     }
 
     // A configured path pointing outside the models directory is a

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -341,8 +341,16 @@ pub fn geomodel_paths(asset: &RangeFilterAsset) -> Result<InstalledRangeFilter> 
 /// likeliest cause is a file left behind by an older birda version.
 pub async fn install_range_filter(asset: &RangeFilterAsset) -> Result<InstalledRangeFilter> {
     let paths = geomodel_paths(asset)?;
-    if paths.is_installed() && paths.verify(asset).is_ok() {
-        return Ok(paths);
+    if paths.is_installed() {
+        match paths.verify(asset) {
+            Ok(()) => return Ok(paths),
+            // A read error on an installed file is not proof it is wrong, and
+            // re-downloading hundreds of MB will not fix a failing disk. Surface
+            // it, mirroring `resolve_geomodel`, rather than silently redownload
+            // a copy that is fine. Only a genuine mismatch falls through.
+            Err(e) if !crate::update::checksum::is_checksum_mismatch(&e) => return Err(e),
+            Err(_) => {}
+        }
     }
 
     let dir = models_dir()?;
@@ -352,16 +360,30 @@ pub async fn install_range_filter(asset: &RangeFilterAsset) -> Result<InstalledR
     download_file(&client, &asset.model.url, &paths.model).await?;
     download_file(&client, &asset.labels.url, &paths.labels).await?;
 
-    // A post-download checksum failure must not leave the bad files installed.
-    // Consumers gate on presence, so a corrupt file left behind here would be
-    // loaded on every later run without ever being re-verified.
-    if let Err(e) = paths.verify(asset) {
-        drop(std::fs::remove_file(&paths.model));
-        drop(std::fs::remove_file(&paths.labels));
-        return Err(e);
-    }
+    verify_or_remove(&paths, asset)?;
 
     Ok(paths)
+}
+
+/// Verify freshly-downloaded range-filter files, removing them only on a
+/// genuine checksum mismatch.
+///
+/// Consumers gate on presence, so a corrupt file left behind here would be
+/// loaded on every later run without ever being re-verified; a genuine
+/// [`Error::UpdateChecksumMismatch`] therefore removes both files so the caller
+/// downloads a fresh copy. A read error (EACCES/EIO on a failing disk) is not
+/// proof the bytes are wrong: removing a possibly-correct model to force a
+/// re-download is destructive and loops on failing hardware, so on that error
+/// the files are left in place and the error surfaced.
+fn verify_or_remove(paths: &InstalledRangeFilter, asset: &RangeFilterAsset) -> Result<()> {
+    if let Err(e) = paths.verify(asset) {
+        if crate::update::checksum::is_checksum_mismatch(&e) {
+            drop(std::fs::remove_file(&paths.model));
+            drop(std::fs::remove_file(&paths.labels));
+        }
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// Report files in the models directory that birda no longer uses.
@@ -701,6 +723,55 @@ mod tests {
         roll_back(&[&created]);
 
         assert!(!created.exists());
+    }
+
+    #[test]
+    fn test_verify_or_remove_leaves_files_intact_on_a_read_error() {
+        // The #348 data-loss regression guard: a read error (here EISDIR, a
+        // portable stand-in for the EACCES/EIO seen on a failing disk) must not
+        // be mistaken for a checksum mismatch and delete a possibly-correct
+        // model. The model is a valid regular file and the labels are the
+        // unreadable one, so the model assertion is load-bearing: reverting the
+        // `is_checksum_mismatch` gate deletes the real model file and turns this
+        // red, which the predicate-only tests do not catch.
+        let dir = tempfile::tempdir().unwrap();
+
+        // The model reads and verifies fine; the read error is on the labels.
+        let model = dir.path().join("model.onnx");
+        std::fs::write(&model, b"right").unwrap(); // matches RIGHT_SHA256
+        // A directory cannot be read as a file, so `verify` fails with Error::Io.
+        let labels = dir.path().join("labels");
+        std::fs::create_dir(&labels).unwrap();
+        let paths = InstalledRangeFilter { model, labels };
+
+        let err = verify_or_remove(&paths, &test_asset()).expect_err("a read error must surface");
+        assert!(
+            !crate::update::checksum::is_checksum_mismatch(&err),
+            "a read error is not a checksum mismatch"
+        );
+        assert!(
+            paths.model.exists(),
+            "the readable model must not be deleted"
+        );
+        assert!(paths.labels.exists(), "the labels must not be deleted");
+    }
+
+    #[test]
+    fn test_verify_or_remove_deletes_both_files_on_a_mismatch() {
+        // The complement: a genuine mismatch is the one case that legitimately
+        // removes the files, so the caller can download a fresh copy.
+        let dir = tempfile::tempdir().unwrap();
+
+        let model = dir.path().join("model.onnx");
+        std::fs::write(&model, b"wrong").unwrap(); // does not match RIGHT_SHA256
+        let labels = dir.path().join("labels.txt");
+        std::fs::write(&labels, b"right").unwrap();
+        let paths = InstalledRangeFilter { model, labels };
+
+        let err = verify_or_remove(&paths, &test_asset()).expect_err("a mismatch must surface");
+        assert!(crate::update::checksum::is_checksum_mismatch(&err));
+        assert!(!paths.model.exists(), "a corrupt model must be removed");
+        assert!(!paths.labels.exists(), "its labels must be removed with it");
     }
 
     // HF_ENDPOINT is process-global, so these run serially against every other

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -26,6 +26,21 @@ pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
     Ok(())
 }
 
+/// Report whether a verification error is a genuine content mismatch.
+///
+/// `verify_sha256` fails two ways that must not be treated alike. A
+/// [`Error::UpdateChecksumMismatch`] proves the bytes on disk are wrong, so a
+/// caller may safely delete them and download again. A [`Error::Io`] means the
+/// file could not even be read (EACCES, EIO on a failing disk or SD card): that
+/// is not proof the bytes are bad, and deleting a possibly-correct model to
+/// re-download hundreds of MB is destructive and, on failing hardware, loops.
+///
+/// Call sites that react to a failed verification by removing files or
+/// re-downloading must gate that action on this returning `true`.
+pub fn is_checksum_mismatch(err: &Error) -> bool {
+    matches!(err, Error::UpdateChecksumMismatch { .. })
+}
+
 /// Compute the SHA256 hex digest of raw bytes.
 fn hex_digest(data: &[u8]) -> String {
     let hash = Sha256::digest(data);
@@ -42,6 +57,10 @@ fn hex_digest(data: &[u8]) -> String {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    /// A hash no real content produces, used to force a deterministic mismatch.
+    const ALL_ZERO_SHA256: &str =
+        "0000000000000000000000000000000000000000000000000000000000000000";
 
     #[test]
     fn test_hex_digest_known_value() {
@@ -82,10 +101,42 @@ mod tests {
         f.write_all(b"test content").expect("test setup failed");
         drop(f);
 
-        let result = verify_sha256(
-            &path,
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        );
+        let result = verify_sha256(&path, ALL_ZERO_SHA256);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_sha256_read_error_is_io_not_mismatch() {
+        // A directory cannot be read as a file: `std::fs::read` returns EISDIR.
+        // This stands in for the EACCES/EIO read failures on failing hardware,
+        // and locks the contract that a read failure surfaces as `Error::Io`,
+        // never as a spurious checksum mismatch.
+        let dir = tempfile::tempdir().expect("test setup failed");
+
+        let result = verify_sha256(dir.path(), ALL_ZERO_SHA256);
+        assert!(matches!(result, Err(Error::Io(_))));
+    }
+
+    #[test]
+    fn test_is_checksum_mismatch_true_for_mismatch() {
+        let dir = tempfile::tempdir().expect("test setup failed");
+        let path = dir.path().join("test.bin");
+        let mut f = std::fs::File::create(&path).expect("test setup failed");
+        f.write_all(b"test content").expect("test setup failed");
+        drop(f);
+
+        let err =
+            verify_sha256(&path, ALL_ZERO_SHA256).expect_err("mismatched checksum should fail");
+        assert!(is_checksum_mismatch(&err));
+    }
+
+    #[test]
+    fn test_is_checksum_mismatch_false_for_read_error() {
+        // The destructive delete-and-redownload must not fire on a read error.
+        let dir = tempfile::tempdir().expect("test setup failed");
+
+        let err = verify_sha256(dir.path(), ALL_ZERO_SHA256)
+            .expect_err("reading a directory as a file should fail");
+        assert!(!is_checksum_mismatch(&err));
     }
 }


### PR DESCRIPTION
## What

Fixes #348: a read error while verifying an already-installed geomodel was treated as a checksum mismatch, so birda deleted a correct model plus its labels and re-downloaded them. On failing hardware that turns into a delete-and-redownload loop.

`verify_sha256` already returns `Error::Io` for a read failure and `Error::UpdateChecksumMismatch` for a genuine mismatch, but both geomodel verification sites collapsed the two into one reaction:

- `install_range_filter` deleted the model and labels on *any* verify error, and its pre-download idempotency check (`is_installed() && verify().is_ok()`) re-downloaded hundreds of MB on a read error too.
- `resolve_geomodel` used `.is_ok()`, so an EIO/EACCES read error was logged as "failed checksum verification" and triggered a re-download of a file that was fine.

A read error is not proof the bytes are wrong: re-downloading cannot fix a failing disk or a flaky SD card, and deleting a possibly-correct model is destructive.

## How

- Added a shared `is_checksum_mismatch(&Error)` predicate next to `verify_sha256`, documented so future call sites know to gate destructive or re-downloading reactions on it.
- `install_range_filter` now removes the files only on a genuine mismatch, at both its pre-download check and its post-download check. The post-download verify-and-conditionally-delete step is extracted into a small sync `verify_or_remove` helper so the delete decision is unit-testable.
- `resolve_geomodel` re-downloads only on a genuine mismatch and otherwise surfaces the real read error. On the analyze path this only changes the warning text (range filtering still degrades gracefully); `birda species`, where the species list is the output, still treats an unavailable geomodel as fatal.
- `install_variant` is intentionally unchanged: its rollback is already guarded by `!model_existed`, so it only removes a model this install just created, never a pre-existing correct one.

## Tests

- `verify_sha256` on an unreadable path surfaces as `Error::Io`, never a spurious mismatch (a directory path forces the read error portably, including as root, where a `chmod 000` trick would false-pass).
- `is_checksum_mismatch` is true only for a real mismatch and false for a read error.
- `verify_or_remove` leaves both files intact on a read error and removes both only on a genuine mismatch. These are the direct regression guards for the data-loss behavior; reverting either gate turns them red.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test` suite all pass.
