### PR TITLE
fix: keep birda's filesystem and config promises (#327, #342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ include = []
 device = "auto"  # auto, gpu, or cpu
 
 [output]
-combined_prefix = "BirdNET"
+default_format = "human"  # human, json, or ndjson
 ```
 
 ### Configuration Validation

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4,6 +4,7 @@ use crate::config::{ModelType, OutputFormat, OutputMode};
 use crate::constants::{calendar, range_filter};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use super::clip::ClipArgs;
 
@@ -502,9 +503,9 @@ pub struct AnalyzeArgs {
     #[arg(long, env = "BIRDA_SPECIES_LIST")]
     pub slist: Option<PathBuf>,
 
-    /// Remove locks older than this duration (e.g., 1h, 30m).
-    #[arg(long)]
-    pub stale_lock_timeout: Option<String>,
+    /// Remove locks older than this duration (e.g., 1h, 30m) before processing.
+    #[arg(long, value_parser = parse_stale_lock_timeout)]
+    pub stale_lock_timeout: Option<Duration>,
 
     /// Write results to stdout as NDJSON stream (single file only).
     #[arg(long, conflicts_with_all = ["output_dir", "combine", "format"])]
@@ -532,7 +533,7 @@ impl AnalyzeArgs {
 // Re-use shared validators
 use super::validators::{
     parse_batch_size, parse_confidence, parse_day_of_year, parse_latitude, parse_longitude,
-    parse_overlap,
+    parse_overlap, parse_stale_lock_timeout,
 };
 
 #[cfg(test)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -503,7 +503,7 @@ pub struct AnalyzeArgs {
     #[arg(long, env = "BIRDA_SPECIES_LIST")]
     pub slist: Option<PathBuf>,
 
-    /// Remove locks older than this duration (e.g., 1h, 30m) before processing.
+    /// Remove locks older than this duration before processing (e.g., 30s, 15m, 2h, 1d).
     #[arg(long, value_parser = parse_stale_lock_timeout)]
     pub stale_lock_timeout: Option<Duration>,
 

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -3,6 +3,12 @@
 //! Shared validation functions for CLI argument parsing.
 
 use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, coordinates, day_of_year};
+use std::time::Duration;
+
+/// Seconds in each unit accepted by [`parse_stale_lock_timeout`].
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -199,6 +205,33 @@ pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
 
     // Infallible: the range check above bounds `value` to 1..=366, which fits.
     u32::try_from(value).map_err(|_| format!("'{s}' is not a valid number"))
+}
+
+/// Parse a stale-lock timeout such as `30s`, `15m`, `2h`, or `1d`.
+///
+/// A bare number is read as seconds. Exactly one unit suffix is accepted; a
+/// fractional or compound value (`1.5h`, `1h30m`) is rejected with a message
+/// naming the accepted forms. Backs `--stale-lock-timeout`, whose help advertises
+/// exactly these forms.
+pub fn parse_stale_lock_timeout(s: &str) -> Result<Duration, String> {
+    let trimmed = s.trim();
+    let malformed = || format!("invalid duration '{s}'; use forms like 30s, 15m, 2h, 1d");
+
+    let (number, seconds_per_unit) = match trimmed.chars().last() {
+        Some('s' | 'S') => (&trimmed[..trimmed.len() - 1], 1),
+        Some('m' | 'M') => (&trimmed[..trimmed.len() - 1], SECONDS_PER_MINUTE),
+        Some('h' | 'H') => (&trimmed[..trimmed.len() - 1], SECONDS_PER_HOUR),
+        Some('d' | 'D') => (&trimmed[..trimmed.len() - 1], SECONDS_PER_DAY),
+        Some(c) if c.is_ascii_digit() => (trimmed, 1),
+        _ => return Err(malformed()),
+    };
+
+    let count: u64 = number.trim().parse().map_err(|_| malformed())?;
+
+    count
+        .checked_mul(seconds_per_unit)
+        .map(Duration::from_secs)
+        .ok_or_else(|| format!("duration '{s}' is too large"))
 }
 
 #[cfg(test)]
@@ -635,5 +668,49 @@ mod tests {
                 if file.is_ok() { "ok" } else { "rejected" },
             );
         }
+    }
+
+    #[test]
+    fn test_parse_stale_lock_timeout_units() {
+        // Asserted on the second count rather than by constructing a `Duration`
+        // with `from_mins`/`from_hours`/`from_days`: the day/week constructors are
+        // still unstable, and comparing seconds also sidesteps clippy's
+        // larger-unit lint without depending on which constructors have landed.
+        assert_eq!(parse_stale_lock_timeout("30s").unwrap().as_secs(), 30);
+        assert_eq!(parse_stale_lock_timeout("15m").unwrap().as_secs(), 15 * 60);
+        assert_eq!(
+            parse_stale_lock_timeout("2h").unwrap().as_secs(),
+            2 * 60 * 60
+        );
+        assert_eq!(
+            parse_stale_lock_timeout("1d").unwrap().as_secs(),
+            24 * 60 * 60
+        );
+    }
+
+    #[test]
+    fn test_parse_stale_lock_timeout_bare_number_is_seconds() {
+        assert_eq!(parse_stale_lock_timeout("90").unwrap().as_secs(), 90);
+    }
+
+    #[test]
+    fn test_parse_stale_lock_timeout_is_case_insensitive_and_trims() {
+        assert_eq!(parse_stale_lock_timeout(" 1H ").unwrap().as_secs(), 60 * 60);
+    }
+
+    #[test]
+    fn test_parse_stale_lock_timeout_rejects_malformed() {
+        for bad in ["", "h", "1.5h", "1h30m", "abc", "-5m", "10x"] {
+            assert!(
+                parse_stale_lock_timeout(bad).is_err(),
+                "'{bad}' should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_stale_lock_timeout_rejects_overflow() {
+        // u64 seconds times a day's worth of seconds overflows well before this.
+        assert!(parse_stale_lock_timeout("100000000000000000000d").is_err());
     }
 }

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -2,13 +2,9 @@
 //!
 //! Shared validation functions for CLI argument parsing.
 
+use crate::constants::time::{SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE};
 use crate::constants::{MAX_BATCH_SIZE, MIN_BATCH_SIZE, confidence, coordinates, day_of_year};
 use std::time::Duration;
-
-/// Seconds in each unit accepted by [`parse_stale_lock_timeout`].
-const SECONDS_PER_MINUTE: u64 = 60;
-const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
-const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
 
 /// Parse and validate confidence value (0.0-1.0).
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -209,10 +205,10 @@ pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
 
 /// Parse a stale-lock timeout such as `30s`, `15m`, `2h`, or `1d`.
 ///
-/// A bare number is read as seconds. Exactly one unit suffix is accepted; a
-/// fractional or compound value (`1.5h`, `1h30m`) is rejected with a message
-/// naming the accepted forms. Backs `--stale-lock-timeout`, whose help advertises
-/// exactly these forms.
+/// A bare number is read as seconds and must be greater than zero. Exactly one
+/// unit suffix is accepted; a fractional or compound value (`1.5h`, `1h30m`) is
+/// rejected with a message naming the accepted forms. Backs `--stale-lock-timeout`;
+/// its help lists these forms as examples.
 pub fn parse_stale_lock_timeout(s: &str) -> Result<Duration, String> {
     let trimmed = s.trim();
     let malformed = || format!("invalid duration '{s}'; use forms like 30s, 15m, 2h, 1d");
@@ -228,10 +224,20 @@ pub fn parse_stale_lock_timeout(s: &str) -> Result<Duration, String> {
 
     let count: u64 = number.trim().parse().map_err(|_| malformed())?;
 
-    count
+    let seconds = count
         .checked_mul(seconds_per_unit)
-        .map(Duration::from_secs)
-        .ok_or_else(|| format!("duration '{s}' is too large"))
+        .ok_or_else(|| format!("duration '{s}' is too large"))?;
+
+    // A zero timeout treats every lock, including a live peer's brand-new one, as
+    // stale and reclaims it on sight, which defeats the mutual exclusion it is
+    // meant to recover. Reject it rather than silently disabling locking.
+    if seconds == 0 {
+        return Err(format!(
+            "stale-lock timeout must be greater than zero, got '{s}'"
+        ));
+    }
+
+    Ok(Duration::from_secs(seconds))
 }
 
 #[cfg(test)]
@@ -709,8 +715,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_stale_lock_timeout_rejects_zero() {
+        // A zero timeout would reclaim even a live peer's fresh lock.
+        for zero in ["0", "0s", "0m", "0h", "0d"] {
+            assert!(
+                parse_stale_lock_timeout(zero).is_err(),
+                "'{zero}' should be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn test_parse_stale_lock_timeout_rejects_overflow() {
-        // u64 seconds times a day's worth of seconds overflows well before this.
-        assert!(parse_stale_lock_timeout("100000000000000000000d").is_err());
+        // 1e18 parses as u64 but overflows when multiplied by a day's seconds, so
+        // this exercises the checked_mul guard rather than the u64 parse. (A larger
+        // literal like 1e20 would fail the parse first and never reach checked_mul.)
+        assert!(parse_stale_lock_timeout("1000000000000000000d").is_err());
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -49,6 +49,14 @@ fn warn_deprecated_keys(config: &Config) {
             );
         }
     }
+
+    if config.output.combined_prefix.is_some() {
+        tracing::warn!(
+            "config key 'output.combined_prefix' is deprecated and ignored; combined output no \
+             longer uses a configurable prefix. The key is dropped the next time the config is \
+             saved."
+        );
+    }
 }
 
 /// Load configuration from the default platform-specific path.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -301,8 +301,11 @@ impl std::fmt::Display for OutputMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct OutputConfig {
-    /// Prefix for combined output files.
-    pub combined_prefix: String,
+    /// Deprecated. Combined output no longer uses a configurable prefix.
+    ///
+    /// Parsed only so a stale key can be reported; never written back.
+    #[serde(default, skip_serializing)]
+    pub combined_prefix: Option<String>,
 
     /// Default CLI output format.
     pub default_format: OutputMode,
@@ -311,7 +314,7 @@ pub struct OutputConfig {
 impl Default for OutputConfig {
     fn default() -> Self {
         Self {
-            combined_prefix: "BirdNET".to_string(),
+            combined_prefix: None,
             default_format: OutputMode::Human,
         }
     }
@@ -557,8 +560,30 @@ meta_model = "/models/birdnet-v24-meta.onnx"
     #[test]
     fn test_output_config_default() {
         let config = OutputConfig::default();
-        assert_eq!(config.combined_prefix, "BirdNET");
+        assert!(config.combined_prefix.is_none());
         assert_eq!(config.default_format, OutputMode::Human);
+    }
+
+    #[test]
+    fn test_deprecated_combined_prefix_still_parses() {
+        let output: OutputConfig = toml::from_str("combined_prefix = \"BirdNET\"\n").unwrap();
+        assert!(
+            output.combined_prefix.is_some(),
+            "a stale combined_prefix must still parse so it can be reported"
+        );
+    }
+
+    #[test]
+    fn test_deprecated_combined_prefix_is_not_written_back() {
+        let output = OutputConfig {
+            combined_prefix: Some("BirdNET".to_string()),
+            default_format: OutputMode::Human,
+        };
+        let written = toml::to_string(&output).unwrap();
+        assert!(
+            !written.contains("combined_prefix"),
+            "a deprecated key must not be serialised back into the config"
+        );
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -73,6 +73,21 @@ pub mod day_of_year {
     pub const MAX: u32 = 366;
 }
 
+/// Time-unit conversions, in seconds.
+///
+/// Read by `cli::validators::parse_stale_lock_timeout` so the `--stale-lock-timeout`
+/// unit suffixes (`s`/`m`/`h`/`d`) do not each carry their own literal.
+pub mod time {
+    /// Seconds in a minute.
+    pub const SECONDS_PER_MINUTE: u64 = 60;
+
+    /// Seconds in an hour.
+    pub const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+
+    /// Seconds in a day.
+    pub const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+}
+
 /// Geographic coordinate bounds, in degrees.
 ///
 /// Three routes reach one setting: `--lat`/`--lon` and their `BIRDA_LATITUDE`/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,6 +657,25 @@ fn report_summary(
     });
 }
 
+/// Reclaim a per-file lock older than `timeout`, if a timeout is set.
+///
+/// A peer that crashed leaves its lock behind: the Ctrl+C handler calls
+/// `process::exit` and runs no `Drop`. Without reclamation every later run skips
+/// that file as locked, forever. `--stale-lock-timeout` opts in; `None` honours
+/// every lock. Racing a live peer is safe: `FileLock::acquire` still creates with
+/// `O_EXCL`, so a peer that re-locks in the gap wins and this file takes the
+/// graceful `FileLocked` skip instead.
+fn reclaim_stale_lock(input: &Path, output_dir: &Path, timeout: Option<std::time::Duration>) {
+    let Some(max_age) = timeout else { return };
+    if !crate::locking::FileLock::is_stale(input, output_dir, max_age) {
+        return;
+    }
+    match crate::locking::FileLock::remove_stale(input, output_dir) {
+        Ok(()) => info!("Removed stale lock: {}", input.display()),
+        Err(e) => warn!("Could not remove stale lock for {}: {e}", input.display()),
+    }
+}
+
 /// Process all files, updating stats in place.
 ///
 /// On fail-fast error, returns `Err` immediately but `stats` contains partial results.
@@ -675,20 +694,8 @@ fn process_all_files(
     for (index, file) in files.iter().enumerate() {
         let file_output_dir = output_dir_for(file, params.output_dir);
 
-        // Reclaim a stale lock before the skip-locked check below, so a lock left
-        // by a peer that crashed (the Ctrl+C handler calls process::exit and runs
-        // no Drop) does not make this run skip the file forever. --stale-lock-timeout
-        // opts in; without it every lock is honoured. Racing a live peer is safe:
-        // FileLock::acquire still creates with O_EXCL, so a peer that re-locks in
-        // the gap wins and this file takes the graceful FileLocked skip instead.
-        if let Some(max_age) = params.stale_lock_timeout
-            && crate::locking::FileLock::is_stale(file, &file_output_dir, max_age)
-        {
-            match crate::locking::FileLock::remove_stale(file, &file_output_dir) {
-                Ok(()) => info!("Removed stale lock: {}", file.display()),
-                Err(e) => warn!("Could not remove stale lock for {}: {e}", file.display()),
-            }
-        }
+        // Reclaim a stale lock before the skip-locked check below (see the fn doc).
+        reclaim_stale_lock(file, &file_output_dir, params.stale_lock_timeout);
 
         // Check if should process
         match should_process(
@@ -2434,6 +2441,56 @@ fn handle_geomodel_install(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn test_reclaim_stale_lock_removes_an_aged_lock_when_enabled() {
+        use std::time::{Duration, SystemTime};
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("audio.wav");
+        let lock = crate::locking::FileLock::lock_path_for(&input, dir.path());
+        let f = std::fs::File::create(&lock).unwrap();
+        // Age it deterministically instead of sleeping.
+        f.set_modified(SystemTime::now() - Duration::from_hours(1))
+            .unwrap();
+
+        reclaim_stale_lock(&input, dir.path(), Some(Duration::from_mins(1)));
+
+        assert!(
+            !crate::locking::FileLock::is_locked(&input, dir.path()),
+            "an hour-old lock must be reclaimed against a one-minute timeout"
+        );
+    }
+
+    #[test]
+    fn test_reclaim_stale_lock_keeps_a_fresh_lock() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("audio.wav");
+        let lock = crate::locking::FileLock::lock_path_for(&input, dir.path());
+        std::fs::File::create(&lock).unwrap();
+
+        reclaim_stale_lock(&input, dir.path(), Some(Duration::from_hours(1)));
+
+        assert!(
+            crate::locking::FileLock::is_locked(&input, dir.path()),
+            "a lock younger than the timeout must be kept"
+        );
+    }
+
+    #[test]
+    fn test_reclaim_stale_lock_is_a_noop_without_a_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("audio.wav");
+        let lock = crate::locking::FileLock::lock_path_for(&input, dir.path());
+        std::fs::File::create(&lock).unwrap();
+
+        reclaim_stale_lock(&input, dir.path(), None);
+
+        assert!(
+            crate::locking::FileLock::is_locked(&input, dir.path()),
+            "without --stale-lock-timeout every lock is honoured"
+        );
+    }
 
     /// A stand-in audio path for the `record_file_failure` tests; only ever
     /// displayed, never touched on disk.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,9 @@ struct ProcessingParams<'a> {
     bsg_params: Option<(f64, f64, Option<u32>)>,
     /// Optional custom classifier for two-stage inference (bat detection).
     custom_classifier: Option<&'a birdnet_onnx::CustomClassifier>,
+    /// Reclaim a per-file lock older than this before processing, if set.
+    /// Backs `--stale-lock-timeout`; `None` leaves every lock in place.
+    stale_lock_timeout: Option<std::time::Duration>,
 }
 
 /// Statistics from processing all files.
@@ -671,6 +674,21 @@ fn process_all_files(
 
     for (index, file) in files.iter().enumerate() {
         let file_output_dir = output_dir_for(file, params.output_dir);
+
+        // Reclaim a stale lock before the skip-locked check below, so a lock left
+        // by a peer that crashed (the Ctrl+C handler calls process::exit and runs
+        // no Drop) does not make this run skip the file forever. --stale-lock-timeout
+        // opts in; without it every lock is honoured. Racing a live peer is safe:
+        // FileLock::acquire still creates with O_EXCL, so a peer that re-locks in
+        // the gap wins and this file takes the graceful FileLocked skip instead.
+        if let Some(max_age) = params.stale_lock_timeout
+            && crate::locking::FileLock::is_stale(file, &file_output_dir, max_age)
+        {
+            match crate::locking::FileLock::remove_stale(file, &file_output_dir) {
+                Ok(()) => info!("Removed stale lock: {}", file.display()),
+                Err(e) => warn!("Could not remove stale lock for {}: {e}", file.display()),
+            }
+        }
 
         // Check if should process
         match should_process(
@@ -1060,6 +1078,7 @@ fn analyze_files(
         dual_output_mode,
         bsg_params,
         custom_classifier: bat_classifier.as_ref(),
+        stale_lock_timeout: args.stale_lock_timeout,
     };
 
     // Process all files - stats owned here so partial results available on fail-fast

--- a/src/locking/file_lock.rs
+++ b/src/locking/file_lock.rs
@@ -253,4 +253,73 @@ mod tests {
             "unregister_lock should not delete files"
         );
     }
+
+    #[test]
+    fn test_is_stale_is_false_for_a_fresh_lock() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let input = temp_dir.path().join("test.wav");
+        File::create(&input).unwrap();
+
+        let _lock = FileLock::acquire(&input, temp_dir.path()).unwrap();
+
+        assert!(
+            !FileLock::is_stale(&input, temp_dir.path(), Duration::from_hours(1)),
+            "a lock taken just now is not older than an hour"
+        );
+    }
+
+    #[test]
+    fn test_is_stale_is_false_when_no_lock_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let input = temp_dir.path().join("nope.wav");
+
+        assert!(
+            !FileLock::is_stale(&input, temp_dir.path(), Duration::from_secs(0)),
+            "an absent lock is never stale"
+        );
+    }
+
+    #[test]
+    fn test_is_stale_detects_an_aged_lock_and_remove_stale_reclaims_it() {
+        use std::time::SystemTime;
+
+        let _guard = TEST_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let input = temp_dir.path().join("test.wav");
+
+        // Age the lock deterministically rather than sleeping, so the timing is
+        // not at the mercy of the test runner or the filesystem clock.
+        let lock_path = FileLock::lock_path_for(&input, temp_dir.path());
+        let lock_file = File::create(&lock_path).unwrap();
+        lock_file
+            .set_modified(SystemTime::now() - Duration::from_hours(1))
+            .unwrap();
+
+        assert!(
+            FileLock::is_stale(&input, temp_dir.path(), Duration::from_mins(1)),
+            "an hour-old lock is stale against a one-minute timeout"
+        );
+        assert!(
+            !FileLock::is_stale(&input, temp_dir.path(), Duration::from_hours(2)),
+            "the same lock is fresh against a two-hour timeout"
+        );
+
+        FileLock::remove_stale(&input, temp_dir.path()).unwrap();
+        assert!(
+            !FileLock::is_locked(&input, temp_dir.path()),
+            "remove_stale must clear the lock so the file can be processed"
+        );
+    }
+
+    #[test]
+    fn test_remove_stale_errors_when_there_is_no_lock() {
+        let temp_dir = TempDir::new().unwrap();
+        let input = temp_dir.path().join("missing.wav");
+
+        assert!(
+            FileLock::remove_stale(&input, temp_dir.path()).is_err(),
+            "removing a lock that is not there is an error, not a silent success"
+        );
+    }
 }

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -11,8 +11,12 @@ pub const RELEASE_DOWNLOAD_URL: &str = "https://github.com/{repo}/releases/lates
 /// Filename of the release manifest.
 pub const MANIFEST_FILENAME: &str = "manifest.json";
 
-/// Temporary file suffix used during extraction.
-pub const UPDATE_TEMP_SUFFIX: &str = ".birda-update-new.tmp";
+/// Filename prefix for the extracted-binary temporary written during a self-update.
+///
+/// A unique random suffix is appended per run (see `reserve_temp_path`), so two
+/// concurrent `birda update` invocations sharing this directory cannot write the
+/// same temporary and corrupt each other's extraction.
+pub const UPDATE_TEMP_PREFIX: &str = "birda-update-new-";
 
 /// Maximum manifest response size in bytes (1 MiB).
 pub const MANIFEST_MAX_BYTES: u64 = 1024 * 1024;

--- a/src/update/constants.rs
+++ b/src/update/constants.rs
@@ -18,6 +18,13 @@ pub const MANIFEST_FILENAME: &str = "manifest.json";
 /// same temporary and corrupt each other's extraction.
 pub const UPDATE_TEMP_PREFIX: &str = "birda-update-new-";
 
+/// Filename prefix for the downloaded release archive during a self-update.
+///
+/// A unique random component and the asset's own `.download` suffix are appended
+/// per run (see `reserve_temp_path`), so concurrent updates cannot collide. The
+/// suffix stays at the end because `extract_binary` picks the format from it.
+pub const UPDATE_ARCHIVE_PREFIX: &str = "birda-update-";
+
 /// Maximum manifest response size in bytes (1 MiB).
 pub const MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
 

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -12,7 +12,7 @@ mod replace;
 use crate::error::{Error, Result};
 use constants::{
     BUILT_CUDA_TOOLKIT_VERSION, BUILT_CUDNN_VERSION, BUILT_ONNXRUNTIME_VERSION, GITHUB_REPO,
-    RELEASE_DOWNLOAD_URL, UPDATE_TEMP_PREFIX,
+    RELEASE_DOWNLOAD_URL, UPDATE_ARCHIVE_PREFIX, UPDATE_TEMP_PREFIX,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use manifest::Manifest;
@@ -139,7 +139,7 @@ pub async fn perform_update(
     // the end because `extract_binary` selects the archive format from it.
     let archive_path = reserve_temp_path(
         parent_dir,
-        "birda-update-",
+        UPDATE_ARCHIVE_PREFIX,
         &format!(".{}.download", asset.file),
     )?;
     if let Err(e) =
@@ -158,7 +158,15 @@ pub async fn perform_update(
     }
 
     // 8. Extract to temp file in same directory (avoids EXDEV)
-    let temp_binary = reserve_temp_path(parent_dir, UPDATE_TEMP_PREFIX, ".tmp")?;
+    // Reserving the extraction temp is now fallible; clean up the verified archive
+    // if it fails, matching every other error arm below.
+    let temp_binary = match reserve_temp_path(parent_dir, UPDATE_TEMP_PREFIX, ".tmp") {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = std::fs::remove_file(&archive_path);
+            return Err(e);
+        }
+    };
     if let Err(e) = extract_binary(&archive_path, &temp_binary) {
         let _ = std::fs::remove_file(&archive_path);
         let _ = std::fs::remove_file(&temp_binary);
@@ -267,7 +275,6 @@ fn ort_major_minor_changed(current: &str, required: &str) -> bool {
     current_ver.major != required_ver.major || current_ver.minor != required_ver.minor
 }
 
-/// Download a file with a progress bar.
 /// Reserve a uniquely named path in `dir`, built as `<prefix><random><suffix>`.
 ///
 /// Two concurrent `birda update` runs sharing this directory would otherwise
@@ -291,6 +298,7 @@ fn reserve_temp_path(dir: &Path, prefix: &str, suffix: &str) -> Result<PathBuf> 
     Ok(path)
 }
 
+/// Download a file with a progress bar.
 async fn download_with_progress(
     client: &reqwest::Client,
     url: &str,

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -12,7 +12,7 @@ mod replace;
 use crate::error::{Error, Result};
 use constants::{
     BUILT_CUDA_TOOLKIT_VERSION, BUILT_CUDNN_VERSION, BUILT_ONNXRUNTIME_VERSION, GITHUB_REPO,
-    RELEASE_DOWNLOAD_URL, UPDATE_TEMP_SUFFIX,
+    RELEASE_DOWNLOAD_URL, UPDATE_TEMP_PREFIX,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use manifest::Manifest;
@@ -133,7 +133,15 @@ pub async fn perform_update(
             reason: "cannot determine parent directory of current binary".to_string(),
         })?;
 
-    let archive_path = parent_dir.join(format!("{}.download", asset.file));
+    // Unique per-run temp names. Two `birda update` runs sharing this directory,
+    // or an update racing anything else in it, would otherwise write the same two
+    // fixed paths and corrupt each other. The `.<file>.download` suffix is kept at
+    // the end because `extract_binary` selects the archive format from it.
+    let archive_path = reserve_temp_path(
+        parent_dir,
+        "birda-update-",
+        &format!(".{}.download", asset.file),
+    )?;
     if let Err(e) =
         download_with_progress(client, &download_url, &archive_path, &manifest.version).await
     {
@@ -150,7 +158,7 @@ pub async fn perform_update(
     }
 
     // 8. Extract to temp file in same directory (avoids EXDEV)
-    let temp_binary = parent_dir.join(UPDATE_TEMP_SUFFIX);
+    let temp_binary = reserve_temp_path(parent_dir, UPDATE_TEMP_PREFIX, ".tmp")?;
     if let Err(e) = extract_binary(&archive_path, &temp_binary) {
         let _ = std::fs::remove_file(&archive_path);
         let _ = std::fs::remove_file(&temp_binary);
@@ -260,6 +268,29 @@ fn ort_major_minor_changed(current: &str, required: &str) -> bool {
 }
 
 /// Download a file with a progress bar.
+/// Reserve a uniquely named path in `dir`, built as `<prefix><random><suffix>`.
+///
+/// Two concurrent `birda update` runs sharing this directory would otherwise
+/// collide on a fixed name and corrupt each other. This mirrors
+/// [`crate::utils::fs`]'s temporary naming: the kernel-provided random component
+/// is load-bearing, not cosmetic. The empty file is left in place for the caller
+/// to overwrite (both `download_with_progress` and `extract_binary` truncate with
+/// `File::create`); the caller removes it on every exit path, so it is persisted
+/// rather than deleted on drop.
+fn reserve_temp_path(dir: &Path, prefix: &str, suffix: &str) -> Result<PathBuf> {
+    let temp = tempfile::Builder::new()
+        .prefix(prefix)
+        .suffix(suffix)
+        .tempfile_in(dir)
+        .map_err(|e| Error::UpdateReplaceFailed {
+            reason: format!("cannot create temporary file in {}: {e}", dir.display()),
+        })?;
+    let (_file, path) = temp.keep().map_err(|e| Error::UpdateReplaceFailed {
+        reason: format!("cannot persist temporary file in {}: {e}", dir.display()),
+    })?;
+    Ok(path)
+}
+
 async fn download_with_progress(
     client: &reqwest::Client,
     url: &str,
@@ -478,6 +509,36 @@ fn extract_zip(archive_path: &Path, dest: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_reserve_temp_path_is_unique_per_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = reserve_temp_path(dir.path(), "birda-update-", ".download").unwrap();
+        let b = reserve_temp_path(dir.path(), "birda-update-", ".download").unwrap();
+
+        assert_ne!(a, b, "two reservations must not collide on a name");
+        assert!(a.is_file() && b.is_file(), "both temporaries are created");
+        assert_eq!(a.parent(), Some(dir.path()));
+    }
+
+    #[test]
+    fn test_reserve_temp_path_keeps_archive_suffix_for_format_detection() {
+        // `extract_binary` selects the format from the trailing `.tar.gz.download`
+        // / `.zip.download`, so the random component must not land at the end.
+        let dir = tempfile::tempdir().unwrap();
+        let path = reserve_temp_path(
+            dir.path(),
+            "birda-update-",
+            ".birda-linux-x64.tar.gz.download",
+        )
+        .unwrap();
+
+        assert!(
+            path.to_string_lossy().ends_with(".tar.gz.download"),
+            "archive name must still end with the format-bearing suffix, got {}",
+            path.display()
+        );
+    }
 
     #[test]
     fn test_ort_major_minor_changed_same() {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -41,7 +41,7 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// The mode to create a file with, where the platform has one.
 ///
@@ -206,6 +206,13 @@ where
     }
 
     let dir = parent_dir(target);
+    // Which ancestors are about to be created. `create_dir_all` fsyncs nothing, so
+    // each directory it makes needs its own parent flushed below; otherwise a crash
+    // right after a first write on a fresh install (the first `config set`, or the
+    // first clip into a new output tree) can lose the directory entry along with
+    // the file, having reported success. Recorded before the call because after it
+    // they all exist.
+    let created_dirs = missing_ancestors(dir);
     std::fs::create_dir_all(dir)?;
 
     // Worth knowing when the next line fails: creating the temporary needs write
@@ -235,9 +242,33 @@ where
     // Drops the temporary on failure, so a rejected write leaves nothing behind.
     temp.persist(target).map_err(|e| e.error)?;
 
+    // The leaf directory holds the file's new entry.
     sync_directory(dir);
+    // Each directory `create_dir_all` created holds a new entry in ITS parent, so
+    // flush those too. The shallowest one's parent is the deepest pre-existing
+    // ancestor, which is what actually makes the new tree survive a crash.
+    for created in &created_dirs {
+        sync_parent_directory(created);
+    }
 
     Ok(())
+}
+
+/// The ancestors of `dir`, from deepest to shallowest, that do not exist yet.
+///
+/// Used to record what [`write_atomic_with`] is about to create so each new
+/// directory can be made durable afterwards. Best effort by nature: a peer
+/// creating one of these between this check and the create only means its own
+/// durability is that peer's responsibility, not a correctness bug here.
+fn missing_ancestors(dir: &Path) -> Vec<PathBuf> {
+    let mut missing = Vec::new();
+    for ancestor in dir.ancestors() {
+        if ancestor.as_os_str().is_empty() || ancestor.exists() {
+            break;
+        }
+        missing.push(ancestor.to_path_buf());
+    }
+    missing
 }
 
 /// `path` with a resolvable symlink followed, or `path` itself.
@@ -510,6 +541,34 @@ mod tests {
         write_atomic(&path, b"contents", NewFileMode::OwnerOnly).unwrap();
 
         assert_eq!(std::fs::read(&path).unwrap(), b"contents");
+    }
+
+    #[test]
+    fn test_missing_ancestors_lists_only_the_directories_to_be_created() {
+        let root = tempfile::tempdir().unwrap();
+        // root exists; a/b/c does not.
+        let target = root.path().join("a").join("b").join("c");
+
+        let missing = missing_ancestors(&target);
+
+        assert_eq!(
+            missing,
+            vec![
+                root.path().join("a").join("b").join("c"),
+                root.path().join("a").join("b"),
+                root.path().join("a"),
+            ],
+            "deepest-to-shallowest, stopping at the first existing ancestor"
+        );
+    }
+
+    #[test]
+    fn test_missing_ancestors_is_empty_when_the_directory_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            missing_ancestors(dir.path()).is_empty(),
+            "an existing directory needs no creation and so no parent flush"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What and why

Two open issues, both the same shape: birda documents or defaults a behaviour and then silently doesn't deliver it. This closes that gap on the filesystem and config surfaces.

### #327 - two documented surfaces that did nothing

- **`--stale-lock-timeout` is now honoured.** It was in `--help` ("Remove locks older than this duration") but read nowhere: `FileLock::is_stale`/`remove_stale` had zero call sites, so stale-lock cleanup never happened. A user who read the help believed stale locks were being reclaimed on their schedule; they were not. In distributed analysis this matters, because a peer that crashes leaves a lock behind (the Ctrl+C handler calls `process::exit` and runs no `Drop`), and every later run then skips that file as locked, forever. The flag now parses a duration (`30s`/`15m`/`2h`/`1d`, or bare seconds; a zero or malformed value is rejected up front) and reclaims a stale lock before the file is skipped. Racing a live peer is safe: `FileLock::acquire` still creates with `O_EXCL`, so a peer that re-locks in the gap wins and the file takes the graceful "locked, skip" path.
- **`output.combined_prefix` is dropped.** It was defaulted, serialised into every `config.toml`, and asserted in a test, but read by no production code. It is now a deprecated field that is skipped on serialize (so it stops being written and is dropped the next time the config is saved) and reported through `warn_deprecated_keys`, exactly as `meta_model` is handled. Existing configs still load; serde ignores the key, so no migration is needed.

### #342 - durable-write gaps

- **`birda update` uses unique per-run temp names.** The download archive and the extracted binary were written to two fixed names in the binary's directory, so two concurrent updates (or an update racing anything else there) could corrupt each other. Both now get a unique name via `tempfile`, the same uniqueness the config and clip write paths already rely on. The archive keeps its `.tar.gz.download`/`.zip.download` suffix at the end because `extract_binary` selects the format from it.
- **A newly-created directory is made durable.** `write_atomic_with` ran `create_dir_all` and then fsynced only the leaf directory, which persists the file's entry but not each created directory's own entry in its parent. A crash right after a first write on a fresh install (the first `config set`, or the first clip into a new output tree) could lose the directory along with the file, having reported success. It now fsyncs the parent of each directory it created.

## Notes for reviewers

- **`--stale-lock-timeout` is now validated.** A malformed or zero value is a hard CLI error where before it was silently ignored. The two forms the old help advertised (`1h`, `30m`) still parse, so anyone who followed the docs is unaffected; compound (`1h30m`), fractional (`1.5h`) and spelled-out (`60min`) forms are rejected.
- Behaviour on Unix is unchanged throughout; the durability additions are best-effort directory fsyncs that cannot turn a successful write into a failure.

## Deferred (not in this PR)

- **Windows publish-rename retry** (the third `#342` item). On Windows a `MoveFileExW` can transiently fail with a sharing violation while an antivirus scanner or the search indexer holds the destination open. A correct fix has to cover both publish paths (`finalize_download` **and** `write_atomic_with`, which is the one that publishes `registry.json` that birda-gui reads) and must not block the async runtime with a synchronous sleep, so it belongs in its own change. Tracked in #366.

## Testing

`cargo fmt --check`, `cargo clippy --no-default-features --features gen-registry --all-targets -- -D warnings`, and `cargo test --no-default-features` all pass. New unit tests cover the duration parser (units, bare seconds, zero, overflow, malformed), the stale-lock reclamation helper, `is_stale`/`remove_stale`, `missing_ancestors`, the deprecated-key round-trip, and the unique-temp-name property.
