### PR TITLE
fix: harden FileLock against the Ctrl+C / poison races fixed in ConfigLock (#363)

### DIFF
--- a/src/locking/config_lock.rs
+++ b/src/locking/config_lock.rs
@@ -25,61 +25,27 @@
 //!   an advisory lock (`flock`/`LockFileEx`, released by the kernel on process
 //!   death) would restore automatic recovery without the race.
 //!
-//! The registry is deliberately separate from `file_lock`'s: one shared `Vec`
-//! would let either type's cleanup remove the other's lock file.
+//! The registry is a separate [`super::registry::LockRegistry`] instance from
+//! `file_lock`'s: the two lock types share the primitive but not the backing
+//! `Vec`, since one shared registry would let either type's cleanup remove the
+//! other's lock file.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
+use super::registry::LockRegistry;
 use crate::constants::config_lock::{ACQUIRE_TIMEOUT, LOCK_SUFFIX, RETRY_INTERVAL};
 use crate::error::{Error, Result};
 
-/// Active config-lock paths, removed if the process is interrupted.
-static ACTIVE_CONFIG_LOCKS: LazyLock<Mutex<Vec<PathBuf>>> =
-    LazyLock::new(|| Mutex::new(Vec::new()));
-
-/// Register a held lock path for signal cleanup.
-///
-/// Recovers from a poisoned mutex (`unwrap_or_else(into_inner)`) rather than
-/// skipping the update, matching [`cleanup_all_config_locks`]. If a panic while
-/// holding the lock left `register`/`unregister` no-ops but cleanup still
-/// draining, an unregister could silently not happen and cleanup would later
-/// delete a peer's fresh lock at that path.
-fn register(path: &Path) {
-    let mut locks = ACTIVE_CONFIG_LOCKS
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner);
-    locks.push(path.to_path_buf());
-}
-
-/// Unregister a lock path once it is released.
-///
-/// Poison-recovering for the same reason as [`register`].
-fn unregister(path: &Path) {
-    let mut locks = ACTIVE_CONFIG_LOCKS
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner);
-    locks.retain(|p| p != path);
-}
+/// Active config-lock paths, removed if the process is interrupted. A separate
+/// [`LockRegistry`] instance from `file_lock`'s so neither type's cleanup can
+/// remove the other's lock file.
+static ACTIVE_CONFIG_LOCKS: LockRegistry = LockRegistry::new();
 
 /// Remove every held config lock. Called from the Ctrl+C handler.
-///
-/// Recovers from a poisoned mutex so cleanup still runs after a panic, and
-/// drains the registry so each path is removed once. Only paths this process has
-/// successfully acquired are ever registered, so this never removes a peer's
-/// lock.
 pub fn cleanup_all_config_locks() {
-    let paths = {
-        let mut locks = ACTIVE_CONFIG_LOCKS
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
-        std::mem::take(&mut *locks)
-    };
-    for path in paths {
-        let _ = std::fs::remove_file(&path);
-    }
+    ACTIVE_CONFIG_LOCKS.cleanup();
 }
 
 /// RAII guard serialising a config load-mutate-save against other processes.
@@ -120,7 +86,7 @@ impl ConfigLock {
                     // `cleanup_all_config_locks` delete a peer's lock. The cost is
                     // a Ctrl+C in the create-then-register gap leaking our own
                     // lock, which is a manual delete, not lost data.
-                    register(&lock_path);
+                    ACTIVE_CONFIG_LOCKS.register(&lock_path);
                     return Ok(Self { lock_path });
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -142,17 +108,9 @@ impl ConfigLock {
 
 impl Drop for ConfigLock {
     fn drop(&mut self) {
-        // Unregister BEFORE removing the file, not after. A Ctrl+C landing
-        // between the two then leaks only our own lock file (a manual delete),
-        // never a peer's: once the path is out of the registry our signal cleanup
-        // ignores it, so a peer that re-creates a lock at this path right after
-        // our remove cannot be caught by our cleanup. The other order leaves a
-        // window where the path is still registered but the file at it is a
-        // peer's fresh lock, which cleanup would then delete.
-        unregister(&self.lock_path);
-        // Safe to remove by path: nothing breaks a held lock, so while we hold it
-        // the file at `lock_path` is always the one we created.
-        let _ = std::fs::remove_file(&self.lock_path);
+        // release() unregisters before it unlinks; see LockRegistry::release for
+        // why that ordering is what keeps a Ctrl+C from deleting a peer's lock.
+        ACTIVE_CONFIG_LOCKS.release(&self.lock_path);
     }
 }
 

--- a/src/locking/file_lock.rs
+++ b/src/locking/file_lock.rs
@@ -1,5 +1,6 @@
 //! File locking for distributed processing.
 
+use super::registry::LockRegistry;
 use crate::constants::LOCK_FILE_EXTENSION;
 use crate::error::{Error, Result};
 use chrono::{DateTime, Utc};
@@ -23,6 +24,7 @@ pub struct LockInfo {
 }
 
 /// RAII guard for file locks.
+#[derive(Debug)]
 pub struct FileLock {
     lock_path: PathBuf,
 }
@@ -39,10 +41,6 @@ impl FileLock {
             path: output_dir.to_path_buf(),
             source: e,
         })?;
-
-        // Register for cleanup BEFORE file creation to avoid race condition
-        // if Ctrl+C occurs between creation and registration
-        register_lock(&lock_path);
 
         // Try to create lock file exclusively
         let file = OpenOptions::new()
@@ -66,19 +64,25 @@ impl FileLock {
                 let json = serde_json::to_string_pretty(&info).unwrap_or_else(|_| "{}".to_string());
                 let _ = f.write_all(json.as_bytes());
 
+                // Registered only AFTER we own the file, so a path we do not own is
+                // never in the registry and a Ctrl+C can never make
+                // `cleanup_all_locks` delete a peer's lock. The cost is a Ctrl+C in
+                // the create-then-register gap leaking our own lock, which is a
+                // manual delete, not lost data. Registering before the create (the
+                // old behaviour) meant an `AlreadyExists` create for a peer-owned
+                // path left that path registered until the error arm unregistered
+                // it, and a Ctrl+C in that window deleted the peer's live lock.
+                ACTIVE_FILE_LOCKS.register(&lock_path);
+
                 Ok(Self { lock_path })
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                unregister_lock(&lock_path);
                 Err(Error::FileLocked { path: lock_path })
             }
-            Err(e) => {
-                unregister_lock(&lock_path);
-                Err(Error::LockCreate {
-                    path: lock_path,
-                    source: e,
-                })
-            }
+            Err(e) => Err(Error::LockCreate {
+                path: lock_path,
+                source: e,
+            }),
         }
     }
 
@@ -127,45 +131,20 @@ impl FileLock {
 
 impl Drop for FileLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.lock_path);
-        unregister_lock(&self.lock_path);
+        // release() unregisters before it unlinks; see LockRegistry::release for
+        // why that ordering is what keeps a Ctrl+C from deleting a peer's lock.
+        ACTIVE_FILE_LOCKS.release(&self.lock_path);
     }
 }
 
-/// Global registry of active lock paths for cleanup on signal.
-static ACTIVE_LOCKS: std::sync::LazyLock<std::sync::Mutex<Vec<PathBuf>>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+/// Active per-input-file lock paths, removed if the process is interrupted. A
+/// separate [`LockRegistry`] instance from the config lock's so neither type's
+/// cleanup can remove the other's lock file.
+static ACTIVE_FILE_LOCKS: LockRegistry = LockRegistry::new();
 
-/// Register a lock path for cleanup on signal.
-pub fn register_lock(path: &Path) {
-    if let Ok(mut locks) = ACTIVE_LOCKS.lock() {
-        locks.push(path.to_path_buf());
-    }
-}
-
-/// Unregister a lock path after normal cleanup.
-pub fn unregister_lock(path: &Path) {
-    if let Ok(mut locks) = ACTIVE_LOCKS.lock() {
-        locks.retain(|p| p != path);
-    }
-}
-
-/// Clean up all registered locks. Called on signal.
-///
-/// This function recovers from a poisoned mutex to ensure cleanup
-/// always runs even if another thread panicked while holding the lock.
-/// It drains the registry so each path is only cleaned up once.
+/// Clean up all registered file locks. Called from the Ctrl+C handler.
 pub fn cleanup_all_locks() {
-    // Take ownership of all paths, clearing the registry
-    let paths = {
-        let mut locks = ACTIVE_LOCKS
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        std::mem::take(&mut *locks)
-    };
-    for lock_path in paths {
-        let _ = fs::remove_file(&lock_path);
-    }
+    ACTIVE_FILE_LOCKS.cleanup();
 }
 
 #[cfg(test)]
@@ -225,7 +204,7 @@ mod tests {
         assert!(lock_path.exists());
 
         // Register this path and call cleanup
-        register_lock(&lock_path);
+        ACTIVE_FILE_LOCKS.register(&lock_path);
         cleanup_all_locks();
 
         // Our lock file should be removed
@@ -245,12 +224,52 @@ mod tests {
         File::create(&lock_path).unwrap();
 
         // Register and unregister - file should still exist
-        register_lock(&lock_path);
-        unregister_lock(&lock_path);
+        ACTIVE_FILE_LOCKS.register(&lock_path);
+        ACTIVE_FILE_LOCKS.unregister(&lock_path);
 
+        assert!(lock_path.exists(), "unregister should not delete files");
+    }
+
+    #[test]
+    fn test_acquire_registers_only_the_lock_it_owns() {
+        // This guards the ownership INVARIANT: a held lock is registered, a lost
+        // acquire registers nothing, and Drop unregisters. It does NOT prove the
+        // register-after-create or unregister-before-remove ORDERING; those differ
+        // from the old code only when a Ctrl+C lands inside a sub-instruction
+        // window, which a synchronous test cannot reach. Of the three fixes, only
+        // the poison recovery is deterministically red-green (see registry.rs).
+        let _guard = TEST_LOCK.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let input = temp_dir.path().join("test.wav");
+        let lock_path = FileLock::lock_path_for(&input, temp_dir.path());
+
+        // A peer's live lock: created out-of-band, so this process must never
+        // register it, even though its own acquire loses the race to create it.
+        File::create(&lock_path).unwrap();
+
+        let contended = FileLock::acquire(&input, temp_dir.path());
         assert!(
-            lock_path.exists(),
-            "unregister_lock should not delete files"
+            matches!(contended, Err(Error::FileLocked { .. })),
+            "acquiring an already-locked input must fail: {contended:?}"
+        );
+        assert!(
+            !ACTIVE_FILE_LOCKS.contains(&lock_path),
+            "a failed acquire must not register a path this process does not own, \
+             so a signal cleanup can never delete a peer's lock"
+        );
+
+        // With the peer's lock gone, winning the create registers the path we own.
+        std::fs::remove_file(&lock_path).unwrap();
+        let held = FileLock::acquire(&input, temp_dir.path()).unwrap();
+        assert!(
+            ACTIVE_FILE_LOCKS.contains(&lock_path),
+            "a successful acquire must register the lock it owns"
+        );
+
+        drop(held);
+        assert!(
+            !ACTIVE_FILE_LOCKS.contains(&lock_path),
+            "drop must unregister the lock it owned"
         );
     }
 

--- a/src/locking/mod.rs
+++ b/src/locking/mod.rs
@@ -2,6 +2,7 @@
 
 mod config_lock;
 mod file_lock;
+mod registry;
 
 pub use config_lock::{cleanup_all_config_locks, with_config_lock};
 pub use file_lock::{FileLock, LockInfo, cleanup_all_locks};

--- a/src/locking/registry.rs
+++ b/src/locking/registry.rs
@@ -1,0 +1,230 @@
+//! A registry of held lock-file paths, drained if the process is interrupted.
+//!
+//! Both lock types ([`super::FileLock`] and the config lock) keep a registry of
+//! the lock files they currently hold so the Ctrl+C handler can remove them on
+//! the way out. The two registries are deliberately SEPARATE instances: one
+//! shared `Vec` would let either type's cleanup remove the other type's lock
+//! file. This primitive factors out the register/unregister/drain logic and the
+//! three race and poison hardenings it carries (first applied to the config lock
+//! in #313, extended to the file lock in #363) into one place that each lock type
+//! instantiates as its own module-local `static`.
+//!
+//! The correctness rules the callers must follow are encoded in the method docs:
+//! register only after winning the exclusive create, and unregister before
+//! removing the file.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, PoisonError};
+
+/// The set of lock-file paths this process currently holds for one lock type.
+///
+/// Every method recovers from a poisoned mutex (`unwrap_or_else(into_inner)`)
+/// rather than skipping the update. An asymmetry where `register`/`unregister`
+/// silently no-op on poison while `cleanup` still drains could leave a stale
+/// entry for a path this process no longer owns, which `cleanup` would then
+/// remove, deleting a peer's fresh lock at that path.
+pub(super) struct LockRegistry {
+    active: Mutex<Vec<PathBuf>>,
+}
+
+impl LockRegistry {
+    /// Create an empty registry. `const` so it can back a plain `static`.
+    pub(super) const fn new() -> Self {
+        Self {
+            active: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Record a held lock path so a signal can clean it up.
+    ///
+    /// Call only AFTER winning the exclusive create. A path this process does not
+    /// own must never enter the registry, or a Ctrl+C in the window before the
+    /// owner is established could make [`Self::cleanup`] delete a peer's lock. The
+    /// cost of registering late is that a Ctrl+C in the create-then-register gap
+    /// leaks this process's own lock file, which is a manual delete, not lost data.
+    pub(super) fn register(&self, path: &Path) {
+        let mut active = self.active.lock().unwrap_or_else(PoisonError::into_inner);
+        active.push(path.to_path_buf());
+    }
+
+    /// Drop a lock path from the registry once it is released.
+    ///
+    /// Call BEFORE removing the file, not after. Once the path is out of the
+    /// registry, a peer that re-creates a lock there is safe from this process's
+    /// cleanup. The other order leaves a window where the path is still registered
+    /// but the file at it is a peer's fresh lock, which cleanup would then delete.
+    pub(super) fn unregister(&self, path: &Path) {
+        let mut active = self.active.lock().unwrap_or_else(PoisonError::into_inner);
+        active.retain(|p| p != path);
+    }
+
+    /// Remove every held lock file. Called from the Ctrl+C handler.
+    ///
+    /// Recovers from a poisoned mutex so cleanup still runs after a panic, and
+    /// drains the registry so each path is removed once. Only paths this process
+    /// has successfully acquired are ever registered, so this never removes a
+    /// peer's lock.
+    pub(super) fn cleanup(&self) {
+        let paths = {
+            let mut active = self.active.lock().unwrap_or_else(PoisonError::into_inner);
+            std::mem::take(&mut *active)
+        };
+        for path in paths {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// Release one held lock: drop it from the registry, then remove its file.
+    ///
+    /// Unregister BEFORE removing, so a Ctrl+C between the two leaks only this
+    /// process's own lock file (a manual delete), never a peer's. Once the path is
+    /// out of the registry, a peer re-creating a lock there is not caught by this
+    /// process's cleanup; the reverse order leaves a window where the path is still
+    /// registered but the file at it is a peer's fresh lock, which cleanup would
+    /// delete. Removing by path is safe because nothing breaks a held lock, so
+    /// while it is held the file at `path` is always the one we created.
+    pub(super) fn release(&self, path: &Path) {
+        self.unregister(path);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Whether `path` is currently registered. Test-only helper.
+    #[cfg(test)]
+    pub(super) fn contains(&self, path: &Path) -> bool {
+        let active = self.active.lock().unwrap_or_else(PoisonError::into_inner);
+        active.iter().any(|p| p == path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_register_then_unregister_leaves_no_entry() {
+        let registry = LockRegistry::new();
+        let path = Path::new("/tmp/does-not-matter.lock");
+
+        registry.register(path);
+        assert!(registry.contains(path), "register must record the path");
+
+        registry.unregister(path);
+        assert!(
+            !registry.contains(path),
+            "unregister must drop the path from the registry"
+        );
+    }
+
+    #[test]
+    fn test_unregister_does_not_remove_the_file() {
+        let registry = LockRegistry::new();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("held.lock");
+        std::fs::write(&path, b"held").unwrap();
+
+        registry.register(&path);
+        registry.unregister(&path);
+
+        assert!(
+            path.exists(),
+            "unregister only touches the registry, never the filesystem"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_removes_registered_files_and_drains() {
+        let registry = LockRegistry::new();
+        let dir = TempDir::new().unwrap();
+        let one = dir.path().join("one.lock");
+        let two = dir.path().join("two.lock");
+        std::fs::write(&one, b"1").unwrap();
+        std::fs::write(&two, b"2").unwrap();
+
+        registry.register(&one);
+        registry.register(&two);
+        registry.cleanup();
+
+        assert!(
+            !one.exists(),
+            "cleanup must remove the first registered lock"
+        );
+        assert!(
+            !two.exists(),
+            "cleanup must remove the second registered lock"
+        );
+        assert!(
+            !registry.contains(&one) && !registry.contains(&two),
+            "cleanup must drain the registry so a second call is a no-op"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_ignores_an_unregistered_path() {
+        let registry = LockRegistry::new();
+        let dir = TempDir::new().unwrap();
+        let unregistered = dir.path().join("peer.lock");
+        std::fs::write(&unregistered, b"peer").unwrap();
+
+        // Nothing registered: cleanup must not touch a file this process never
+        // recorded, which is how a peer's lock stays safe.
+        registry.cleanup();
+
+        assert!(
+            unregistered.exists(),
+            "cleanup must leave an unregistered (e.g. peer-owned) file alone"
+        );
+    }
+
+    #[test]
+    fn test_registry_methods_recover_from_a_poisoned_mutex() {
+        use std::sync::Arc;
+
+        let dir = TempDir::new().unwrap();
+        let registry = Arc::new(LockRegistry::new());
+
+        // Registered BEFORE the poison, so unregister and cleanup have something to
+        // act on: on the old `if let Ok(..)` behaviour they would silently no-op
+        // through the poison and leave this entry (and its file) behind.
+        let pre = dir.path().join("registered-before-poison.lock");
+        std::fs::write(&pre, b"pre").unwrap();
+        registry.register(&pre);
+
+        // Poison the inner mutex by panicking while it is held.
+        let poisoner = Arc::clone(&registry);
+        let handle = std::thread::spawn(move || {
+            let _guard = poisoner.active.lock().unwrap();
+            panic!("poison the lock registry");
+        });
+        assert!(
+            handle.join().is_err(),
+            "the helper thread must have panicked"
+        );
+
+        // register must still record a path through the poison.
+        let after = dir.path().join("registered-after-poison.lock");
+        registry.register(&after);
+        assert!(
+            registry.contains(&after),
+            "register must record a path even after the mutex was poisoned"
+        );
+
+        // unregister must still drop the entry through the poison.
+        registry.unregister(&after);
+        assert!(
+            !registry.contains(&after),
+            "unregister must still work after the mutex was poisoned"
+        );
+
+        // cleanup must still drain the registry AND remove the file through poison.
+        registry.cleanup();
+        assert!(
+            !registry.contains(&pre),
+            "cleanup must drain the registry even after the mutex was poisoned"
+        );
+        assert!(
+            !pre.exists(),
+            "cleanup must remove the registered file even after the mutex was poisoned"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`FileLock`, the per-input-file lock used for distributed analysis across processes that share an output directory, carried the same three Ctrl+C / mutex-poison races that #313 hardened in `ConfigLock`. Each could delete a *peer* process's live lock file and break mutual exclusion. This ports the fixes and factors the shared logic into one primitive.

The three fixes to `FileLock`:

1. **Register-after-create.** `acquire()` registered the lock path *before* the exclusive `O_CREAT|O_EXCL` create, so an `AlreadyExists` create for a peer-owned path left that path registered until the error arm unregistered it, and a Ctrl+C in that window made `cleanup_all_locks` delete the peer's lock. It now registers only after winning the create.
2. **Unregister-before-remove.** `Drop` removed the file then unregistered, so a peer that re-created a lock at the same path in the gap could have it deleted by a Ctrl+C-triggered cleanup. `Drop` now unregisters first.
3. **Poison recovery.** The old `register_lock`/`unregister_lock` silently skipped on a poisoned mutex while `cleanup` recovered, so a poisoned mutex could leave a stale registry entry that cleanup later removed. All registry methods now recover from poison.

De-duplication: the register/unregister/drain/release logic and the three hardenings now live in one module-private `LockRegistry` (`src/locking/registry.rs`), instantiated as two *separate* module-local statics so the deliberate registry separation is preserved (one shared `Vec` would let either lock type's cleanup remove the other type's file). Both `Drop` impls route through `LockRegistry::release`, which single-sources the unregister-before-remove ordering. `ConfigLock` is refactored onto the same primitive with no behaviour change, guarded by its existing tests.

## Related Issues

Fixes #363

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --no-default-features --all-targets -- -D warnings` clean
- [x] `cargo test --no-default-features` green (600 lib unit tests + all integration suites)
- [x] New `LockRegistry` unit tests: register/unregister, unregister-does-not-touch-the-file, cleanup drains once, cleanup ignores an unregistered (peer-owned) path, and poison recovery across register/unregister/cleanup (red-green against the old silent no-op on poison)
- [x] New `FileLock` ownership-invariant test. The two ordering fixes are Ctrl+C timing windows a synchronous test cannot reach, and the test comment says so plainly; only the poison recovery is deterministically red-green