### PR TITLE
fix: auto-bump registry_version so a content change reaches cached users (#332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,12 @@ jobs:
       # lib and the binary, and the test code drifts unchecked: this flag was
       # added against a backlog of 221 warnings that had accumulated entirely
       # in test code, none of which any CI run had ever reported.
+      #
+      # --features gen-registry so the feature-gated generator (src/gen_registry.rs,
+      # the gen-registry bin, and tests/registry_generation.rs) is linted too;
+      # without it that code carries production logic no CI clippy run ever sees.
       - name: Run clippy
-        run: cargo clippy --no-default-features --all-targets -- -D warnings
+        run: cargo clippy --no-default-features --features gen-registry --all-targets -- -D warnings
 
   test:
     name: Test
@@ -67,6 +71,19 @@ jobs:
 
       - name: Run tests
         run: cargo test --no-default-features --no-fail-fast
+
+      # The generator, its auto-bump unit tests, and the drift test all live
+      # behind the gen-registry feature, so the default test run above never
+      # touches them. This step covers both: the --lib run exercises the
+      # version auto-bump (the drift test only regenerates unchanged inputs, so
+      # it hits the no-op path and cannot catch a broken bump), and the
+      # --test run verifies registry.json matches what the generator produces
+      # (a manifest change committed without regenerating, or a hand-edit, would
+      # ship a stale registry). A bare --test would skip the lib unit tests.
+      - name: Check the generated registry and its version auto-bump
+        run: |
+          cargo test --no-default-features --features gen-registry --no-fail-fast --lib gen_registry
+          cargo test --no-default-features --features gen-registry --no-fail-fast --test registry_generation
 
   # Every other job installs @stable, which floats to whatever Rust shipped most
   # recently (1.97.1 at the time of writing). That left the `rust-version` floor

--- a/registry-sources.toml
+++ b/registry-sources.toml
@@ -13,11 +13,11 @@
 # untouched, which is how the frozen legacy entries survive regeneration.
 
 schema_version = "2.0"
-# Bump on every content change, not only when a model is added. The loader
-# replaces a user's cached registry only when the bundled version is higher, so
-# a corrected checksum or class count that ships without a bump is invisible to
-# everyone who already has a cache.
-registry_version = 6
+# registry_version is not set here: the generator (gen-registry) manages it,
+# bumping it by one on every content change. The loader replaces a user's cached
+# registry only when the bundled version is higher, so an automatic bump is what
+# makes a corrected checksum or class count reach everyone who already has a
+# cache, instead of a manual step that is easy to forget.
 
 [[model]]
 id = "birdnet-v30"

--- a/src/gen_registry.rs
+++ b/src/gen_registry.rs
@@ -383,6 +383,29 @@ mod tests {
     }
 
     #[test]
+    fn test_next_registry_version_bumps_on_a_model_level_change() {
+        // The #329/#332 failure was a model-level change (a corrected class
+        // count), not a schema_version change, so pin that a difference inside
+        // `models` alone, with schema_version held constant, still bumps.
+        let root = env!("CARGO_MANIFEST_DIR");
+        let existing: Registry = serde_json::from_str(
+            &std::fs::read_to_string(Path::new(root).join(REGISTRY_FILE)).unwrap(),
+        )
+        .unwrap();
+        let mut generated = existing.clone();
+        let model = generated
+            .models
+            .first_mut()
+            .expect("the registry has at least one model");
+        model.version = format!("{}-changed", model.version);
+
+        assert_eq!(
+            next_registry_version(&generated, &existing),
+            existing.registry_version.saturating_add(1)
+        );
+    }
+
+    #[test]
     fn test_generate_bumps_the_version_when_the_content_changes() {
         // End-to-end through the real generator: a hermetic copy of its inputs
         // plus a stale on-disk registry proves a content change forces a bump.

--- a/src/gen_registry.rs
+++ b/src/gen_registry.rs
@@ -88,9 +88,33 @@ struct SourceModel {
 #[derive(Debug, Deserialize)]
 struct Sources {
     schema_version: String,
-    registry_version: u32,
     #[serde(rename = "model")]
     models: Vec<SourceModel>,
+}
+
+/// The `registry_version` for freshly generated content.
+///
+/// The loader replaces a user's cached registry only when the bundled version
+/// is strictly greater, so any content change must bump the version or it never
+/// reaches a cached user (the corrected Perch class counts that shipped without
+/// a bump and left every region showing "0 species"). This bumps by one when
+/// `generated` differs from `existing` in anything but the version field, and
+/// keeps the version when they match, so a no-op regeneration stays a no-op and
+/// a real change forces exactly one increment.
+///
+/// The comparison is against the on-disk registry, from which the frozen legacy
+/// entries and the range filter are also carried through verbatim, so it tracks
+/// changes to the generator-owned (manifest-derived) models. A manual edit to a
+/// carried-through entry appears on both sides and so does not bump; those
+/// entries are frozen, which is why that is acceptable.
+fn next_registry_version(generated: &Registry, existing: &Registry) -> u32 {
+    let mut normalized = generated.clone();
+    normalized.registry_version = existing.registry_version;
+    if normalized == *existing {
+        existing.registry_version
+    } else {
+        existing.registry_version.saturating_add(1)
+    }
 }
 
 /// Build the registry JSON text from the vendored manifests under `root`.
@@ -131,12 +155,16 @@ pub fn generate_from_repo_root(root: &str) -> Result<String> {
     // regeneration produces a reviewable diff rather than a reshuffle.
     models.sort_by(|a, b| a.id.cmp(&b.id));
 
-    let registry = Registry {
+    let mut registry = Registry {
         schema_version: sources.schema_version.clone(),
-        registry_version: sources.registry_version,
+        // Seeded from the on-disk registry; bumped just below only when the
+        // content actually changed, so the version is generator-managed rather
+        // than a manual step in registry-sources.toml that is easy to forget.
+        registry_version: existing.registry_version,
         models,
-        range_filter: existing.range_filter,
+        range_filter: existing.range_filter.clone(),
     };
+    registry.registry_version = next_registry_version(&registry, &existing);
 
     let mut json = serde_json::to_string_pretty(&registry).map_err(|e| Error::Internal {
         message: format!("could not serialize the registry: {e}"),
@@ -310,4 +338,89 @@ fn basename(path: &str) -> Result<&str> {
 pub fn write_registry(root: &str) -> Result<()> {
     let json = generate_from_repo_root(root)?;
     std::fs::write(Path::new(root).join(REGISTRY_FILE), json).map_err(Error::Io)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry(schema: &str, version: u32) -> Registry {
+        Registry {
+            schema_version: schema.to_string(),
+            registry_version: version,
+            models: Vec::new(),
+            range_filter: None,
+        }
+    }
+
+    #[test]
+    fn test_next_registry_version_keeps_version_when_content_is_unchanged() {
+        let existing = registry("2.0", 6);
+        // Same content, even though the generated struct carries a different
+        // version: the version is held equal for the comparison, so a no-op
+        // regeneration does not bump.
+        let generated = registry("2.0", 999);
+        assert_eq!(next_registry_version(&generated, &existing), 6);
+    }
+
+    #[test]
+    fn test_next_registry_version_bumps_once_when_content_changes() {
+        let existing = registry("2.0", 6);
+        // Any field but the version differing is a content change, and the
+        // loader only replaces a cached registry when the bundled version is
+        // strictly greater, so it must bump.
+        let generated = registry("2.1", 6);
+        assert_eq!(next_registry_version(&generated, &existing), 7);
+    }
+
+    #[test]
+    fn test_next_registry_version_saturates_at_u32_max() {
+        // A content change at the ceiling stays at the ceiling rather than
+        // wrapping to 0, which every cache would read as a downgrade.
+        let existing = registry("2.0", u32::MAX);
+        let generated = registry("2.1", u32::MAX);
+        assert_eq!(next_registry_version(&generated, &existing), u32::MAX);
+    }
+
+    #[test]
+    fn test_generate_bumps_the_version_when_the_content_changes() {
+        // End-to-end through the real generator: a hermetic copy of its inputs
+        // plus a stale on-disk registry proves a content change forces a bump.
+        // This reproduces the failure the versioned-model work (#329) exposed: a
+        // corrected class count shipped without a bump and reached no cached user.
+        let real_root = env!("CARGO_MANIFEST_DIR");
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+
+        std::fs::copy(
+            Path::new(real_root).join(SOURCES_FILE),
+            root.join(SOURCES_FILE),
+        )
+        .unwrap();
+        let manifests = root.join(MANIFEST_DIR);
+        std::fs::create_dir(&manifests).unwrap();
+        for entry in std::fs::read_dir(Path::new(real_root).join(MANIFEST_DIR)).unwrap() {
+            let entry = entry.unwrap();
+            std::fs::copy(entry.path(), manifests.join(entry.file_name())).unwrap();
+        }
+
+        // Stand in for a cached registry at version 6 whose content is stale.
+        let mut stale: Registry =
+            serde_json::from_str(&generate_from_repo_root(real_root).unwrap()).unwrap();
+        stale.registry_version = 6;
+        stale.schema_version = "0.0-stale".to_string();
+        std::fs::write(
+            root.join(REGISTRY_FILE),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let regenerated: Registry =
+            serde_json::from_str(&generate_from_repo_root(root.to_str().unwrap()).unwrap())
+                .unwrap();
+
+        // The generated content differs from the stale on-disk copy, so the
+        // version bumps exactly once.
+        assert_eq!(regenerated.registry_version, 7);
+    }
 }


### PR DESCRIPTION
The model registry loader replaces a user's cached `registry.json` only when the bundled `registry_version` is strictly greater. `registry_version` was hand-set in `registry-sources.toml`, so a content change that shipped without a manual bump reached nobody who already had a cache. This is not hypothetical: during #329 a correction to the Perch class counts shipped without a bump, and running binaries kept reading the stale cache and printing "0 species" beside every Perch region long after the fix was in the tree.

## Fix

The generator now owns `registry_version` instead of copying a hand-maintained integer. `generate_from_repo_root` seeds the version from the on-disk registry and bumps it by one whenever the freshly generated content differs from what is on disk (comparing the parsed registries with the version field held equal). Any content change forces exactly one increment; an unchanged regeneration is a no-op. `registry_version` is removed from `registry-sources.toml`, so there is no manual step left to forget.

## Enforcement

The drift test (`tests/registry_generation.rs`) already asserts that the checked-in `registry.json` equals what the generator produces. With the version now generator-owned, a content change committed without regenerating (or a hand-edit of `registry.json`) makes `generated != checked-in` and fails that test. It lives behind the `gen-registry` feature, which the default CI test run never exercised, so this adds a CI step that runs it. That closes the loop: the bump can no longer be forgotten, and a stale registry can no longer land.

## Tests

- Unit tests for the version decision: an unchanged regeneration keeps the version (proven by varying only the version field), and any content change bumps it by one.
- An end-to-end test that copies the generator's inputs into a temp directory alongside a stale registry and asserts a regeneration bumps the version, which is exactly the shape of the #329 regression.

The checked-in `registry.json` is unchanged by this refactor (it stays at version 6).

Fixes #332.
