### PR TITLE
fix: give `birda clip` a real failure contract (#319)

### DIFF
--- a/docs/clip-extraction.md
+++ b/docs/clip-extraction.md
@@ -164,6 +164,21 @@ birda clip detections/*.csv -c 0.85 -o best_clips/
 - **Efficient seeking**: Uses format-native seeking when available (WAV, FLAC)
 - **Progress indication**: Shows extraction progress with time estimates
 
+## Exit Status
+
+`birda clip` exits non-zero only when the whole batch failed, that is, when every detection file failed: missing, unreadable, malformed, or with every detection failing to extract. A batch where at least one file was processed exits zero, even if other files failed and even if a processed file simply held no detections above the threshold. Each per-file failure is reported as a warning on stderr; in `ndjson` mode also as an `error` event, and in both `json` and `ndjson` modes in the result's `failed_files` field.
+
+So a total failure stops a chained publish step while a partial one does not:
+
+```bash
+# Skips the publish step only if the WHOLE batch failed. This does not
+# guarantee clips were produced: a batch that found nothing above the
+# threshold still exits 0, so check the output if that matters.
+birda clip detections/*.csv -o best_clips/ && rsync best_clips/ backup:/clips/
+```
+
+A direct-extraction range (`--start`/`--end`) that lies past the end of the file, or is too short to hold a single frame, is reported as an error rather than written out as an empty clip.
+
 ## Troubleshooting
 
 ### "Source audio file not found"

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -253,6 +253,10 @@ birda --output-mode json clip results.csv -c 0.7
 }
 ```
 
+`total_files` counts only the detection files that were processed successfully. When one or more files fail, the payload carries a `failed_files` array, each entry `{ "file": <path>, "error": <message> }`; the field is omitted entirely when every file succeeded, so an all-success payload is unchanged from earlier versions.
+
+In `ndjson` mode `birda clip` also emits a per-file `error` event (severity `warning`) as each failure occurs; in `json` mode the output stays a single document, so the failures are conveyed only through `failed_files`. Its exit status reflects the batch outcome: it exits non-zero only when every detection file failed. A batch where at least one file was processed exits zero even if others failed, so a machine consumer should read `failed_files` to detect partial failures rather than relying on the exit code alone. A direct-extraction range that decodes no audio (past the end of the file, or too short to hold a frame) is an error, not an empty clip.
+
 ## JSON Detection File Format
 
 Use `-f json` to write detection results to JSON files:

--- a/src/clipper/command.rs
+++ b/src/clipper/command.rs
@@ -9,7 +9,10 @@ use crate::Error;
 use crate::cli::ClipArgs;
 use crate::config::OutputMode;
 use crate::constants::{clipper, confidence, output_extensions};
-use crate::output::{ClipExtractionEntry, ClipExtractionPayload, ResultType, emit_json_result};
+use crate::output::{
+    ClipExtractionEntry, ClipExtractionFailure, ClipExtractionPayload, ErrorSeverity, ResultType,
+    emit_json_error, emit_json_result,
+};
 
 use super::{
     ClipExtractor, DetectionGroup, ParsedDetection, WavWriter, group_detections,
@@ -73,48 +76,93 @@ fn validate_float_args(args: &ClipArgs) -> Result<(), Error> {
     Ok(())
 }
 
+/// JSON `error`-event code for a detection file that failed to process.
+///
+/// A named constant rather than an inline literal because it is an API-contract
+/// string a consumer keys on, mirroring `PROCESSING_ERROR_CODE` in `lib.rs`.
+const CLIP_FILE_FAILED_CODE: &str = "clip_file_failed";
+
 /// Execute clip extraction from CSV detection files.
-#[allow(clippy::unnecessary_wraps)]
+///
+/// Each detection file is processed independently. A per-file failure is a
+/// warning and the batch keeps going, so a mixed batch still writes the clips it
+/// could. The batch as a whole fails only when no file produced anything: that
+/// is the difference between "some recordings had no detections" and "every file
+/// was rejected", and before #319 the command reported success either way.
 fn execute_csv_mode(args: &ClipArgs, output_mode: OutputMode) -> Result<(), Error> {
     let extractor = ClipExtractor::new();
     let writer = WavWriter::new(args.output.clone());
     let is_json = output_mode.is_structured();
 
     let mut total_clips = 0;
-    let mut total_files = 0;
+    let mut processed_files = 0;
     let mut all_clips: Vec<ClipExtractionEntry> = Vec::new();
+    let mut failed_files: Vec<ClipExtractionFailure> = Vec::new();
 
     for detection_file in &args.files {
         match process_detection_file(detection_file, args, &extractor, &writer, is_json) {
             Ok((clip_count, clips)) => {
                 total_clips += clip_count;
-                total_files += 1;
+                processed_files += 1;
                 all_clips.extend(clips);
             }
             Err(e) => {
                 warn!("Failed to process {}: {e}", detection_file.display());
+                // Streaming diagnostic for NDJSON consumers: one `error` event
+                // per failure, as it happens. Gated to NDJSON specifically, not
+                // every structured mode, because plain `json` output is a single
+                // document (one `result` object) that `json.loads` has to parse,
+                // and a stream of `error` objects ahead of it would make stdout
+                // N+1 top-level objects. In `json` mode the same failures ride
+                // in the result's `failed_files` field instead.
+                if matches!(output_mode, OutputMode::Ndjson) {
+                    emit_json_error(
+                        CLIP_FILE_FAILED_CODE,
+                        ErrorSeverity::Warning,
+                        &format!("failed to process {}: {e}", detection_file.display()),
+                        None,
+                    );
+                }
+                failed_files.push(ClipExtractionFailure {
+                    file: detection_file.clone(),
+                    error: e.to_string(),
+                });
             }
         }
     }
 
-    // JSON/NDJSON output
+    // A total failure is a batch that had files to process and none of them
+    // produced anything. An empty batch, or one where every file simply held no
+    // detections above the threshold, is a legitimate zero-clip run. When
+    // `processed_files` is zero and something failed, every file failed, so
+    // `failed_files.len() == args.files.len()`.
+    let total_failure = processed_files == 0 && !failed_files.is_empty();
+
     if is_json {
         let payload = ClipExtractionPayload {
             result_type: ResultType::ClipExtraction,
             output_dir: args.output.clone(),
             total_clips,
-            total_files,
+            total_files: processed_files,
             clips: all_clips,
+            failed_files,
         };
         emit_json_result(&payload);
-        return Ok(());
+    } else {
+        info!(
+            "Extracted {total_clips} clips from {processed_files} detection files to {}",
+            args.output.display()
+        );
+        if !failed_files.is_empty() {
+            warn!("{} detection file(s) failed to process", failed_files.len());
+        }
     }
 
-    // Human-readable output
-    info!(
-        "Extracted {total_clips} clips from {total_files} detection files to {}",
-        args.output.display()
-    );
+    if total_failure {
+        return Err(Error::ClipBatchAllFailed {
+            total: args.files.len(),
+        });
+    }
 
     Ok(())
 }
@@ -184,6 +232,7 @@ fn execute_direct_extraction(
                 end_time: padded_end,
                 output_file: output_path,
             }],
+            failed_files: Vec::new(),
         };
         emit_json_result(&payload);
     } else {
@@ -314,6 +363,20 @@ fn process_detection_file(
     }
 
     pb.finish_with_message("done");
+
+    // The file had detections to extract (`groups` is non-empty) but every one
+    // failed to extract or write, so `clip_count` is zero. That is a failed
+    // file, not the legitimate zero-clip result of a file with no detections
+    // above the threshold (which returned early above). Reporting it as a
+    // failure is what lets the batch exit non-zero when nothing was produced,
+    // and what distinguishes "no detections" from "every detection thrown away"
+    // for a machine consumer (#319).
+    if !groups.is_empty() && clip_count == 0 {
+        return Err(Error::ClipFileProducedNothing {
+            path: detection_file.to_path_buf(),
+            attempted: groups.len(),
+        });
+    }
 
     Ok((clip_count, clip_entries))
 }

--- a/src/clipper/extractor.rs
+++ b/src/clipper/extractor.rs
@@ -82,8 +82,9 @@ impl ClipExtractor {
     /// # Errors
     ///
     /// Returns [`Error::InvalidTimeRange`] if `group`'s bounds are not finite
-    /// or do not increase, and an error if the audio file cannot be read or
-    /// decoded.
+    /// or do not increase, [`Error::EmptyExtraction`] if the range is valid but
+    /// decodes to no frames (it lies beyond the end of the file, or rounds to no
+    /// samples), and an error if the audio file cannot be read or decoded.
     pub fn extract_clip(
         &self,
         source_path: &Path,
@@ -257,6 +258,21 @@ impl ClipExtractor {
             if current_sample >= end_sample {
                 break;
             }
+        }
+
+        // A range that passed validation can still decode nothing: it lies past
+        // the end of the file, or is short enough to round to no samples. Left
+        // unchecked, that reaches the writer as a structurally valid 0-frame WAV
+        // reported as an extracted clip, byte-indistinguishable from a clip
+        // truncated by a crash mid-write. Reject it at the one chokepoint both
+        // extraction routes share, so neither the CSV batch nor the direct route
+        // can publish an empty clip (#319).
+        if samples.is_empty() {
+            return Err(Error::EmptyExtraction {
+                path: source_path.to_path_buf(),
+                start: group.start,
+                end: group.end,
+            });
         }
 
         Ok(ExtractedClip {

--- a/src/clipper/writer.rs
+++ b/src/clipper/writer.rs
@@ -113,10 +113,11 @@ fn generate_filename(species: &str, confidence: f32, start_time: f64, end_time: 
 /// from a legitimately empty clip. Writing to a temporary and renaming means the
 /// clip appears at its path complete or not at all.
 ///
-/// Only half of that ambiguity closes here. Nothing checks the decoded result
-/// before writing it, so a range that decodes no audio still produces a valid
-/// 0-frame WAV and is still reported as an extracted clip; that is #319. Until
-/// both land, an empty clip and a crash-truncated one remain byte-identical.
+/// The other half of that ambiguity is closed upstream: `extract_clip` now
+/// rejects a range that decodes no audio with [`Error::EmptyExtraction`] (#319),
+/// so this helper is no longer reached with an empty clip through either
+/// extraction route, and a 0-frame WAV at a serving path can only mean a
+/// crash-truncated write.
 ///
 /// The cost, stated because it is paid per clip rather than once: this adds an
 /// fsync of the clip and an fsync of the species directory to every extraction,

--- a/src/error.rs
+++ b/src/error.rs
@@ -565,6 +565,55 @@ pub enum Error {
         value: f32,
     },
 
+    /// A clip extraction produced no audio.
+    ///
+    /// The requested range is finite and correctly ordered, yet decoding it
+    /// yielded zero frames: it lies past the end of the file, or is so short it
+    /// rounds to no samples. Returned instead of writing a structurally valid
+    /// but empty 0-frame WAV and reporting it as an extracted clip, which was
+    /// byte-indistinguishable from a clip truncated by a crash mid-write (#319).
+    // Unit-free `{start}`/`{end}`, as in `InvalidTimeRange`: these bounds are
+    // always finite here (they pass validation before the decode), so no NaN
+    // can render, but the same spelling keeps the two clip-range messages
+    // consistent.
+    #[error(
+        "no audio in range {start}s-{end}s of '{path}' (the range decoded to zero frames; it may lie beyond the end of the file)"
+    )]
+    EmptyExtraction {
+        /// Source audio file.
+        path: std::path::PathBuf,
+        /// Requested start time in seconds.
+        start: f64,
+        /// Requested end time in seconds.
+        end: f64,
+    },
+
+    /// A detection file had detections to extract but produced no clips.
+    ///
+    /// Distinct from a file with no detections above the confidence threshold,
+    /// which is a legitimate empty result: here every candidate detection failed
+    /// to extract or write, so the file is reported as failed rather than as a
+    /// successful run that happened to yield nothing (#319).
+    #[error("no clips extracted from '{path}': all {attempted} detection(s) failed")]
+    ClipFileProducedNothing {
+        /// The detection file.
+        path: std::path::PathBuf,
+        /// Number of candidate detection groups, all of which failed.
+        attempted: usize,
+    },
+
+    /// Every detection file in a clip batch failed to process.
+    ///
+    /// `birda clip` treats a per-file problem as a warning and continues, so a
+    /// batch with at least one success exits zero. When no file produced
+    /// anything, the batch as a whole failed and says so rather than reporting
+    /// success over an empty result (#319).
+    #[error("clip extraction failed: all {total} detection file(s) were rejected")]
+    ClipBatchAllFailed {
+        /// Number of detection files attempted, all of which failed.
+        total: usize,
+    },
+
     /// BSG model configuration error.
     #[error("BSG configuration error: {message}")]
     BsgConfig {

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -709,6 +709,15 @@ pub struct ClipExtractionPayload {
     pub total_files: usize,
     /// List of extracted clips.
     pub clips: Vec<ClipExtractionEntry>,
+    /// Detection files that failed to process.
+    ///
+    /// Empty and omitted from the JSON when every file succeeded, so a consumer
+    /// that never sees a failure reads the same payload as before #319. A
+    /// non-empty list means the run had per-file failures even when `total_clips`
+    /// is non-zero; a total failure (no file produced anything) additionally
+    /// exits the process non-zero.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_files: Vec<ClipExtractionFailure>,
 }
 
 /// A single extracted clip entry.
@@ -726,6 +735,15 @@ pub struct ClipExtractionEntry {
     pub end_time: f64,
     /// Output clip file path.
     pub output_file: PathBuf,
+}
+
+/// A detection file that failed during clip extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipExtractionFailure {
+    /// The detection file that failed.
+    pub file: PathBuf,
+    /// Human-readable reason it failed.
+    pub error: String,
 }
 
 #[cfg(test)]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -17,21 +17,22 @@ pub use csv::CsvWriter;
 pub use json::JsonResultWriter;
 pub use json_envelope::{
     AvailableModelEntry, AvailableModelsPayload, AvailableRangeFilterEntry, BatchProgress,
-    BsgMetadata, CancelReason, CancelledPayload, ClipExtractionEntry, ClipExtractionPayload,
-    ConfigPathPayload, ConfigPayload, DetectionInfo, DetectionsPayload, DownloadProgress,
-    ErrorPayload, ErrorSeverity, EventType, ExecutionProviderInfo, FileCompletedPayload,
-    FileErrorInfo, FileProgress, FileStartedPayload, FileStatus, GeomodelInfo, JsonEnvelope,
-    ModelCheckEntry, ModelCheckPayload, ModelDetails, ModelEntry, ModelInfoPayload,
-    ModelInstalledPayload, ModelListPayload, ModelRemovedPayload, PipelineCompletedPayload,
-    PipelineStartedPayload, PipelineStatus, ProgressPayload, ProviderInfo, ProvidersPayload,
-    RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry, SpeciesListPayload, VersionPayload,
+    BsgMetadata, CancelReason, CancelledPayload, ClipExtractionEntry, ClipExtractionFailure,
+    ClipExtractionPayload, ConfigPathPayload, ConfigPayload, DetectionInfo, DetectionsPayload,
+    DownloadProgress, ErrorPayload, ErrorSeverity, EventType, ExecutionProviderInfo,
+    FileCompletedPayload, FileErrorInfo, FileProgress, FileStartedPayload, FileStatus,
+    GeomodelInfo, JsonEnvelope, ModelCheckEntry, ModelCheckPayload, ModelDetails, ModelEntry,
+    ModelInfoPayload, ModelInstalledPayload, ModelListPayload, ModelRemovedPayload,
+    PipelineCompletedPayload, PipelineStartedPayload, PipelineStatus, ProgressPayload,
+    ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry,
+    SpeciesListPayload, VersionPayload,
 };
 pub use kaleidoscope::KaleidoscopeWriter;
 pub use parquet::{ParquetWriter, combine_parquet_files};
 pub use raven::RavenWriter;
 pub use reporter::{
     JsonProgressReporter, NullReporter, PipelineSummary, ProgressReporter, ProgressThrottler,
-    create_reporter, emit_json_result,
+    create_reporter, emit_json_error, emit_json_result,
 };
 pub use types::{Detection, DetectionMetadata};
 pub use writer::OutputWriter;

--- a/src/output/reporter.rs
+++ b/src/output/reporter.rs
@@ -507,6 +507,36 @@ pub fn emit_json_result<T: serde::Serialize>(payload: &T) {
     }
 }
 
+/// Emit a JSON error event to stdout.
+///
+/// The structured counterpart to a `warn!`/`eprintln!` diagnostic, for command
+/// handlers running in a structured output mode. `docs/json-output.md` documents
+/// this `error` event; until #319 nothing in the tree emitted it, and `birda
+/// clip` is its first caller.
+pub fn emit_json_error(
+    code: &str,
+    severity: ErrorSeverity,
+    message: &str,
+    suggestion: Option<&str>,
+) {
+    use crate::output::json_envelope::{EventType, JsonEnvelope};
+
+    let payload = ErrorPayload {
+        code: code.to_string(),
+        severity,
+        message: message.to_string(),
+        suggestion: suggestion.map(ToString::to_string),
+    };
+    let envelope = JsonEnvelope::new(EventType::Error, payload);
+    match serde_json::to_string(&envelope) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            // Log to stderr so it doesn't corrupt the JSON output stream.
+            eprintln!("error: failed to serialize JSON error event: {e}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/clip_integration_test.rs
+++ b/tests/clip_integration_test.rs
@@ -554,3 +554,387 @@ fn test_skipped_row_warnings_are_capped_and_then_summarised() {
     // The cap bounds the diagnostics, never the skipping.
     assert_eq!(walk_wav_files(&output_dir).len(), 1);
 }
+
+/// Write a detection results CSV (header plus `rows`) at `dir/<name>`.
+///
+/// The name follows the `<audio>.BirdNET.results.csv` convention so
+/// `find_source_audio` can locate the sibling WAV.
+fn write_results_csv(dir: &std::path::Path, name: &str, rows: &[&str]) -> PathBuf {
+    let path = dir.join(name);
+    let mut file = std::fs::File::create(&path).unwrap();
+    writeln!(
+        file,
+        "Start (s),End (s),Scientific name,Common name,Confidence"
+    )
+    .unwrap();
+    for row in rows {
+        writeln!(file, "{row}").unwrap();
+    }
+    path
+}
+
+/// Parse every non-empty line of stdout as a JSON value. `birda clip` emits one
+/// envelope per line in structured mode, so a machine consumer reads it as
+/// NDJSON whichever of `json`/`ndjson` was asked for.
+fn json_events(stdout: &[u8]) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("stdout line was not JSON: {line:?}: {e}"))
+        })
+        .collect()
+}
+
+/// A direct-extraction range past the end of the file decodes no audio. It used
+/// to be written out as a valid 0-frame WAV and reported as an extracted clip,
+/// byte-indistinguishable from a crash-truncated one; it must now fail and write
+/// nothing (#319).
+#[test]
+fn test_clip_direct_rejects_a_range_that_decodes_nothing() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("tone.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = run_direct_clip(
+        &wav_path,
+        &output_dir,
+        &[
+            "--start", "100", "--end", "105", "--pre", "0", "--post", "0",
+        ],
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a range that decodes nothing must fail: {stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(
+        stderr.contains("no audio"),
+        "the failure should name the empty range: {stderr}"
+    );
+    assert!(
+        walk_wav_files(&output_dir).is_empty(),
+        "a range that decodes nothing must not leave a 0-frame WAV"
+    );
+}
+
+/// A CSV batch in which every file is rejected must exit non-zero. The
+/// documented `birda clip detections/*.csv && publish` workflow depends on it:
+/// before #319 a fully rejected batch exited 0 and the publish ran anyway.
+#[test]
+fn test_clip_csv_all_files_rejected_exits_nonzero() {
+    let temp_dir = TempDir::new().unwrap();
+    // A non-numeric start makes the row unparseable, so the whole file is
+    // rejected; contrast a non-finite row, which is skipped and the file kept.
+    let csv = write_results_csv(
+        temp_dir.path(),
+        "rec.wav.BirdNET.results.csv",
+        &["abc,3.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "clip",
+            csv.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a fully rejected batch must fail: {stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(
+        stderr.contains("clip extraction failed"),
+        "the batch failure should be named, not surfaced as a generic error: {stderr}"
+    );
+    assert!(
+        walk_wav_files(&output_dir).is_empty(),
+        "a fully rejected batch must not write clips"
+    );
+}
+
+/// One file failing while another succeeds is a partial failure and stays exit
+/// 0: the surviving file's clips are real output. Only a total failure is
+/// non-zero (#319).
+#[test]
+fn test_clip_csv_partial_failure_still_exits_zero() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("good.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    let good = write_results_csv(
+        temp_dir.path(),
+        "good.wav.BirdNET.results.csv",
+        &["0.0,3.0,Parus major,Great Tit,0.85"],
+    );
+    let bad = write_results_csv(
+        temp_dir.path(),
+        "bad.wav.BirdNET.results.csv",
+        &["abc,3.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "clip",
+            good.to_str().unwrap(),
+            bad.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "a partial failure must not fail the whole run: {stderr}"
+    );
+    assert!(
+        stderr.contains("detection file(s) failed to process"),
+        "the partial failure should be summarised on stderr: {stderr}"
+    );
+    assert_eq!(
+        walk_wav_files(&output_dir).len(),
+        1,
+        "the surviving file's clip should still be written"
+    );
+}
+
+/// A detection file whose every detection lies past the end of the file has
+/// work to do and produces nothing. That is distinct from a file with no
+/// detections above the threshold (a legitimate empty result), and must be
+/// reported as a failure rather than a successful run that yielded nothing
+/// (#319).
+#[test]
+fn test_clip_csv_file_that_extracts_nothing_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("rec.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    // A finite, well-ordered range that simply lies beyond the 5s file.
+    let csv = write_results_csv(
+        temp_dir.path(),
+        "rec.wav.BirdNET.results.csv",
+        &["100.0,105.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "clip",
+            csv.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a file that extracts nothing must fail: {stderr}"
+    );
+    assert!(
+        stderr.contains("no clips extracted"),
+        "the failure should name the empty file, not a source-resolution error: {stderr}"
+    );
+    assert!(
+        walk_wav_files(&output_dir).is_empty(),
+        "no clip should be written for an all-out-of-range file"
+    );
+}
+
+/// `--output-mode json` must stay a SINGLE JSON document even on the failure
+/// path. #319 added per-file `error` events; emitting them in plain `json` mode
+/// (rather than `ndjson`) would put N `error` objects ahead of the `result`,
+/// making stdout N+1 top-level objects that `json.loads` cannot parse. So json
+/// mode carries the failures only in the result's `failed_files`. A single
+/// object also proves the result reaches stdout despite the non-zero exit.
+#[test]
+fn test_clip_json_failure_is_a_single_document() {
+    let temp_dir = TempDir::new().unwrap();
+    let csv = write_results_csv(
+        temp_dir.path(),
+        "rec.wav.BirdNET.results.csv",
+        &["abc,3.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "--output-mode",
+            "json",
+            "clip",
+            csv.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    assert!(
+        !output.status.success(),
+        "a fully rejected batch must exit non-zero even in JSON mode"
+    );
+
+    let events = json_events(&output.stdout);
+    assert_eq!(
+        events.len(),
+        1,
+        "json mode must emit exactly one top-level object (the result), not a \
+         stream of error objects ahead of it: {events:?}"
+    );
+    let result = &events[0];
+    assert_eq!(result["event"], "result");
+    assert_eq!(result["payload"]["result_type"], "clip_extraction");
+    let failed = result["payload"]["failed_files"]
+        .as_array()
+        .unwrap_or_else(|| panic!("failed_files should be an array: {result}"));
+    assert_eq!(
+        failed.len(),
+        1,
+        "the rejected file should be listed in failed_files: {result}"
+    );
+}
+
+/// `--output-mode ndjson` is the streaming contract, so there a rejected batch
+/// is visible on both channels: a per-file `error` event as it happens, and
+/// `failed_files` in the final `result`. Before #319 the payload had no failure
+/// channel and nothing emitted the documented `error` event.
+#[test]
+fn test_clip_ndjson_streams_error_events() {
+    let temp_dir = TempDir::new().unwrap();
+    let csv = write_results_csv(
+        temp_dir.path(),
+        "rec.wav.BirdNET.results.csv",
+        &["abc,3.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "--output-mode",
+            "ndjson",
+            "clip",
+            csv.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    assert!(
+        !output.status.success(),
+        "a fully rejected batch must exit non-zero in ndjson mode"
+    );
+
+    let events = json_events(&output.stdout);
+    assert!(
+        events.iter().any(|e| e["event"] == "error"),
+        "ndjson mode should stream a per-file error event: {events:?}"
+    );
+    let result = events
+        .iter()
+        .find(|e| e["event"] == "result")
+        .unwrap_or_else(|| panic!("expected a result event, got: {events:?}"));
+    let failed = result["payload"]["failed_files"]
+        .as_array()
+        .unwrap_or_else(|| panic!("failed_files should be an array: {result}"));
+    assert_eq!(
+        failed.len(),
+        1,
+        "the rejected file should be listed: {result}"
+    );
+}
+
+/// A partial failure in json mode: one file succeeds, one is rejected. The run
+/// exits 0, stays a single document, and the result carries BOTH the extracted
+/// clip and the failure, which is the contract that lets a machine consumer
+/// tell "some recordings had no detections" from "some files failed".
+#[test]
+fn test_clip_json_partial_failure_lists_failed_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let wav_path = temp_dir.path().join("good.wav");
+    create_test_wav(&wav_path, 5, 48000);
+    let good = write_results_csv(
+        temp_dir.path(),
+        "good.wav.BirdNET.results.csv",
+        &["0.0,3.0,Parus major,Great Tit,0.85"],
+    );
+    let bad = write_results_csv(
+        temp_dir.path(),
+        "bad.wav.BirdNET.results.csv",
+        &["abc,3.0,Parus major,Great Tit,0.85"],
+    );
+    let output_dir = temp_dir.path().join("clips");
+
+    let output = birda_cmd()
+        .args([
+            "--output-mode",
+            "json",
+            "clip",
+            good.to_str().unwrap(),
+            bad.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+            "--pre",
+            "0",
+            "--post",
+            "0",
+        ])
+        .output()
+        .expect("failed to execute birda clip");
+
+    assert!(
+        output.status.success(),
+        "a partial failure must exit zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let events = json_events(&output.stdout);
+    assert_eq!(
+        events.len(),
+        1,
+        "json mode must stay a single document on a partial failure: {events:?}"
+    );
+    let payload = &events[0]["payload"];
+    assert_eq!(
+        payload["total_clips"].as_u64().unwrap(),
+        1,
+        "the good file's clip should be counted: {payload}"
+    );
+    assert_eq!(
+        payload["failed_files"].as_array().unwrap().len(),
+        1,
+        "the bad file should be listed even though a clip was produced: {payload}"
+    );
+}


### PR DESCRIPTION
Fixes #319.

`birda clip` could not tell a caller it had failed. Four holes, all closed here:

- The CSV batch route caught every per-file error, downgraded it to a warning, and returned `Ok(())`, so `birda clip detections/*.csv && publish` treated a fully rejected batch as a success. It now exits non-zero on a *total* failure (every input file rejected) and stays exit 0 on a partial one, with the failures surfaced either way.
- A range that decoded no audio (past the end of the file, or too short to hold a frame) was written out as a structurally valid 0-frame WAV and reported as an extracted clip, byte-indistinguishable from a clip truncated by a crash mid-write. `extract_clip` now rejects an empty decode at the single chokepoint both extraction routes share.
- The JSON result had no failure channel. `ClipExtractionPayload` gains `failed_files`, marked `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so an all-success payload is byte-identical to before.
- The `error` event documented in `docs/json-output.md` was emitted by nothing. It is now streamed per failed file in `ndjson` mode. Plain `json` mode stays a single parseable document and carries the failures in `failed_files` instead.

## Exit contract

Non-zero only when the whole batch failed: every detection file was missing, unreadable, malformed, or had every detection fail to extract. A batch where at least one file was processed exits 0, even if other files failed and even if a processed file simply held no detections above the threshold. A direct-extraction range that decodes no audio is an error, not an empty clip.

## Tests

Integration tests cover the total-vs-partial exit boundary, the empty-range rejection on the direct route, a file that has detections but extracts nothing, and the json (single-document) vs ndjson (streaming `error` events) failure channels.