### PR TITLE
fix: serialise config writes so a concurrent writer cannot lose an edit (#313)

### DIFF
--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -2,7 +2,7 @@
 
 use crate::config::Config;
 use crate::error::{Error, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Load configuration from a TOML file.
 ///
@@ -93,11 +93,15 @@ fn write_error(path: &Path, source: std::io::Error) -> Error {
 /// write would have followed a symlink at that name, so the link is resolved
 /// first. See [`resolve_link`].
 ///
-/// Two things this deliberately does not address. The whole file is
-/// re-serialised from the struct, so comments and unrecognised keys are dropped
-/// as they always were. And every caller is a lock-free load-mutate-save, so
-/// two concurrent saves still lose one of the two edits; the rename makes each
-/// write whole, not the pair of them serialised.
+/// One thing this deliberately does not address: the whole file is re-serialised
+/// from the struct, so comments and unrecognised keys are dropped as they always
+/// were.
+///
+/// This is only the validated atomic-write primitive, not the serialisation of a
+/// PAIR of writes. That is [`update_config`]'s job: it holds a lock across the
+/// whole load-mutate-save, so two concurrent writers cannot both load the same
+/// base and lose one of the two edits (#313). Reach for `update_config`, not
+/// `save_config` directly, for any read-modify-write of the live config.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
     super::validate_config(config)?;
 
@@ -195,13 +199,39 @@ fn resolve_link(path: &Path) -> std::path::PathBuf {
     }
 }
 
-/// Save configuration to the default platform-specific path.
+/// Load the config, apply `mutate`, and save it, all under an exclusive lock in
+/// the config directory so a concurrent `birda` cannot load the same base and
+/// lose the update (#313).
 ///
-/// Validates before writing; see [`save_config`].
-pub fn save_default_config(config: &Config) -> Result<std::path::PathBuf> {
+/// The config is loaded INSIDE the lock, so the whole load-mutate-save is
+/// serialised, not just the atomic write [`save_config`] already gives. Work
+/// that does not touch the config (a `models install` download, a confirmation
+/// prompt) MUST stay outside this call, so the lock is held only for the short
+/// write and never for a minutes-long download. `mutate`'s own return value is
+/// handed back alongside the saved config and the path it was written to.
+pub fn update_config<T>(
+    mutate: impl FnOnce(&mut Config) -> Result<T>,
+) -> Result<(T, Config, PathBuf)> {
     let path = super::config_file_path()?;
-    save_config(config, &path)?;
-    Ok(path)
+    let (out, config) = update_config_at(&path, mutate)?;
+    Ok((out, config, path))
+}
+
+/// [`update_config`] against an explicit `path`.
+///
+/// Split out so a test can drive the real load-lock-mutate-save against a
+/// temporary file, rather than the user's platform config path that
+/// [`update_config`] resolves.
+fn update_config_at<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut Config) -> Result<T>,
+) -> Result<(T, Config)> {
+    crate::locking::with_config_lock(path, || {
+        let mut config = load_config_file(path)?;
+        let out = mutate(&mut config)?;
+        save_config(&config, path)?;
+        Ok((out, config))
+    })
 }
 
 #[cfg(test)]
@@ -661,5 +691,80 @@ min_confidence = 0.25
         let loaded = load_config_file(&path).unwrap();
         assert_eq!(loaded.defaults.latitude, Some(60.17));
         assert_eq!(loaded.defaults.longitude, Some(24.94));
+    }
+
+    #[test]
+    fn test_update_config_at_persists_the_mutation_and_returns_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let (out, returned) = update_config_at(&path, |config| {
+            config.defaults.min_confidence = 0.42;
+            Ok("applied")
+        })
+        .unwrap();
+
+        assert_eq!(
+            out, "applied",
+            "the mutation's own return value is handed back"
+        );
+        assert!((returned.defaults.min_confidence - 0.42).abs() < f32::EPSILON);
+
+        // Persisted to disk, not merely returned in memory.
+        let loaded = load_config_file(&path).unwrap();
+        assert!((loaded.defaults.min_confidence - 0.42).abs() < f32::EPSILON);
+    }
+
+    /// The #313 guarantee, exercised through the shipped `update_config` helper
+    /// (via its path-injected core) rather than a hand-rolled copy: two writers
+    /// each load-mutate-save one field; under the lock the second waits for the
+    /// first, so both survive. Lock-free, the later save would discard the
+    /// earlier edit.
+    #[test]
+    fn test_update_config_at_serialises_concurrent_writers() {
+        use std::sync::{Arc, Barrier};
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save_config(&Config::default(), &path).unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let spawn = |field: char| {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                update_config_at(&path, |config| {
+                    match field {
+                        'c' => config.defaults.min_confidence = 0.5,
+                        'o' => config.defaults.overlap = 1.5,
+                        _ => unreachable!(),
+                    }
+                    // Widen the load-mutate-save window so a lock-free helper
+                    // would reliably interleave and clobber.
+                    std::thread::sleep(Duration::from_millis(150));
+                    Ok(())
+                })
+                .unwrap();
+            })
+        };
+
+        let a = spawn('c');
+        let b = spawn('o');
+        a.join().unwrap();
+        b.join().unwrap();
+
+        let loaded = load_config_file(&path).unwrap();
+        assert!(
+            (loaded.defaults.min_confidence - 0.5).abs() < f32::EPSILON,
+            "the min_confidence edit was lost to an interleaved save: {}",
+            loaded.defaults.min_confidence
+        );
+        assert!(
+            (loaded.defaults.overlap - 1.5).abs() < f32::EPSILON,
+            "the overlap edit was lost to an interleaved save: {}",
+            loaded.defaults.overlap
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ mod types;
 mod validate;
 
 pub use bat::{BatConfig, BatRegion};
-pub use file::{load_config_file, load_default_config, save_config, save_default_config};
+pub use file::{load_config_file, load_default_config, save_config, update_config};
 pub use geomodel::{GeomodelRequest, GeomodelResolution, resolve_geomodel};
 pub use paths::{config_dir, config_file_path, tensorrt_cache_dir};
 pub use types::{

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -150,6 +150,36 @@ pub const DEFAULT_TOP_K: usize = 5;
 /// Lock file extension.
 pub const LOCK_FILE_EXTENSION: &str = ".birda.lock";
 
+/// Tuning for the exclusive lock that serialises config read-modify-write.
+///
+/// The lock closes #313: #307 made each config write atomic, but two concurrent
+/// writers still both load the old file and the later save discards the earlier
+/// edit. This lock spans the whole load-mutate-save so a pair of writes is
+/// serialised, not just each write made whole.
+pub mod config_lock {
+    use std::time::Duration;
+
+    /// Suffix appended to the config file name to form its sibling lock file,
+    /// e.g. `config.toml` -> `config.toml.birda.lock`.
+    ///
+    /// Shares `FileLock`'s `.birda.lock` spelling so the sibling file is clearly
+    /// a birda artefact, which the "delete the lock file" recovery advice relies
+    /// on. The two locks never collide: they live in different directories and
+    /// use separate registries.
+    pub const LOCK_SUFFIX: &str = ".birda.lock";
+
+    /// How long to keep retrying a contended lock before giving up.
+    ///
+    /// A config read-modify-write is sub-second, so this easily outlasts
+    /// legitimate contention (a concurrent `models install` only holds the lock
+    /// for the write, not its download) while still bounding the wait behind a
+    /// wedged peer.
+    pub const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Delay between acquisition attempts.
+    pub const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+}
+
 /// Output file extensions by format.
 pub mod output_extensions {
     /// CSV output extension.

--- a/src/error.rs
+++ b/src/error.rs
@@ -602,6 +602,20 @@ pub enum Error {
         attempted: usize,
     },
 
+    /// The configuration is locked by another `birda` process.
+    ///
+    /// Returned when the config lock cannot be acquired within its timeout, so a
+    /// read-modify-write of `config.toml` is not attempted against a concurrent
+    /// writer that would otherwise lose one of the two edits (#313).
+    #[error(
+        "the configuration is locked by another birda process (lock file '{path}'); \
+         retry, or delete the lock file if no other birda is running"
+    )]
+    ConfigLocked {
+        /// Path to the lock file that could not be acquired.
+        path: std::path::PathBuf,
+    },
+
     /// Every detection file in a clip batch failed to process.
     ///
     /// `birda clip` treats a per-file problem as a warning and continues, so a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ use cli::{AnalyzeArgs, Cli, Command};
 use config::{
     BatConfig, Config, InferenceDevice, ModelConfig, ModelType, OutputFormat, OutputMode,
     config_file_path, load_default_config, range_filter::build_range_filter_config,
-    save_default_config,
 };
 use constants::DEFAULT_TOP_K;
 use inference::BirdClassifier;
@@ -337,6 +336,7 @@ pub fn run() -> Result<()> {
     // Install Ctrl+C handler to clean up lock files on interrupt
     if let Err(e) = ctrlc::set_handler(|| {
         locking::cleanup_all_locks();
+        locking::cleanup_all_config_locks();
         std::process::exit(130); // 128 + SIGINT(2)
     }) {
         warn!("Failed to install Ctrl+C handler: {e}");
@@ -1310,17 +1310,26 @@ fn handle_config_command(action: cli::ConfigAction, output_mode: OutputMode) -> 
     match action {
         ConfigAction::Init => {
             let path = config_file_path()?;
-            if path.exists() {
-                println!("Configuration file already exists: {}", path.display());
-                println!("Use 'birda models add' to add models.");
-            } else {
-                let config = Config::default();
-                let saved_path = save_default_config(&config)?;
-                println!("Created configuration file: {}", saved_path.display());
+            // Re-check existence and create the file under the config lock, so an
+            // `init` racing a `config set` cannot clobber the set's file with a
+            // fresh default (#313).
+            let created = locking::with_config_lock(&path, || {
+                if path.exists() {
+                    Ok(false)
+                } else {
+                    config::save_config(&Config::default(), &path)?;
+                    Ok(true)
+                }
+            })?;
+            if created {
+                println!("Created configuration file: {}", path.display());
                 println!("\nNext steps:");
                 println!(
                     "  birda models add <name> --path <model.onnx> --labels <labels.txt> --type <type> --default"
                 );
+            } else {
+                println!("Configuration file already exists: {}", path.display());
+                println!("Use 'birda models add' to add models.");
             }
             Ok(())
         }
@@ -1395,151 +1404,151 @@ fn parse_config_value<T>(
 }
 
 fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<()> {
-    let mut config = load_default_config()?;
-    let config_path = config_file_path()?;
+    let ((), config, config_path) = config::update_config(|config| {
+        match key {
+            "defaults.model" => {
+                config.defaults.model = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
+            "defaults.min_confidence" => {
+                config.defaults.min_confidence = if value.is_empty() {
+                    config::DefaultsConfig::default().min_confidence
+                } else {
+                    parse_config_value(key, value, cli::validators::parse_confidence)?
+                };
+            }
+            "defaults.overlap" => {
+                config.defaults.overlap = if value.is_empty() {
+                    config::DefaultsConfig::default().overlap
+                } else {
+                    parse_config_value(key, value, cli::validators::parse_overlap)?
+                };
+            }
+            "defaults.latitude" => {
+                config.defaults.latitude = if value.is_empty() {
+                    None
+                } else {
+                    Some(parse_config_value(
+                        key,
+                        value,
+                        cli::validators::parse_latitude,
+                    )?)
+                };
+            }
+            "defaults.longitude" => {
+                config.defaults.longitude = if value.is_empty() {
+                    None
+                } else {
+                    Some(parse_config_value(
+                        key,
+                        value,
+                        cli::validators::parse_longitude,
+                    )?)
+                };
+            }
+            "defaults.batch_size" => {
+                config.defaults.batch_size = if value.is_empty() {
+                    None
+                } else {
+                    Some(parse_config_value(
+                        key,
+                        value,
+                        cli::validators::parse_batch_size,
+                    )?)
+                };
+            }
+            // No arm existed for this key, so hand-editing config.toml was the only
+            // way to set it, and that was the one route `validate_defaults` did not
+            // check either (#312). Both halves are closed now.
+            "defaults.day_of_year" => {
+                config.defaults.day_of_year = if value.is_empty() {
+                    None
+                } else {
+                    Some(parse_config_value(
+                        key,
+                        value,
+                        cli::validators::parse_day_of_year,
+                    )?)
+                };
+            }
+            "defaults.range_threshold" => {
+                config.defaults.range_threshold = if value.is_empty() {
+                    config::DefaultsConfig::default().range_threshold
+                } else {
+                    // `parse_confidence` rather than a threshold-specific parser
+                    // because `--range-threshold` already uses it: both are bounded
+                    // by `confidence::MIN`/`MAX`, and a second parser would be a
+                    // second copy of one rule. The message it produces says
+                    // "confidence", which the key prefix disambiguates.
+                    parse_config_value(key, value, cli::validators::parse_confidence)?
+                };
+            }
+            // The three keys below are siblings of range_threshold above. They were
+            // missed when the geomodel landed, so reaching them meant hand-editing
+            // config.toml. (The GUI's only config write is `config set
+            // defaults.model`, which reaches this same handler and is serialised
+            // by the #313 lock like any other; it never sets these three.)
+            "defaults.geomodel" => {
+                config.defaults.geomodel = if value.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(value))
+                };
+            }
+            "defaults.geomodel_labels" => {
+                config.defaults.geomodel_labels = if value.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(value))
+                };
+            }
+            "defaults.range_unmatched" => {
+                config.defaults.range_unmatched = if value.is_empty() {
+                    config::DefaultsConfig::default().range_unmatched
+                } else {
+                    // Parsed through clap's ValueEnum so `config set` accepts
+                    // exactly the spellings `--range-unmatched` accepts, rather
+                    // than a second, drifting list. The error message derives its
+                    // list the same way, so adding a variant cannot leave the two
+                    // out of step.
+                    <config::UnmatchedPolicy as clap::ValueEnum>::from_str(value, false).map_err(
+                        |_| {
+                            let accepted =
+                                <config::UnmatchedPolicy as clap::ValueEnum>::value_variants()
+                                    .iter()
+                                    .filter_map(clap::ValueEnum::to_possible_value)
+                                    .map(|v| format!("'{}'", v.get_name()))
+                                    .collect::<Vec<_>>()
+                                    .join(" or ");
+                            Error::ConfigValidation {
+                                message: format!(
+                                    "invalid value for '{key}': {value} (expected {accepted})"
+                                ),
+                            }
+                        },
+                    )?
+                };
+            }
+            _ => {
+                return Err(Error::InvalidConfigKey {
+                    key: key.to_string(),
+                });
+            }
+        }
+        Ok(())
+    })?;
 
-    match key {
-        "defaults.model" => {
-            config.defaults.model = if value.is_empty() {
-                None
-            } else {
-                Some(value.to_string())
-            };
-        }
-        "defaults.min_confidence" => {
-            config.defaults.min_confidence = if value.is_empty() {
-                config::DefaultsConfig::default().min_confidence
-            } else {
-                parse_config_value(key, value, cli::validators::parse_confidence)?
-            };
-        }
-        "defaults.overlap" => {
-            config.defaults.overlap = if value.is_empty() {
-                config::DefaultsConfig::default().overlap
-            } else {
-                parse_config_value(key, value, cli::validators::parse_overlap)?
-            };
-        }
-        "defaults.latitude" => {
-            config.defaults.latitude = if value.is_empty() {
-                None
-            } else {
-                Some(parse_config_value(
-                    key,
-                    value,
-                    cli::validators::parse_latitude,
-                )?)
-            };
-        }
-        "defaults.longitude" => {
-            config.defaults.longitude = if value.is_empty() {
-                None
-            } else {
-                Some(parse_config_value(
-                    key,
-                    value,
-                    cli::validators::parse_longitude,
-                )?)
-            };
-        }
-        "defaults.batch_size" => {
-            config.defaults.batch_size = if value.is_empty() {
-                None
-            } else {
-                Some(parse_config_value(
-                    key,
-                    value,
-                    cli::validators::parse_batch_size,
-                )?)
-            };
-        }
-        // No arm existed for this key, so hand-editing config.toml was the only
-        // way to set it, and that was the one route `validate_defaults` did not
-        // check either (#312). Both halves are closed now.
-        "defaults.day_of_year" => {
-            config.defaults.day_of_year = if value.is_empty() {
-                None
-            } else {
-                Some(parse_config_value(
-                    key,
-                    value,
-                    cli::validators::parse_day_of_year,
-                )?)
-            };
-        }
-        "defaults.range_threshold" => {
-            config.defaults.range_threshold = if value.is_empty() {
-                config::DefaultsConfig::default().range_threshold
-            } else {
-                // `parse_confidence` rather than a threshold-specific parser
-                // because `--range-threshold` already uses it: both are bounded
-                // by `confidence::MIN`/`MAX`, and a second parser would be a
-                // second copy of one rule. The message it produces says
-                // "confidence", which the key prefix disambiguates.
-                parse_config_value(key, value, cli::validators::parse_confidence)?
-            };
-        }
-        // The three keys below are siblings of range_threshold above. They were
-        // missed when the geomodel landed, so reaching them meant hand-editing
-        // config.toml. (Only users: the GUI has no config write path at all, it
-        // shells out to `config show` and `config path` only.)
-        "defaults.geomodel" => {
-            config.defaults.geomodel = if value.is_empty() {
-                None
-            } else {
-                Some(PathBuf::from(value))
-            };
-        }
-        "defaults.geomodel_labels" => {
-            config.defaults.geomodel_labels = if value.is_empty() {
-                None
-            } else {
-                Some(PathBuf::from(value))
-            };
-        }
-        "defaults.range_unmatched" => {
-            config.defaults.range_unmatched = if value.is_empty() {
-                config::DefaultsConfig::default().range_unmatched
-            } else {
-                // Parsed through clap's ValueEnum so `config set` accepts
-                // exactly the spellings `--range-unmatched` accepts, rather
-                // than a second, drifting list. The error message derives its
-                // list the same way, so adding a variant cannot leave the two
-                // out of step.
-                <config::UnmatchedPolicy as clap::ValueEnum>::from_str(value, false).map_err(
-                    |_| {
-                        let accepted =
-                            <config::UnmatchedPolicy as clap::ValueEnum>::value_variants()
-                                .iter()
-                                .filter_map(clap::ValueEnum::to_possible_value)
-                                .map(|v| format!("'{}'", v.get_name()))
-                                .collect::<Vec<_>>()
-                                .join(" or ");
-                        Error::ConfigValidation {
-                            message: format!(
-                                "invalid value for '{key}': {value} (expected {accepted})"
-                            ),
-                        }
-                    },
-                )?
-            };
-        }
-        _ => {
-            return Err(Error::InvalidConfigKey {
-                key: key.to_string(),
-            });
-        }
-    }
-
-    // Validation happens inside `save_config`, which `save_default_config`
-    // delegates to and every config writer reaches, so the mutated config is
-    // rejected before anything is written.
+    // `update_config` validates the whole config inside `save_config` before
+    // writing, and holds the config lock across the load-mutate-save so a
+    // concurrent writer cannot lose this edit (#313).
     //
-    // Note this validates the whole config, not just the key being set, so a
-    // file carrying two independent faults cannot be repaired one key at a time
-    // here. That predates #295 and is tracked separately; the load gate is
+    // Note the validation covers the whole config, not just the key being set,
+    // so a file carrying two independent faults cannot be repaired one key at a
+    // time here. That predates #295 and is tracked separately; the load gate is
     // scoped to analysis so it does not turn that into a lockout.
-    save_default_config(&config)?;
 
     if output_mode.is_structured() {
         let config_json = serde_json::to_value(&config).map_err(|e| Error::ConfigValidation {
@@ -1625,7 +1634,7 @@ fn handle_models_command(
             labels,
             r#type,
             default,
-        } => handle_models_add(name, path, labels, r#type, default),
+        } => handle_models_add(&name, &path, &labels, r#type, default),
         ModelsAction::Check => {
             // Leftover <name>.<pid>.part files from a download interrupted
             // before it finished, reported on both output paths so a directory
@@ -1812,54 +1821,58 @@ fn handle_models_command(
 
 /// Handle the `models add` command.
 fn handle_models_add(
-    name: String,
-    path: PathBuf,
-    labels: PathBuf,
+    name: &str,
+    path: &Path,
+    labels: &Path,
     model_type: ModelType,
     set_default: bool,
 ) -> Result<()> {
     // Validate files exist
     if !path.exists() {
-        return Err(Error::ModelFileNotFound { path });
+        return Err(Error::ModelFileNotFound {
+            path: path.to_path_buf(),
+        });
     }
     if !labels.exists() {
-        return Err(Error::LabelsFileNotFound { path: labels });
+        return Err(Error::LabelsFileNotFound {
+            path: labels.to_path_buf(),
+        });
     }
 
-    // Load existing config
-    let mut config = load_default_config()?;
+    // Load, check, insert and save under the config lock. The existence check
+    // and the insert must be atomic against a concurrent writer, so both live
+    // inside the locked closure (#313).
+    let ((), _config, config_path) = config::update_config(|config| {
+        if config.models.contains_key(name) {
+            return Err(Error::ModelAlreadyExists {
+                name: name.to_string(),
+            });
+        }
 
-    // Check if model already exists
-    if config.models.contains_key(&name) {
-        return Err(Error::ModelAlreadyExists { name });
-    }
+        config.models.insert(
+            name.to_string(),
+            ModelConfig {
+                registry_id: None,
+                installed_version: None,
+                installed_build: None,
+                region: None,
+                variant: None,
+                path: path.to_path_buf(),
+                labels: labels.to_path_buf(),
+                model_type,
+                meta_model: None,
+                bsg_calibration: None,
+                bsg_migration: None,
+                bsg_distribution_maps: None,
+            },
+        );
 
-    // Add the model
-    config.models.insert(
-        name.clone(),
-        ModelConfig {
-            registry_id: None,
-            installed_version: None,
-            installed_build: None,
-            region: None,
-            variant: None,
-            path: path.clone(),
-            labels: labels.clone(),
-            model_type,
-            meta_model: None,
-            bsg_calibration: None,
-            bsg_migration: None,
-            bsg_distribution_maps: None,
-        },
-    );
+        if set_default {
+            config.defaults.model = Some(name.to_string());
+        }
 
-    // Set as default if requested
-    if set_default {
-        config.defaults.model = Some(name.clone());
-    }
-
-    // Save config
-    let config_path = save_default_config(&config)?;
+        Ok(())
+    })?;
 
     // Print success message
     println!("Added model '{name}' ({model_type})");
@@ -1932,14 +1945,15 @@ fn handle_models_remove(
 ) -> Result<()> {
     use std::io::Write;
 
-    // Load config and verify model exists
-    let mut config = load_default_config()?;
-
-    // If purge, confirm before deleting files (skip in structured mode).
+    // Confirm before deleting files (skip in structured mode).
     //
     // `--yes` is honoured here because the flag is global and therefore appears
     // in this command's `--help`. A prompt that advertises the flag and then
     // ignores it is the same defect as a flag that never reaches the command.
+    //
+    // Prompted before the lock, not inside it: the prompt waits on the user, and
+    // holding the config lock across that would block every other config write
+    // for as long as the user takes to answer.
     if purge && !output_mode.is_structured() && !assume_yes {
         print!("This will delete model files for '{name}' from disk. Continue? [y/N]: ");
         std::io::stdout().flush()?;
@@ -1951,11 +1965,12 @@ fn handle_models_remove(
         }
     }
 
-    // Remove from config and handle default promotion
-    let (model, promoted) = remove_model_from_config(&mut config, name)?;
-
-    // Save config before deleting files (safer: config stays consistent even if delete fails)
-    let config_path = save_default_config(&config)?;
+    // Remove from config and handle default promotion under the config lock, so
+    // the load-mutate-save is serialised against a concurrent writer (#313).
+    // Files are deleted afterward, outside the lock: the config stays consistent
+    // even if a delete fails, and deleting model files does not touch the config.
+    let ((model, promoted), config, config_path) =
+        config::update_config(|config| remove_model_from_config(config, name))?;
 
     // Build the structured-output payload once for reuse in both the error and success paths.
     let structured_payload = ModelRemovedPayload {
@@ -2219,44 +2234,45 @@ fn handle_models_install(
     // download. The load above exists only to read the inference device for
     // variant selection, and the download between them can take minutes on a
     // 557 MB model: saving the stale copy would silently discard any `config
-    // set` or second install that landed in the meantime. This keeps the
-    // load/mutate/save window as narrow as it was before selection needed the
-    // device.
-    let mut config = load_default_config()?;
+    // set` or second install that landed in the meantime. Under the config lock
+    // this load-mutate-save is also serialised, so a concurrent writer cannot
+    // lose this install either (#313). The download stays outside the lock, so
+    // it never holds the lock for those minutes.
+    let (orphans, _config, _config_path) = config::update_config(|config| {
+        // Collected before the insert overwrites the entry that names them, and
+        // deleted only after the config is saved: a crash in between leaves a
+        // config that points exclusively at files which exist.
+        let mut keeping = vec![model_path.clone(), labels_path.clone()];
+        keeping.extend(installed.bsg_calibration.clone());
+        keeping.extend(installed.bsg_migration.clone());
+        keeping.extend(installed.bsg_distribution_maps.clone());
+        let orphans = registry::orphaned_files(config, &config_key, &keeping);
 
-    // Collected before the insert overwrites the entry that names them, and
-    // deleted only after the config is saved: a crash in between leaves a
-    // config that points exclusively at files which exist.
-    let mut keeping = vec![model_path.clone(), labels_path.clone()];
-    keeping.extend(installed.bsg_calibration.clone());
-    keeping.extend(installed.bsg_migration.clone());
-    keeping.extend(installed.bsg_distribution_maps.clone());
-    let orphans = registry::orphaned_files(&config, &config_key, &keeping);
+        let provenance = installed.provenance;
+        config.models.insert(
+            config_key.clone(),
+            ModelConfig {
+                registry_id: Some(id.to_string()),
+                installed_version: provenance.as_ref().map(|p| p.version.clone()),
+                installed_build: provenance.as_ref().and_then(|p| p.build),
+                region: provenance.as_ref().and_then(|p| p.region.clone()),
+                variant: provenance.as_ref().and_then(|p| p.variant.clone()),
+                path: installed.model,
+                labels: installed.labels,
+                model_type,
+                meta_model: None,
+                bsg_calibration: installed.bsg_calibration,
+                bsg_migration: installed.bsg_migration,
+                bsg_distribution_maps: installed.bsg_distribution_maps,
+            },
+        );
 
-    let provenance = installed.provenance;
-    config.models.insert(
-        config_key.clone(),
-        ModelConfig {
-            registry_id: Some(id.to_string()),
-            installed_version: provenance.as_ref().map(|p| p.version.clone()),
-            installed_build: provenance.as_ref().and_then(|p| p.build),
-            region: provenance.as_ref().and_then(|p| p.region.clone()),
-            variant: provenance.as_ref().and_then(|p| p.variant.clone()),
-            path: installed.model,
-            labels: installed.labels,
-            model_type,
-            meta_model: None,
-            bsg_calibration: installed.bsg_calibration,
-            bsg_migration: installed.bsg_migration,
-            bsg_distribution_maps: installed.bsg_distribution_maps,
-        },
-    );
+        if should_set_default {
+            config.defaults.model = Some(config_key.clone());
+        }
 
-    if should_set_default {
-        config.defaults.model = Some(config_key.clone());
-    }
-
-    save_default_config(&config)?;
+        Ok(orphans)
+    })?;
 
     // Files the replaced entry owned and nothing else references. Published
     // filenames never change, so an upgrade writes new files beside the old
@@ -2375,10 +2391,12 @@ fn handle_geomodel_install(
     })?;
     let installed = runtime.block_on(registry::install_range_filter(asset))?;
 
-    let mut config = load_default_config()?;
-    config.defaults.geomodel = Some(installed.model.clone());
-    config.defaults.geomodel_labels = Some(installed.labels.clone());
-    save_default_config(&config)?;
+    // Serialised load-mutate-save (#313); the download above is outside the lock.
+    config::update_config(|config| {
+        config.defaults.geomodel = Some(installed.model.clone());
+        config.defaults.geomodel_labels = Some(installed.labels.clone());
+        Ok(())
+    })?;
 
     if !output_mode.is_structured() {
         println!();

--- a/src/locking/config_lock.rs
+++ b/src/locking/config_lock.rs
@@ -41,17 +41,27 @@ static ACTIVE_CONFIG_LOCKS: LazyLock<Mutex<Vec<PathBuf>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
 /// Register a held lock path for signal cleanup.
+///
+/// Recovers from a poisoned mutex (`unwrap_or_else(into_inner)`) rather than
+/// skipping the update, matching [`cleanup_all_config_locks`]. If a panic while
+/// holding the lock left `register`/`unregister` no-ops but cleanup still
+/// draining, an unregister could silently not happen and cleanup would later
+/// delete a peer's fresh lock at that path.
 fn register(path: &Path) {
-    if let Ok(mut locks) = ACTIVE_CONFIG_LOCKS.lock() {
-        locks.push(path.to_path_buf());
-    }
+    let mut locks = ACTIVE_CONFIG_LOCKS
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    locks.push(path.to_path_buf());
 }
 
 /// Unregister a lock path once it is released.
+///
+/// Poison-recovering for the same reason as [`register`].
 fn unregister(path: &Path) {
-    if let Ok(mut locks) = ACTIVE_CONFIG_LOCKS.lock() {
-        locks.retain(|p| p != path);
-    }
+    let mut locks = ACTIVE_CONFIG_LOCKS
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    locks.retain(|p| p != path);
 }
 
 /// Remove every held config lock. Called from the Ctrl+C handler.

--- a/src/locking/config_lock.rs
+++ b/src/locking/config_lock.rs
@@ -1,0 +1,297 @@
+//! Serialising lock for the config file's read-modify-write (#313).
+//!
+//! #307 made each config write atomic, so a reader sees the whole old file or
+//! the whole new one. It did not serialise a PAIR of writes: two `birda`
+//! processes both load `{X}`, one saves `{X,Y}`, the other saves `{X,Z}`, and
+//! `Y` is gone with no error at any point. This lock spans the whole
+//! load-mutate-save, so the second writer waits for the first instead of loading
+//! the same base and clobbering the edit.
+//!
+//! It is an `O_CREAT|O_EXCL` lock file beside the config (the issue's first
+//! suggestion), mirroring [`super::FileLock`]'s create/registry/Drop shape. Two
+//! deliberate choices:
+//!
+//! - It retries briefly instead of failing on the first miss, because config
+//!   writes are sub-second and a fail-fast lock would turn ordinary back-to-back
+//!   `config set`/`models` commands into spurious errors.
+//! - It does NOT auto-break a lock left behind. Breaking an existence lock by age
+//!   or liveness is a time-of-check/time-of-use race: two processes can both
+//!   judge the same lock breakable, and the second's blind remove deletes the
+//!   first's fresh lock, putting both into the critical section, which is the
+//!   exact data loss this lock exists to prevent. Instead a lock is released on
+//!   normal exit (Drop), on Ctrl+C ([`cleanup_all_config_locks`]), and on panic
+//!   (unwind runs Drop); only a hard kill or power loss leaves one behind, and
+//!   [`Error::ConfigLocked`] then tells the user to delete it. A future move to
+//!   an advisory lock (`flock`/`LockFileEx`, released by the kernel on process
+//!   death) would restore automatic recovery without the race.
+//!
+//! The registry is deliberately separate from `file_lock`'s: one shared `Vec`
+//! would let either type's cleanup remove the other's lock file.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use crate::constants::config_lock::{ACQUIRE_TIMEOUT, LOCK_SUFFIX, RETRY_INTERVAL};
+use crate::error::{Error, Result};
+
+/// Active config-lock paths, removed if the process is interrupted.
+static ACTIVE_CONFIG_LOCKS: LazyLock<Mutex<Vec<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Register a held lock path for signal cleanup.
+fn register(path: &Path) {
+    if let Ok(mut locks) = ACTIVE_CONFIG_LOCKS.lock() {
+        locks.push(path.to_path_buf());
+    }
+}
+
+/// Unregister a lock path once it is released.
+fn unregister(path: &Path) {
+    if let Ok(mut locks) = ACTIVE_CONFIG_LOCKS.lock() {
+        locks.retain(|p| p != path);
+    }
+}
+
+/// Remove every held config lock. Called from the Ctrl+C handler.
+///
+/// Recovers from a poisoned mutex so cleanup still runs after a panic, and
+/// drains the registry so each path is removed once. Only paths this process has
+/// successfully acquired are ever registered, so this never removes a peer's
+/// lock.
+pub fn cleanup_all_config_locks() {
+    let paths = {
+        let mut locks = ACTIVE_CONFIG_LOCKS
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        std::mem::take(&mut *locks)
+    };
+    for path in paths {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// RAII guard serialising a config load-mutate-save against other processes.
+#[derive(Debug)]
+struct ConfigLock {
+    lock_path: PathBuf,
+}
+
+impl ConfigLock {
+    /// Acquire the exclusive config lock beside `config_path`.
+    ///
+    /// Retries on contention up to [`ACQUIRE_TIMEOUT`], then returns
+    /// [`Error::ConfigLocked`]. Does not break a lock left by a crashed process;
+    /// see the module docs for why, and for how a leftover lock is recovered.
+    fn acquire(config_path: &Path) -> Result<Self> {
+        Self::acquire_with(config_path, ACQUIRE_TIMEOUT)
+    }
+
+    /// [`Self::acquire`] with an explicit timeout, so tests need not wait seconds.
+    fn acquire_with(config_path: &Path, timeout: Duration) -> Result<Self> {
+        let lock_path = lock_path_for(config_path);
+
+        // The lock create and the later save both need the directory to exist.
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| Error::LockCreate {
+                path: lock_path.clone(),
+                source: e,
+            })?;
+        }
+
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            match try_create(&lock_path) {
+                Ok(()) => {
+                    // Registered only AFTER we own the file, so a path we do not
+                    // own is never in the registry and a Ctrl+C can never make
+                    // `cleanup_all_config_locks` delete a peer's lock. The cost is
+                    // a Ctrl+C in the create-then-register gap leaking our own
+                    // lock, which is a manual delete, not lost data.
+                    register(&lock_path);
+                    return Ok(Self { lock_path });
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if Instant::now() >= deadline {
+                        return Err(Error::ConfigLocked { path: lock_path });
+                    }
+                    std::thread::sleep(RETRY_INTERVAL);
+                }
+                Err(e) => {
+                    return Err(Error::LockCreate {
+                        path: lock_path,
+                        source: e,
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ConfigLock {
+    fn drop(&mut self) {
+        // Unregister BEFORE removing the file, not after. A Ctrl+C landing
+        // between the two then leaks only our own lock file (a manual delete),
+        // never a peer's: once the path is out of the registry our signal cleanup
+        // ignores it, so a peer that re-creates a lock at this path right after
+        // our remove cannot be caught by our cleanup. The other order leaves a
+        // window where the path is still registered but the file at it is a
+        // peer's fresh lock, which cleanup would then delete.
+        unregister(&self.lock_path);
+        // Safe to remove by path: nothing breaks a held lock, so while we hold it
+        // the file at `lock_path` is always the one we created.
+        let _ = std::fs::remove_file(&self.lock_path);
+    }
+}
+
+/// Run `f` while holding the config lock, releasing it when `f` returns.
+///
+/// The lock is dropped (and the lock file removed) whether `f` returns `Ok` or
+/// `Err`. Wrap the whole load-mutate-save in `f`, not just the save, so a
+/// concurrent writer cannot load the same base and clobber the edit.
+///
+/// Not re-entrant: `f` must not call `with_config_lock` or `update_config` again
+/// for the same config, or it will block on its own lock until the timeout.
+pub fn with_config_lock<T>(config_path: &Path, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    let _lock = ConfigLock::acquire(config_path)?;
+    f()
+}
+
+/// The lock file path beside `config_path`
+/// (`config.toml` -> `config.toml.birda.lock`).
+fn lock_path_for(config_path: &Path) -> PathBuf {
+    let name = config_path.file_name().map_or_else(
+        || std::borrow::Cow::Borrowed("config"),
+        |n| n.to_string_lossy(),
+    );
+    config_path.with_file_name(format!("{name}{LOCK_SUFFIX}"))
+}
+
+/// Create the lock file exclusively, writing best-effort debug info.
+fn try_create(lock_path: &Path) -> std::io::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(lock_path)?;
+    // For a human debugging a stuck lock only; a write failure does not matter.
+    let host = hostname::get().map_or_else(
+        |_| "unknown".to_string(),
+        |h| h.to_string_lossy().into_owned(),
+    );
+    let _ = writeln!(file, "pid={}\nhost={host}", std::process::id());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cfg_path(dir: &TempDir) -> PathBuf {
+        dir.path().join("config.toml")
+    }
+
+    #[test]
+    fn test_acquire_creates_lock_and_drop_removes_it() {
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        let lock_path = lock_path_for(&path);
+        {
+            let _lock = ConfigLock::acquire(&path).unwrap();
+            assert!(lock_path.exists(), "the lock file should exist while held");
+        }
+        assert!(
+            !lock_path.exists(),
+            "the lock file should be removed on drop"
+        );
+    }
+
+    #[test]
+    fn test_lock_path_is_a_sibling_of_the_config() {
+        let path = Path::new("/etc/birda/config.toml");
+        assert_eq!(
+            lock_path_for(path),
+            PathBuf::from("/etc/birda/config.toml.birda.lock")
+        );
+    }
+
+    #[test]
+    fn test_second_acquire_is_refused_while_held() {
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        let _held = ConfigLock::acquire(&path).unwrap();
+        // Short timeout so the test does not wait the production five seconds.
+        let contended = ConfigLock::acquire_with(&path, Duration::from_millis(80));
+        assert!(
+            matches!(contended, Err(Error::ConfigLocked { .. })),
+            "a held lock must refuse a second acquirer: {contended:?}"
+        );
+    }
+
+    #[test]
+    fn test_acquire_succeeds_after_release() {
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        drop(ConfigLock::acquire(&path).unwrap());
+        assert!(
+            ConfigLock::acquire(&path).is_ok(),
+            "a released lock must be re-acquirable"
+        );
+    }
+
+    #[test]
+    fn test_a_leftover_lock_blocks_until_removed() {
+        // A lock left by a crashed process is NOT auto-broken (that would be a
+        // TOCTOU race); it blocks until it is deleted.
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        let lock_path = lock_path_for(&path);
+        std::fs::write(&lock_path, b"pid=999999\nhost=ghost").unwrap();
+
+        let blocked = ConfigLock::acquire_with(&path, Duration::from_millis(80));
+        assert!(
+            matches!(blocked, Err(Error::ConfigLocked { .. })),
+            "a leftover lock must block, not be stolen: {blocked:?}"
+        );
+
+        std::fs::remove_file(&lock_path).unwrap();
+        assert!(
+            ConfigLock::acquire(&path).is_ok(),
+            "once the leftover lock is deleted, acquisition succeeds"
+        );
+    }
+
+    #[test]
+    fn test_with_config_lock_returns_value_and_releases() {
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        let lock_path = lock_path_for(&path);
+        let out: i32 = with_config_lock(&path, || Ok(42)).unwrap();
+        assert_eq!(out, 42);
+        assert!(
+            !lock_path.exists(),
+            "with_config_lock must release the lock on return"
+        );
+    }
+
+    #[test]
+    fn test_with_config_lock_releases_on_error() {
+        let dir = TempDir::new().unwrap();
+        let path = cfg_path(&dir);
+        let lock_path = lock_path_for(&path);
+        let result: Result<()> = with_config_lock(&path, || {
+            Err(Error::ConfigLocked {
+                path: cfg_path(&dir),
+            })
+        });
+        assert!(result.is_err());
+        assert!(
+            !lock_path.exists(),
+            "the lock must be released even when the closure returns Err"
+        );
+        // Provably released: a fresh acquire wins immediately.
+        assert!(ConfigLock::acquire(&path).is_ok());
+    }
+}

--- a/src/locking/mod.rs
+++ b/src/locking/mod.rs
@@ -1,5 +1,7 @@
-//! File locking for distributed processing.
+//! File locking for distributed processing and config serialisation.
 
+mod config_lock;
 mod file_lock;
 
+pub use config_lock::{cleanup_all_config_locks, with_config_lock};
 pub use file_lock::{FileLock, LockInfo, cleanup_all_locks};


### PR DESCRIPTION
Fixes #313.

#307 made each config write atomic, but every writer was still a lock-free load-mutate-save: `config set`, `models add/remove/install` and the geomodel install each load the whole config, change one part, and save it back. Two concurrent runs both load `{X}`, one saves `{X,Y}`, the other saves `{X,Z}`, and `Y` is gone with no error at any point. The realistic trigger is a `models install` running while the user (or the GUI, which shells out `config set defaults.model`) edits something in another terminal.

This serialises the whole load-mutate-save so the second writer waits for the first.

## What changed

- A new `config::update_config(|cfg| ...)` helper loads the config inside an exclusive lock, applies the mutation, and saves. The read-modify-write is serialised, not just each write made whole (which #307 already did). All six config writers route through it (or `with_config_lock` for `config init`). Work that does not touch the config stays outside the lock: a `models install` download can take minutes, and a `models remove` confirmation prompt waits on the user, so neither holds the lock.
- The lock is an `O_CREAT|O_EXCL` file beside `config.toml` (`config.toml.birda.lock`). It is released on normal exit (RAII), on Ctrl+C, and on panic. It is registered for signal cleanup only after it is won, and unregistered before its file is removed, so a signal can never make cleanup delete another process's lock.

## Stale locks are not auto-broken, on purpose

I first added a "steal a lock older than 30s" recovery, but breaking an existence-based lock by age is a TOCTOU race: two processes can both judge the same lock stale, and the second's blind `remove` deletes the first's fresh lock, putting both into the critical section, which is the exact data loss this fixes. So a lock left behind by a hard-killed process (SIGKILL, power loss) is not auto-broken; it blocks with a clear `ConfigLocked` error telling the user to delete the lock file. Ctrl+C, normal exit and panic all clean up, so only a hard kill leaves one behind. Moving to an advisory lock (`flock`/`LockFileEx`, released by the kernel on process death) is the future path to automatic recovery without the race.

## User-visible notes

- A `config.toml.birda.lock` sibling file appears in the config directory during a write and is removed when it completes.
- Under contention a config write can now wait up to 5s; if a peer is wedged or a lock was leaked by a hard kill, it fails with `ConfigLocked` naming the lock file to delete.

## Tests

Unit tests cover the lock primitive (exclusion, release on `Ok` and on `Err`, a leftover lock blocking rather than being stolen) and the shipped `update_config` helper (persistence, and a two-thread concurrency proof that both edits survive under the lock where a lock-free helper would drop one).