### PR TITLE
fix: hash model files in a streaming loop to bound checksum-verification memory (#355)

### DIFF
--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -2,15 +2,17 @@
 
 use crate::error::{Error, Result};
 use sha2::{Digest, Sha256};
+use std::io::Read;
 use std::path::Path;
 
 /// Verify that a file's SHA256 hash matches the expected hex digest.
 ///
-/// Returns `Ok(())` if the checksum matches. Returns `Err(UpdateChecksumMismatch)`
-/// if it doesn't.
+/// Returns `Ok(())` if the checksum matches, `Err(UpdateChecksumMismatch)` if it
+/// does not, and `Err(Error::Io)` if the file cannot be read. Callers gate a
+/// destructive re-download on [`is_checksum_mismatch`], so the read-error case
+/// must stay distinct from a content mismatch.
 pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
-    let file_bytes = std::fs::read(path).map_err(Error::Io)?;
-    let actual_hex = hex_digest(&file_bytes);
+    let actual_hex = hash_file(path)?;
 
     if actual_hex != expected_hex.to_ascii_lowercase() {
         return Err(Error::UpdateChecksumMismatch {
@@ -41,10 +43,36 @@ pub fn is_checksum_mismatch(err: &Error) -> bool {
     matches!(err, Error::UpdateChecksumMismatch { .. })
 }
 
-/// Compute the SHA256 hex digest of raw bytes.
-fn hex_digest(data: &[u8]) -> String {
-    let hash = Sha256::digest(data);
-    // Format each byte as two lowercase hex characters
+/// Compute the SHA256 hex digest of a file, streaming it through a fixed-size
+/// buffer so peak memory stays bounded to
+/// [`HASH_CHUNK_BYTES`](super::constants::HASH_CHUNK_BYTES) regardless of the
+/// file's length. Hashing a several-hundred-MB model therefore never
+/// materialises the whole file in memory.
+///
+/// A read failure surfaces as [`Error::Io`], never as a spurious mismatch, which
+/// the delete-and-redownload callers rely on (see [`is_checksum_mismatch`]).
+fn hash_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path).map_err(Error::Io)?;
+    let mut hasher = Sha256::new();
+    // Heap-allocated so the buffer does not sit on the stack; a single 64 KiB
+    // allocation per call is negligible next to the file read it serves.
+    let mut buf = vec![0u8; super::constants::HASH_CHUNK_BYTES];
+    loop {
+        // Retry on EINTR, matching std::fs::read's read_to_end: a signal
+        // interrupting the read must not abort verification.
+        let read = match file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(Error::Io(e)),
+        };
+        hasher.update(&buf[..read]);
+    }
+    Ok(format_hex(hasher.finalize().as_slice()))
+}
+
+/// Format a hash digest as a lowercase hex string.
+fn format_hex(hash: &[u8]) -> String {
     hash.iter()
         .fold(String::with_capacity(64), |mut acc, byte| {
             use std::fmt::Write;
@@ -62,21 +90,24 @@ mod tests {
     const ALL_ZERO_SHA256: &str =
         "0000000000000000000000000000000000000000000000000000000000000000";
 
+    /// Hash raw bytes to a lowercase hex SHA256, for computing expected values.
+    fn sha256_hex(data: &[u8]) -> String {
+        format_hex(Sha256::digest(data).as_slice())
+    }
+
     #[test]
-    fn test_hex_digest_known_value() {
-        // SHA256 of empty string
-        let hash = hex_digest(b"");
+    fn test_sha256_hex_empty_string() {
+        // SHA256 of the empty string
         assert_eq!(
-            hash,
+            sha256_hex(b""),
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
     }
 
     #[test]
-    fn test_hex_digest_hello_world() {
-        let hash = hex_digest(b"hello world");
+    fn test_sha256_hex_hello_world() {
         assert_eq!(
-            hash,
+            sha256_hex(b"hello world"),
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         );
     }
@@ -89,8 +120,52 @@ mod tests {
         f.write_all(b"test content").expect("test setup failed");
         drop(f);
 
-        let expected = hex_digest(b"test content");
+        let expected = sha256_hex(b"test content");
         assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_streams_file_larger_than_chunk() {
+        use crate::update::constants::HASH_CHUNK_BYTES;
+        // A file spanning several read buffers, ending on a partial chunk. This
+        // pins that the hasher is fed only the bytes actually read (buf[..n])
+        // and accumulates across chunk boundaries: a whole-buffer bug would
+        // corrupt the digest of any file whose size is not a chunk multiple.
+        let dir = tempfile::tempdir().expect("test setup failed");
+        let path = dir.path().join("multi_chunk.bin");
+        let size = HASH_CHUNK_BYTES * 2 + HASH_CHUNK_BYTES / 2 + 7;
+        let pattern = b"BIRDA";
+        let content: Vec<u8> = (0..size).map(|i| pattern[i % pattern.len()]).collect();
+        std::fs::write(&path, &content).expect("test setup failed");
+
+        let expected = sha256_hex(&content);
+        assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_empty_file() {
+        // The streaming loop's immediate-break path: the first read returns 0,
+        // so the digest is SHA256 of no input.
+        let dir = tempfile::tempdir().expect("test setup failed");
+        let path = dir.path().join("empty.bin");
+        std::fs::File::create(&path).expect("test setup failed");
+
+        let expected = sha256_hex(b"");
+        assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_missing_file_is_io_not_mismatch() {
+        // Covers the `File::open` error arm on every platform (a directory path
+        // only fails at open on Windows), and locks that a missing file is
+        // `Error::Io`, never a spurious mismatch that would delete a model.
+        let dir = tempfile::tempdir().expect("test setup failed");
+        let path = dir.path().join("does-not-exist.bin");
+
+        let err = verify_sha256(&path, ALL_ZERO_SHA256)
+            .expect_err("a missing file should fail to verify");
+        assert!(matches!(err, Error::Io(_)));
+        assert!(!is_checksum_mismatch(&err));
     }
 
     #[test]
@@ -107,10 +182,11 @@ mod tests {
 
     #[test]
     fn test_verify_sha256_read_error_is_io_not_mismatch() {
-        // A directory cannot be read as a file: `std::fs::read` returns EISDIR.
-        // This stands in for the EACCES/EIO read failures on failing hardware,
-        // and locks the contract that a read failure surfaces as `Error::Io`,
-        // never as a spurious checksum mismatch.
+        // A directory cannot be read as a file: on Linux `File::open` succeeds
+        // and the first `read` returns EISDIR; on Windows the open itself fails.
+        // Either way it stands in for the EACCES/EIO read failures on failing
+        // hardware, and locks the contract that a read failure surfaces as
+        // `Error::Io`, never as a spurious checksum mismatch.
         let dir = tempfile::tempdir().expect("test setup failed");
 
         let result = verify_sha256(dir.path(), ALL_ZERO_SHA256);

--- a/src/update/checksum.rs
+++ b/src/update/checksum.rs
@@ -14,7 +14,9 @@ use std::path::Path;
 pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<()> {
     let actual_hex = hash_file(path)?;
 
-    if actual_hex != expected_hex.to_ascii_lowercase() {
+    // Case-insensitive compare, so an uppercase expected digest still matches
+    // without allocating a lowercased copy of it.
+    if !actual_hex.eq_ignore_ascii_case(expected_hex) {
         return Err(Error::UpdateChecksumMismatch {
             file: path.file_name().map_or_else(
                 || "unknown".to_string(),
@@ -73,12 +75,14 @@ fn hash_file(path: &Path) -> Result<String> {
 
 /// Format a hash digest as a lowercase hex string.
 fn format_hex(hash: &[u8]) -> String {
-    hash.iter()
-        .fold(String::with_capacity(64), |mut acc, byte| {
+    hash.iter().fold(
+        String::with_capacity(super::constants::SHA256_HEX_LEN),
+        |mut acc, byte| {
             use std::fmt::Write;
             let _ = write!(acc, "{byte:02x}");
             acc
-        })
+        },
+    )
 }
 
 #[cfg(test)]
@@ -121,6 +125,18 @@ mod tests {
         drop(f);
 
         let expected = sha256_hex(b"test content");
+        assert!(verify_sha256(&path, &expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_accepts_uppercase_expected() {
+        // The expected digest is compared case-insensitively, so an uppercase
+        // hex string must still verify.
+        let dir = tempfile::tempdir().expect("test setup failed");
+        let path = dir.path().join("test.bin");
+        std::fs::write(&path, b"test content").expect("test setup failed");
+
+        let expected = sha256_hex(b"test content").to_ascii_uppercase();
         assert!(verify_sha256(&path, &expected).is_ok());
     }
 

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -24,6 +24,11 @@ pub const MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
 /// materialise the whole file in memory.
 pub const HASH_CHUNK_BYTES: usize = 64 * 1024;
 
+/// Length of a SHA-256 digest rendered as a lowercase hex string.
+///
+/// A SHA-256 digest is 32 bytes, and each byte becomes two hex characters.
+pub const SHA256_HEX_LEN: usize = 64;
+
 /// HTTP connect timeout in seconds for update requests.
 pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -17,6 +17,13 @@ pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
 /// Maximum manifest response size in bytes (1 MiB).
 pub const MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
 
+/// Read-buffer size (64 KiB) for streaming a file through the SHA256 hasher.
+///
+/// Bounds peak memory during checksum verification to this size regardless of
+/// the file's length, so hashing a several-hundred-MB model does not first
+/// materialise the whole file in memory.
+pub const HASH_CHUNK_BYTES: usize = 64 * 1024;
+
 /// HTTP connect timeout in seconds for update requests.
 pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 


### PR DESCRIPTION
`verify_sha256` read the entire file into memory with `std::fs::read` before hashing it, so peak memory equalled the full file size. It runs against the model files (regional slices around 150 MB, up to a 557 MB global fp32), so on a memory-constrained deployment the read alone can spike memory well past what hashing actually needs.

This streams the file through a fixed 64 KiB buffer into the SHA256 hasher instead, so peak memory stays bounded to that buffer regardless of file size.

## Changes

- `verify_sha256` now delegates to a new private `hash_file`, which opens the file and feeds it to `Sha256::update` in 64 KiB chunks until EOF, then formats the digest.
- Extracted `format_hex` (the hex formatter) so the streaming finalize and the tests share one implementation.
- Added `HASH_CHUNK_BYTES` (64 KiB) to `src/update/constants.rs`, next to `MANIFEST_MAX_BYTES`, so the buffer size is not a magic number.

## Behavior preserved

- The digest is identical to the previous whole-file result for every input size.
- A read failure still surfaces as `Error::Io`, never a spurious checksum mismatch. Callers gate their destructive delete-and-redownload on `is_checksum_mismatch`, which stays true only for a genuine content mismatch, so this distinction is load-bearing and is unchanged.

## Tests

- Added `test_verify_sha256_streams_file_larger_than_chunk`, which hashes a file spanning multiple read buffers with a partial final chunk. It catches the classic streaming bug of feeding the whole buffer rather than the bytes actually read.
- Existing coverage for a matching digest, a mismatch, and the read-error-is-`Error::Io` contract is retained.

Fixes #355.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum verification for large files by processing data in smaller portions, reducing memory usage.
  * Preserved clear error handling for unreadable files and checksum mismatches.
  * Added support for verifying empty and multi-part files reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->