### PR TITLE
fix: surface leaked .part downloads in models check (#349)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1627,6 +1627,13 @@ fn handle_models_command(
             default,
         } => handle_models_add(name, path, labels, r#type, default),
         ModelsAction::Check => {
+            // Leftover <name>.<pid>.part files from a download interrupted
+            // before it finished, reported on both output paths so a directory
+            // that looks clean but holds an abandoned download stays visible.
+            let leftover_downloads = registry::models_dir()
+                .and_then(|dir| registry::find_stale_part_files(&dir))
+                .unwrap_or_default();
+
             // JSON/NDJSON output: collect all results then emit
             if output_mode.is_structured() {
                 let models: Vec<ModelCheckEntry> = config
@@ -1645,6 +1652,7 @@ fn handle_models_command(
                     result_type: ResultType::ModelCheck,
                     models,
                     geomodel: check_geomodel()?,
+                    leftover_downloads,
                 };
                 emit_json_result(&payload);
                 return Ok(());
@@ -1657,6 +1665,12 @@ fn handle_models_command(
             }
 
             report_geomodel_status(&check_geomodel()?);
+            for path in &leftover_downloads {
+                println!(
+                    "  {} is a leftover partial download (safe to remove if no download is running)",
+                    path.display()
+                );
+            }
             Ok(())
         }
         ModelsAction::Info { id, languages } => {

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -572,6 +572,12 @@ pub struct ModelCheckPayload {
     pub models: Vec<ModelCheckEntry>,
     /// Shared range filter status.
     pub geomodel: GeomodelInfo,
+    /// Leftover partial-download files (`<name>.<pid>.part`) in the models
+    /// directory, from a download interrupted before it finished. Reported so a
+    /// directory that looks clean but is holding an abandoned multi-hundred-MB
+    /// download is visible; birda never deletes these automatically.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub leftover_downloads: Vec<PathBuf>,
 }
 
 /// Status of the shared `BirdNET` Geomodel range filter.
@@ -948,6 +954,7 @@ mod tests {
                 labels_path: Some(PathBuf::from("/models/birdnet-geomodel-v3.0.2-labels.txt")),
                 obsolete_files: Vec::new(),
             },
+            leftover_downloads: vec![PathBuf::from("/models/birdnet-v30.onnx.4242.part")],
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
@@ -970,9 +977,31 @@ mod tests {
                     "valid": false,
                     "error": "model file not found"
                 }
-            ]
+            ],
+            "leftover_downloads": ["/models/birdnet-v30.onnx.4242.part"]
         });
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_check_payload_omits_empty_leftover_downloads() {
+        // skip_serializing_if keeps the key out of the JSON when there are no
+        // leftovers, so the common case is byte-identical to before the field.
+        let payload = ModelCheckPayload {
+            result_type: ResultType::ModelCheck,
+            models: Vec::new(),
+            geomodel: GeomodelInfo {
+                version: "3.0.2".to_string(),
+                installed: false,
+                species_count: 0,
+                model_path: None,
+                labels_path: None,
+                obsolete_files: Vec::new(),
+            },
+            leftover_downloads: Vec::new(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert!(!json.contains("leftover_downloads"));
     }
 
     #[test]

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -1001,7 +1001,8 @@ mod tests {
             leftover_downloads: Vec::new(),
         };
         let json = serde_json::to_string(&payload).expect("serialize");
-        assert!(!json.contains("leftover_downloads"));
+        let value: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
+        assert!(value.get("leftover_downloads").is_none());
     }
 
     #[test]

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -403,6 +403,46 @@ pub fn find_obsolete_files(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(found)
 }
 
+/// Report leftover partial-download files in the models directory.
+///
+/// A download in progress is written to `<name>.<pid>.part` (see `part_path`)
+/// and renamed onto its destination only on success. A process killed
+/// mid-download leaves that part file behind: the Ctrl+C handler calls
+/// `std::process::exit`, which runs no cleanup, and because the name is
+/// pid-qualified nothing ever reuses or reclaims it. Model files run to hundreds
+/// of MB, so `models check` reporting the directory "clean" while it holds an
+/// abandoned download is a silent waste of disk.
+///
+/// This only reports; it never deletes, since another live birda may own a
+/// different pid's part file mid-transfer. A missing directory yields an empty
+/// list, matching [`find_obsolete_files`].
+pub fn find_stale_part_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(found),
+        Err(e) => return Err(Error::Io(e)),
+    };
+
+    for entry in entries {
+        let path = entry.map_err(Error::Io)?.path();
+        // Compare the extension as an OsStr (handles a non-UTF-8 name) and gate
+        // the stat behind it, so only a `.part` file is ever stat-checked.
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case(crate::constants::download::PARTIAL_SUFFIX))
+            && path.is_file()
+        {
+            found.push(path);
+        }
+    }
+
+    // read_dir order is unspecified, so sort for deterministic reporting.
+    found.sort();
+    Ok(found)
+}
+
 /// Build the HTTP client used for every registry download.
 fn http_client() -> Result<Client> {
     Client::builder()
@@ -990,6 +1030,60 @@ mod tests {
 
         assert_eq!(found.len(), 1);
         assert!(found[0].ends_with("birdnet-v24-meta.onnx"));
+    }
+
+    #[test]
+    fn test_find_stale_part_files_detects_a_leftover_download() {
+        let dir = tempfile::tempdir().unwrap();
+        // A completed model and its labels must be ignored.
+        std::fs::write(dir.path().join("birdnet-v30.onnx"), b"x").unwrap();
+        std::fs::write(dir.path().join("birdnet-v30-labels.txt"), b"x").unwrap();
+        // A download interrupted mid-transfer leaves a pid-qualified part file.
+        let leftover = format!(
+            "birdnet-v30.onnx.{}.{}",
+            std::process::id(),
+            crate::constants::download::PARTIAL_SUFFIX
+        );
+        std::fs::write(dir.path().join(&leftover), b"partial").unwrap();
+        // A directory whose name ends in .part must not be reported; only
+        // regular files are leftover downloads.
+        std::fs::create_dir(dir.path().join("stale-cache.part")).unwrap();
+
+        let found = find_stale_part_files(dir.path()).unwrap();
+
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with(&leftover));
+    }
+
+    #[test]
+    fn test_find_stale_part_files_returns_all_leftovers_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        let suffix = crate::constants::download::PARTIAL_SUFFIX;
+        std::fs::write(dir.path().join(format!("b-model.onnx.10.{suffix}")), b"x").unwrap();
+        std::fs::write(dir.path().join(format!("a-model.onnx.20.{suffix}")), b"x").unwrap();
+
+        let found = find_stale_part_files(dir.path()).unwrap();
+
+        assert_eq!(found.len(), 2);
+        // read_dir order is unspecified; the result is sorted, so "a-" precedes "b-".
+        assert!(found[0].ends_with(format!("a-model.onnx.20.{suffix}")));
+        assert!(found[1].ends_with(format!("b-model.onnx.10.{suffix}")));
+    }
+
+    #[test]
+    fn test_find_stale_part_files_reports_nothing_on_a_clean_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("birdnet-v30.onnx"), b"x").unwrap();
+
+        assert!(find_stale_part_files(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_find_stale_part_files_is_empty_for_a_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        assert!(find_stale_part_files(&missing).unwrap().is_empty());
     }
 
     #[test]

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -403,6 +403,25 @@ pub fn find_obsolete_files(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(found)
 }
 
+/// Does `path` match the `<name>.<pid>.part` shape that `part_path` writes?
+///
+/// Requiring the numeric pid segment keeps an unrelated `.part` file a user left
+/// in the models directory from being misreported as an interrupted download.
+fn is_part_download(path: &Path) -> bool {
+    if !path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(crate::constants::download::PARTIAL_SUFFIX))
+    {
+        return false;
+    }
+    // With the `.part` extension removed the stem is `<name>.<pid>`; the segment
+    // after its last '.' must be the numeric pid.
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.rsplit('.').next())
+        .is_some_and(|pid| !pid.is_empty() && pid.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Report leftover partial-download files in the models directory.
 ///
 /// A download in progress is written to `<name>.<pid>.part` (see `part_path`)
@@ -427,13 +446,9 @@ pub fn find_stale_part_files(dir: &Path) -> Result<Vec<PathBuf>> {
 
     for entry in entries {
         let path = entry.map_err(Error::Io)?.path();
-        // Compare the extension as an OsStr (handles a non-UTF-8 name) and gate
-        // the stat behind it, so only a `.part` file is ever stat-checked.
-        if path
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case(crate::constants::download::PARTIAL_SUFFIX))
-            && path.is_file()
-        {
+        // Gate the stat behind the name check, so only a matching name is
+        // ever stat-checked.
+        if is_part_download(&path) && path.is_file() {
             found.push(path);
         }
     }
@@ -1045,9 +1060,11 @@ mod tests {
             crate::constants::download::PARTIAL_SUFFIX
         );
         std::fs::write(dir.path().join(&leftover), b"partial").unwrap();
-        // A directory whose name ends in .part must not be reported; only
-        // regular files are leftover downloads.
-        std::fs::create_dir(dir.path().join("stale-cache.part")).unwrap();
+        // A directory matching the <name>.<pid>.part shape must still be
+        // excluded: only regular files are leftover downloads.
+        std::fs::create_dir(dir.path().join("interrupted.99999.part")).unwrap();
+        // A .part file with no numeric pid segment is not a birda download.
+        std::fs::write(dir.path().join("manual-notes.part"), b"x").unwrap();
 
         let found = find_stale_part_files(dir.path()).unwrap();
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -13,8 +13,8 @@ pub mod types;
 pub use cleanup::{orphaned_files, remove_orphans};
 pub use installer::{
     GEOMODEL_INSTALL_ID, InstallProvenance, InstalledRangeFilter, download_file,
-    find_obsolete_files, geomodel_paths, install_model, install_range_filter, install_variant,
-    models_dir,
+    find_obsolete_files, find_stale_part_files, geomodel_paths, install_model,
+    install_range_filter, install_variant, models_dir,
 };
 pub use license::{LicensedAsset, prompt_license_acceptance};
 pub use loader::{find_model, load_registry};


### PR DESCRIPTION
A model download is written to `<name>.<pid>.part` and renamed onto its destination only on success. When a download is interrupted (Ctrl+C runs `std::process::exit`, which skips cleanup), that pid-qualified part file is left behind, and because the name carries the pid nothing ever reuses or reclaims it. Meanwhile `birda models check` scanned only a fixed obsolete-filename list, so it reported the directory clean while it was holding an abandoned download. Model files run 150-557 MB, so this is silent disk waste with no way to find it short of `find`.

## Changes

- New `registry::find_stale_part_files`, a sibling of `find_obsolete_files`, scans the models directory for leftover `.part` files. It is kept separate because a leftover partial download and a superseded/obsolete file are different categories with different messaging.
- `models check` now surfaces them, in both the human output and the JSON payload (a new `leftover_downloads` field on `ModelCheckPayload`, at the top level rather than under `geomodel`, because a Ctrl+C'd classifier download leaks a part file too, not just the geomodel).

## Design notes

- Report only, never delete. The Ctrl+C handler cannot safely delete (it has to stay async-signal-safe), and another live birda may own a different pid's part file mid-transfer.
- No PID-liveness filtering in this change: doing it cross-platform without `unsafe`, a new dependency, or `#[cfg]`-divergent code is awkward, and the report is non-destructive, so the human line is worded "safe to remove if no download is running". PID-liveness can be a follow-up.

## Compatibility

`leftover_downloads` uses `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, matching the sibling `obsolete_files` field: it is absent from the JSON when empty (the common case) and an older payload still deserializes, so the change is additive for JSON consumers. birda-gui will want a matching optional field in its `ModelCheckPayload` type to display them.

## Tests

- Unit tests for `find_stale_part_files`: it detects a `<name>.<pid>.part` leftover while ignoring completed models, reports nothing on a clean directory, and returns empty for a missing directory.
- Extended the `ModelCheckPayload` serialization test to carry a non-empty `leftover_downloads` and assert it serializes under that key.

Fixes #349.
