### PR TITLE
feat: emit model manifest over JSON and surface install provenance (#336)

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -100,6 +100,7 @@ The `result` event includes a `result_type` field:
 | `config` | `birda config show` |
 | `model_list` | `birda models list` |
 | `model_info` | `birda models info <id>` |
+| `model_manifest` | `birda models manifest <id>` |
 | `providers` | `birda providers` |
 | `species_list` | `birda species` |
 | `clip_extraction` | `birda clip` |
@@ -169,12 +170,93 @@ birda --output-mode json models list
         "is_default": true,
         "path": "/home/user/.local/share/birda/models/birdnet.onnx",
         "labels_path": "/home/user/.local/share/birda/models/labels.txt",
-        "has_meta_model": true
+        "registry_id": "birdnet-v24"
+      },
+      {
+        "id": "birdnet-v30-nordic",
+        "model_type": "birdnet-v30",
+        "is_default": false,
+        "path": "/home/user/.local/share/birda/models/birdnet-v3.0-preview3.1-nordic-fp16-b1.onnx",
+        "labels_path": "/home/user/.local/share/birda/models/birdnet-v3.0-preview3.1-nordic-labels-b1.txt",
+        "registry_id": "birdnet-v30",
+        "installed_version": "3.0-preview3.1",
+        "installed_build": 1,
+        "region": "nordic",
+        "variant": "fp16"
       }
     ]
   }
 }
 ```
+
+Install provenance (`registry_id`, `installed_version`, `installed_build`, `region`, `variant`) lets a consumer recover what a model was installed from, and detect when a newer build has superseded it, without parsing the id string. Each field is omitted when it does not apply: a model added with `models add` has no `registry_id`, and a global install has no `region` or `variant`. Feature-detect by field presence.
+
+### Model Manifest
+
+```bash
+birda --output-mode json models manifest birdnet-v30
+```
+
+A documented projection of one registry model, for building a region-aware model gallery. It lists every region and variant with class count, download size, resolved URLs, and the countries each region covers. A legacy single-file model (`birdnet-v24`) projects as one synthetic `global` variant, so a consumer never branches on an empty list.
+
+```json
+{
+  "spec_version": "1.1",
+  "timestamp": "2025-01-11T12:34:56.789Z",
+  "event": "result",
+  "payload": {
+    "result_type": "model_manifest",
+    "manifest": {
+      "id": "birdnet-v30",
+      "name": "BirdNET v3.0",
+      "version": "3.0-preview3.1",
+      "build": 1,
+      "model_type": "birdnet-v30",
+      "license": {
+        "type": "CC-BY-NC-SA-4.0",
+        "url": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+        "commercial_use": false,
+        "attribution_required": true,
+        "share_alike": true
+      },
+      "default_variant": "fp32",
+      "selection": { "cuda": "fp16", "tensorrt": "fp16" },
+      "variants": [
+        {
+          "id": "fp32",
+          "group_order": 0,
+          "classes": 11560,
+          "size_bytes": 123456789,
+          "model_url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/full/birdnet-v3.0-preview3.1-fp32-b1.onnx",
+          "labels_url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/full/birdnet-v3.0-preview3.1-labels-b1.txt"
+        },
+        {
+          "id": "fp32",
+          "region": "amazonia",
+          "region_name": "Amazonia",
+          "group": "south-america",
+          "group_name": "South America",
+          "group_order": 3,
+          "classes": 809,
+          "size_bytes": 156000000,
+          "model_url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/amazonia/birdnet-v3.0-preview3.1-amazonia-fp32-b1.onnx",
+          "labels_url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/amazonia/birdnet-v3.0-preview3.1-amazonia-labels-b1.txt",
+          "countries": {
+            "core": ["Brazil", "Colombia", "Ecuador", "Peru", "Venezuela"],
+            "partial": ["Bolivia", "Panama"]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Notes:
+
+- `model_url` and `labels_url` are resolved through `HF_ENDPOINT`, so a mirror rewrite happens once in birda rather than being reimplemented by every consumer. The per-region coverage map lives beside the model in the same directory, as `regional/<region>/coverage.png`.
+- `region`, `region_name`, `group`, `group_name`, and `countries` are absent on the global model, which is not a region. `countries` splits into `core` (wholly covered) and `partial`, each omitted when empty.
+- `selection` maps a hardware key to a variant id. A consumer need not evaluate these keys against the host: `models install` echoes the variant it resolved (`region`, `variant`, `selection_reason`) once the download completes.
 
 ### Providers
 

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "registry_version": 6,
+  "registry_version": 7,
   "models": [
     {
       "id": "birdnet-v24",
@@ -324,6 +324,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/amazonia/birdnet-v3.0-preview3.1-amazonia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-amazonia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Colombia",
+              "Ecuador",
+              "Guyana",
+              "Peru",
+              "Suriname",
+              "Trinidad and Tobago",
+              "Venezuela"
+            ],
+            "partial": [
+              "Bolivia",
+              "Panama"
+            ]
           }
         },
         {
@@ -343,6 +359,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/amazonia/birdnet-v3.0-preview3.1-amazonia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-amazonia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Colombia",
+              "Ecuador",
+              "Guyana",
+              "Peru",
+              "Suriname",
+              "Trinidad and Tobago",
+              "Venezuela"
+            ],
+            "partial": [
+              "Bolivia",
+              "Panama"
+            ]
           }
         },
         {
@@ -362,6 +394,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/andes/birdnet-v3.0-preview3.1-andes-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-andes-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Aruba",
+              "Bolivia",
+              "Brazil",
+              "Chile",
+              "Colombia",
+              "Curaçao",
+              "Ecuador",
+              "Grenada",
+              "Panama",
+              "Peru",
+              "Venezuela"
+            ]
           }
         },
         {
@@ -381,6 +429,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/andes/birdnet-v3.0-preview3.1-andes-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-andes-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Aruba",
+              "Bolivia",
+              "Brazil",
+              "Chile",
+              "Colombia",
+              "Curaçao",
+              "Ecuador",
+              "Grenada",
+              "Panama",
+              "Peru",
+              "Venezuela"
+            ]
           }
         },
         {
@@ -400,6 +464,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/australia-east/birdnet-v3.0-preview3.1-australia-east-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-australia-east-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Australia"
+            ]
           }
         },
         {
@@ -419,6 +488,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/australia-east/birdnet-v3.0-preview3.1-australia-east-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-australia-east-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Australia"
+            ]
           }
         },
         {
@@ -438,6 +512,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/azores/birdnet-v3.0-preview3.1-azores-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-azores-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -457,6 +536,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/azores/birdnet-v3.0-preview3.1-azores-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-azores-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -476,6 +560,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/baltics/birdnet-v3.0-preview3.1-baltics-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-baltics-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Belarus",
+              "Estonia",
+              "Latvia",
+              "Lithuania",
+              "Russia"
+            ]
           }
         },
         {
@@ -495,6 +588,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/baltics/birdnet-v3.0-preview3.1-baltics-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-baltics-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Belarus",
+              "Estonia",
+              "Latvia",
+              "Lithuania",
+              "Russia"
+            ]
           }
         },
         {
@@ -514,6 +616,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/british-isles/birdnet-v3.0-preview3.1-british-isles-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-british-isles-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Ireland",
+              "Isle of Man",
+              "United Kingdom"
+            ],
+            "partial": [
+              "Guernsey"
+            ]
           }
         },
         {
@@ -533,6 +645,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/british-isles/birdnet-v3.0-preview3.1-british-isles-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-british-isles-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Ireland",
+              "Isle of Man",
+              "United Kingdom"
+            ],
+            "partial": [
+              "Guernsey"
+            ]
           }
         },
         {
@@ -552,6 +674,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/canary-islands/birdnet-v3.0-preview3.1-canary-islands-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-canary-islands-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Morocco",
+              "Spain"
+            ]
           }
         },
         {
@@ -571,6 +699,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/canary-islands/birdnet-v3.0-preview3.1-canary-islands-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-canary-islands-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Morocco",
+              "Spain"
+            ]
           }
         },
         {
@@ -590,6 +724,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/cape-verde/birdnet-v3.0-preview3.1-cape-verde-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-cape-verde-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Cabo Verde"
+            ]
           }
         },
         {
@@ -609,6 +748,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/cape-verde/birdnet-v3.0-preview3.1-cape-verde-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-cape-verde-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Cabo Verde"
+            ]
           }
         },
         {
@@ -628,6 +772,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/central-europe/birdnet-v3.0-preview3.1-central-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-central-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Austria",
+              "Belgium",
+              "Croatia",
+              "Czechia",
+              "France",
+              "Germany",
+              "Hungary",
+              "Liechtenstein",
+              "Luxembourg",
+              "Netherlands",
+              "Poland",
+              "Slovakia",
+              "Slovenia",
+              "Switzerland"
+            ],
+            "partial": [
+              "Bosnia and Herzegovina",
+              "Denmark",
+              "Italy",
+              "Lithuania",
+              "Republic of Serbia",
+              "Romania"
+            ]
           }
         },
         {
@@ -647,6 +817,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/central-europe/birdnet-v3.0-preview3.1-central-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-central-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Austria",
+              "Belgium",
+              "Croatia",
+              "Czechia",
+              "France",
+              "Germany",
+              "Hungary",
+              "Liechtenstein",
+              "Luxembourg",
+              "Netherlands",
+              "Poland",
+              "Slovakia",
+              "Slovenia",
+              "Switzerland"
+            ],
+            "partial": [
+              "Bosnia and Herzegovina",
+              "Denmark",
+              "Italy",
+              "Lithuania",
+              "Republic of Serbia",
+              "Romania"
+            ]
           }
         },
         {
@@ -666,6 +862,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-north-central/birdnet-v3.0-preview3.1-china-north-central-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-north-central-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ]
           }
         },
         {
@@ -685,6 +886,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-north-central/birdnet-v3.0-preview3.1-china-north-central-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-north-central-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ]
           }
         },
         {
@@ -704,6 +910,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-northeast/birdnet-v3.0-preview3.1-china-northeast-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-northeast-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "North Korea",
+              "Russia"
+            ],
+            "partial": [
+              "Mongolia"
+            ]
           }
         },
         {
@@ -723,6 +939,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-northeast/birdnet-v3.0-preview3.1-china-northeast-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-northeast-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "North Korea",
+              "Russia"
+            ],
+            "partial": [
+              "Mongolia"
+            ]
           }
         },
         {
@@ -742,6 +968,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-southeast/birdnet-v3.0-preview3.1-china-southeast-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-southeast-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "Hong Kong S.A.R.",
+              "Macao S.A.R",
+              "Taiwan"
+            ]
           }
         },
         {
@@ -761,6 +995,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-southeast/birdnet-v3.0-preview3.1-china-southeast-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-southeast-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "Hong Kong S.A.R.",
+              "Macao S.A.R",
+              "Taiwan"
+            ]
           }
         },
         {
@@ -780,6 +1022,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-southwest/birdnet-v3.0-preview3.1-china-southwest-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-southwest-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Myanmar",
+              "Vietnam"
+            ]
           }
         },
         {
@@ -799,6 +1050,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/china-southwest/birdnet-v3.0-preview3.1-china-southwest-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-china-southwest-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Myanmar",
+              "Vietnam"
+            ]
           }
         },
         {
@@ -818,6 +1078,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/eastern-brazil/birdnet-v3.0-preview3.1-eastern-brazil-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-eastern-brazil-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Argentina"
+            ]
           }
         },
         {
@@ -837,6 +1107,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/eastern-brazil/birdnet-v3.0-preview3.1-eastern-brazil-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-eastern-brazil-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Argentina"
+            ]
           }
         },
         {
@@ -856,6 +1136,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/eastern-europe/birdnet-v3.0-preview3.1-eastern-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-eastern-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Moldova",
+              "Romania",
+              "Russia",
+              "Ukraine"
+            ],
+            "partial": [
+              "Belarus",
+              "Poland"
+            ]
           }
         },
         {
@@ -875,6 +1167,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/eastern-europe/birdnet-v3.0-preview3.1-eastern-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-eastern-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Moldova",
+              "Romania",
+              "Russia",
+              "Ukraine"
+            ],
+            "partial": [
+              "Belarus",
+              "Poland"
+            ]
           }
         },
         {
@@ -894,6 +1198,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/galapagos/birdnet-v3.0-preview3.1-galapagos-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-galapagos-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Ecuador"
+            ]
           }
         },
         {
@@ -913,6 +1222,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/galapagos/birdnet-v3.0-preview3.1-galapagos-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-galapagos-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Ecuador"
+            ]
           }
         },
         {
@@ -932,6 +1246,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/hawaii/birdnet-v3.0-preview3.1-hawaii-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-hawaii-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "United States of America"
+            ]
           }
         },
         {
@@ -951,6 +1270,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/hawaii/birdnet-v3.0-preview3.1-hawaii-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-hawaii-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "United States of America"
+            ]
           }
         },
         {
@@ -970,6 +1294,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/himalaya/birdnet-v3.0-preview3.1-himalaya-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-himalaya-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bhutan",
+              "China",
+              "India",
+              "Nepal",
+              "Siachen Glacier"
+            ],
+            "partial": [
+              "Pakistan"
+            ]
           }
         },
         {
@@ -989,6 +1325,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/himalaya/birdnet-v3.0-preview3.1-himalaya-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-himalaya-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bhutan",
+              "China",
+              "India",
+              "Nepal",
+              "Siachen Glacier"
+            ],
+            "partial": [
+              "Pakistan"
+            ]
           }
         },
         {
@@ -1008,6 +1356,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/iberia/birdnet-v3.0-preview3.1-iberia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-iberia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Andorra",
+              "Portugal",
+              "Spain"
+            ],
+            "partial": [
+              "France"
+            ]
           }
         },
         {
@@ -1027,6 +1385,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/iberia/birdnet-v3.0-preview3.1-iberia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-iberia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Andorra",
+              "Portugal",
+              "Spain"
+            ],
+            "partial": [
+              "France"
+            ]
           }
         },
         {
@@ -1046,6 +1414,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/iceland/birdnet-v3.0-preview3.1-iceland-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-iceland-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Iceland"
+            ]
           }
         },
         {
@@ -1065,6 +1438,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/iceland/birdnet-v3.0-preview3.1-iceland-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-iceland-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Iceland"
+            ]
           }
         },
         {
@@ -1084,6 +1462,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/indo-gangetic/birdnet-v3.0-preview3.1-indo-gangetic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-indo-gangetic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bangladesh",
+              "Bhutan",
+              "India",
+              "Nepal",
+              "Pakistan"
+            ],
+            "partial": [
+              "China"
+            ]
           }
         },
         {
@@ -1103,6 +1493,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/indo-gangetic/birdnet-v3.0-preview3.1-indo-gangetic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-indo-gangetic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bangladesh",
+              "Bhutan",
+              "India",
+              "Nepal",
+              "Pakistan"
+            ],
+            "partial": [
+              "China"
+            ]
           }
         },
         {
@@ -1122,6 +1524,17 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/japan/birdnet-v3.0-preview3.1-japan-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-japan-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Japan",
+              "South Korea"
+            ],
+            "partial": [
+              "China",
+              "North Korea",
+              "Russia"
+            ]
           }
         },
         {
@@ -1141,6 +1554,17 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/japan/birdnet-v3.0-preview3.1-japan-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-japan-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Japan",
+              "South Korea"
+            ],
+            "partial": [
+              "China",
+              "North Korea",
+              "Russia"
+            ]
           }
         },
         {
@@ -1160,6 +1584,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/madeira/birdnet-v3.0-preview3.1-madeira-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-madeira-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -1179,6 +1608,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/madeira/birdnet-v3.0-preview3.1-madeira-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-madeira-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -1198,6 +1632,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/mauritius/birdnet-v3.0-preview3.1-mauritius-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-mauritius-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Mauritius"
+            ]
           }
         },
         {
@@ -1217,6 +1656,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/mauritius/birdnet-v3.0-preview3.1-mauritius-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-mauritius-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Mauritius"
+            ]
           }
         },
         {
@@ -1236,6 +1680,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/new-caledonia/birdnet-v3.0-preview3.1-new-caledonia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-new-caledonia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "New Caledonia"
+            ]
           }
         },
         {
@@ -1255,6 +1704,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/new-caledonia/birdnet-v3.0-preview3.1-new-caledonia-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-new-caledonia-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "New Caledonia"
+            ]
           }
         },
         {
@@ -1274,6 +1728,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/new-zealand/birdnet-v3.0-preview3.1-new-zealand-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-new-zealand-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "New Zealand"
+            ]
           }
         },
         {
@@ -1293,6 +1752,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/new-zealand/birdnet-v3.0-preview3.1-new-zealand-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-new-zealand-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "New Zealand"
+            ]
           }
         },
         {
@@ -1312,6 +1776,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/nordic/birdnet-v3.0-preview3.1-nordic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-nordic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Denmark",
+              "Finland",
+              "Norway",
+              "Sweden"
+            ]
           }
         },
         {
@@ -1331,6 +1804,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/nordic/birdnet-v3.0-preview3.1-nordic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-nordic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Denmark",
+              "Finland",
+              "Norway",
+              "Sweden"
+            ]
           }
         },
         {
@@ -1350,6 +1832,13 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/north-america-east/birdnet-v3.0-preview3.1-north-america-east-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-north-america-east-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bermuda",
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -1369,6 +1858,13 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/north-america-east/birdnet-v3.0-preview3.1-north-america-east-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-north-america-east-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Bermuda",
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -1388,6 +1884,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/north-america-west/birdnet-v3.0-preview3.1-north-america-west-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-north-america-west-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -1407,6 +1909,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/north-america-west/birdnet-v3.0-preview3.1-north-america-west-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-north-america-west-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -1426,6 +1934,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/reunion/birdnet-v3.0-preview3.1-reunion-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-reunion-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "France"
+            ]
           }
         },
         {
@@ -1445,6 +1958,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/reunion/birdnet-v3.0-preview3.1-reunion-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-reunion-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "France"
+            ]
           }
         },
         {
@@ -1464,6 +1982,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/sao-tome-principe/birdnet-v3.0-preview3.1-sao-tome-principe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-sao-tome-principe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "São Tomé and Principe"
+            ]
           }
         },
         {
@@ -1483,6 +2006,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/sao-tome-principe/birdnet-v3.0-preview3.1-sao-tome-principe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-sao-tome-principe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "São Tomé and Principe"
+            ]
           }
         },
         {
@@ -1502,6 +2030,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/seychelles/birdnet-v3.0-preview3.1-seychelles-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-seychelles-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Seychelles"
+            ]
           }
         },
         {
@@ -1521,6 +2054,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/seychelles/birdnet-v3.0-preview3.1-seychelles-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-seychelles-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Seychelles"
+            ]
           }
         },
         {
@@ -1540,6 +2078,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/south-asia-peninsular/birdnet-v3.0-preview3.1-south-asia-peninsular-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-south-asia-peninsular-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "India",
+              "Sri Lanka"
+            ]
           }
         },
         {
@@ -1559,6 +2103,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/south-asia-peninsular/birdnet-v3.0-preview3.1-south-asia-peninsular-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-south-asia-peninsular-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "India",
+              "Sri Lanka"
+            ]
           }
         },
         {
@@ -1578,6 +2128,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-africa/birdnet-v3.0-preview3.1-southern-africa-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-africa-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Botswana",
+              "Lesotho",
+              "Namibia",
+              "South Africa",
+              "Zimbabwe",
+              "eSwatini"
+            ]
           }
         },
         {
@@ -1597,6 +2157,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-africa/birdnet-v3.0-preview3.1-southern-africa-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-africa-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Botswana",
+              "Lesotho",
+              "Namibia",
+              "South Africa",
+              "Zimbabwe",
+              "eSwatini"
+            ]
           }
         },
         {
@@ -1616,6 +2186,19 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-cone/birdnet-v3.0-preview3.1-southern-cone-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-cone-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Chile",
+              "Falkland Islands",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Bolivia",
+              "Brazil"
+            ]
           }
         },
         {
@@ -1635,6 +2218,19 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-cone/birdnet-v3.0-preview3.1-southern-cone-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-cone-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Chile",
+              "Falkland Islands",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Bolivia",
+              "Brazil"
+            ]
           }
         },
         {
@@ -1654,6 +2250,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-europe/birdnet-v3.0-preview3.1-southern-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Albania",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Croatia",
+              "Greece",
+              "Italy",
+              "Kosovo",
+              "Malta",
+              "Monaco",
+              "Montenegro",
+              "North Macedonia",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Slovenia",
+              "Vatican"
+            ],
+            "partial": [
+              "Hungary",
+              "Switzerland",
+              "Tunisia",
+              "Turkey"
+            ]
           }
         },
         {
@@ -1673,6 +2295,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/southern-europe/birdnet-v3.0-preview3.1-southern-europe-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-southern-europe-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Albania",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Croatia",
+              "Greece",
+              "Italy",
+              "Kosovo",
+              "Malta",
+              "Monaco",
+              "Montenegro",
+              "North Macedonia",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Slovenia",
+              "Vatican"
+            ],
+            "partial": [
+              "Hungary",
+              "Switzerland",
+              "Tunisia",
+              "Turkey"
+            ]
           }
         },
         {
@@ -1692,6 +2340,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/svalbard/birdnet-v3.0-preview3.1-svalbard-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-svalbard-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Norway"
+            ]
           }
         },
         {
@@ -1711,6 +2364,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/svalbard/birdnet-v3.0-preview3.1-svalbard-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-svalbard-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Norway"
+            ]
           }
         },
         {
@@ -1730,6 +2388,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/tibet/birdnet-v3.0-preview3.1-tibet-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-tibet-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Nepal"
+            ]
           }
         },
         {
@@ -1749,6 +2415,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/tibet/birdnet-v3.0-preview3.1-tibet-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-tibet-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Nepal"
+            ]
           }
         },
         {
@@ -1768,6 +2442,96 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/western-palearctic/birdnet-v3.0-preview3.1-western-palearctic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-western-palearctic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Albania",
+              "Algeria",
+              "Andorra",
+              "Armenia",
+              "Austria",
+              "Azerbaijan",
+              "Bahrain",
+              "Belarus",
+              "Belgium",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Chad",
+              "Croatia",
+              "Cyprus",
+              "Czechia",
+              "Denmark",
+              "Egypt",
+              "Eritrea",
+              "Estonia",
+              "Faroe Islands",
+              "Finland",
+              "France",
+              "Georgia",
+              "Germany",
+              "Greece",
+              "Guernsey",
+              "Hungary",
+              "Iran",
+              "Iraq",
+              "Ireland",
+              "Isle of Man",
+              "Israel",
+              "Italy",
+              "Jersey",
+              "Jordan",
+              "Kosovo",
+              "Kuwait",
+              "Latvia",
+              "Lebanon",
+              "Libya",
+              "Liechtenstein",
+              "Lithuania",
+              "Luxembourg",
+              "Malta",
+              "Mauritania",
+              "Moldova",
+              "Monaco",
+              "Montenegro",
+              "Morocco",
+              "Netherlands",
+              "Niger",
+              "North Macedonia",
+              "Northern Cyprus",
+              "Norway",
+              "Oman",
+              "Palestine",
+              "Poland",
+              "Portugal",
+              "Qatar",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Saudi Arabia",
+              "Slovakia",
+              "Slovenia",
+              "Spain",
+              "Sudan",
+              "Sweden",
+              "Switzerland",
+              "Syria",
+              "Tunisia",
+              "Turkey",
+              "Ukraine",
+              "United Arab Emirates",
+              "United Kingdom",
+              "Vatican",
+              "Western Sahara",
+              "Yemen"
+            ],
+            "partial": [
+              "Djibouti",
+              "Ethiopia",
+              "Mali",
+              "Russia",
+              "Turkmenistan"
+            ]
           }
         },
         {
@@ -1787,6 +2551,96 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/BirdNET-v3.0-Models/resolve/main/regional/western-palearctic/birdnet-v3.0-preview3.1-western-palearctic-labels-b1.txt",
             "filename": "birdnet-v3.0-preview3.1-western-palearctic-labels-b1.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Albania",
+              "Algeria",
+              "Andorra",
+              "Armenia",
+              "Austria",
+              "Azerbaijan",
+              "Bahrain",
+              "Belarus",
+              "Belgium",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Chad",
+              "Croatia",
+              "Cyprus",
+              "Czechia",
+              "Denmark",
+              "Egypt",
+              "Eritrea",
+              "Estonia",
+              "Faroe Islands",
+              "Finland",
+              "France",
+              "Georgia",
+              "Germany",
+              "Greece",
+              "Guernsey",
+              "Hungary",
+              "Iran",
+              "Iraq",
+              "Ireland",
+              "Isle of Man",
+              "Israel",
+              "Italy",
+              "Jersey",
+              "Jordan",
+              "Kosovo",
+              "Kuwait",
+              "Latvia",
+              "Lebanon",
+              "Libya",
+              "Liechtenstein",
+              "Lithuania",
+              "Luxembourg",
+              "Malta",
+              "Mauritania",
+              "Moldova",
+              "Monaco",
+              "Montenegro",
+              "Morocco",
+              "Netherlands",
+              "Niger",
+              "North Macedonia",
+              "Northern Cyprus",
+              "Norway",
+              "Oman",
+              "Palestine",
+              "Poland",
+              "Portugal",
+              "Qatar",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Saudi Arabia",
+              "Slovakia",
+              "Slovenia",
+              "Spain",
+              "Sudan",
+              "Sweden",
+              "Switzerland",
+              "Syria",
+              "Tunisia",
+              "Turkey",
+              "Ukraine",
+              "United Arab Emirates",
+              "United Kingdom",
+              "Vatican",
+              "Western Sahara",
+              "Yemen"
+            ],
+            "partial": [
+              "Djibouti",
+              "Ethiopia",
+              "Mali",
+              "Russia",
+              "Turkmenistan"
+            ]
           }
         }
       ],
@@ -1920,6 +2774,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/amazonia/perch_v2_amazonia_labels.txt",
             "filename": "perch_v2_amazonia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Colombia",
+              "Ecuador",
+              "Guyana",
+              "Peru",
+              "Suriname",
+              "Trinidad and Tobago",
+              "Venezuela"
+            ],
+            "partial": [
+              "Bolivia",
+              "Panama"
+            ]
           }
         },
         {
@@ -1939,6 +2809,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/amazonia/perch_v2_amazonia_labels.txt",
             "filename": "perch_v2_amazonia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Colombia",
+              "Ecuador",
+              "Guyana",
+              "Peru",
+              "Suriname",
+              "Trinidad and Tobago",
+              "Venezuela"
+            ],
+            "partial": [
+              "Bolivia",
+              "Panama"
+            ]
           }
         },
         {
@@ -1958,6 +2844,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/andes/perch_v2_andes_labels.txt",
             "filename": "perch_v2_andes_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Aruba",
+              "Bolivia",
+              "Brazil",
+              "Chile",
+              "Colombia",
+              "Curaçao",
+              "Ecuador",
+              "Grenada",
+              "Panama",
+              "Peru",
+              "Venezuela"
+            ]
           }
         },
         {
@@ -1977,6 +2879,22 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/andes/perch_v2_andes_labels.txt",
             "filename": "perch_v2_andes_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Aruba",
+              "Bolivia",
+              "Brazil",
+              "Chile",
+              "Colombia",
+              "Curaçao",
+              "Ecuador",
+              "Grenada",
+              "Panama",
+              "Peru",
+              "Venezuela"
+            ]
           }
         },
         {
@@ -1996,6 +2914,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/australia-east/perch_v2_australia-east_labels.txt",
             "filename": "perch_v2_australia-east_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Australia"
+            ]
           }
         },
         {
@@ -2015,6 +2938,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/australia-east/perch_v2_australia-east_labels.txt",
             "filename": "perch_v2_australia-east_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Australia"
+            ]
           }
         },
         {
@@ -2034,6 +2962,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/azores/perch_v2_azores_labels.txt",
             "filename": "perch_v2_azores_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -2053,6 +2986,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/azores/perch_v2_azores_labels.txt",
             "filename": "perch_v2_azores_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -2072,6 +3010,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/baltics/perch_v2_baltics_labels.txt",
             "filename": "perch_v2_baltics_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Belarus",
+              "Estonia",
+              "Latvia",
+              "Lithuania",
+              "Russia"
+            ]
           }
         },
         {
@@ -2091,6 +3038,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/baltics/perch_v2_baltics_labels.txt",
             "filename": "perch_v2_baltics_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Belarus",
+              "Estonia",
+              "Latvia",
+              "Lithuania",
+              "Russia"
+            ]
           }
         },
         {
@@ -2110,6 +3066,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/british-isles/perch_v2_british-isles_labels.txt",
             "filename": "perch_v2_british-isles_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Ireland",
+              "Isle of Man",
+              "United Kingdom"
+            ],
+            "partial": [
+              "Guernsey"
+            ]
           }
         },
         {
@@ -2129,6 +3095,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/british-isles/perch_v2_british-isles_labels.txt",
             "filename": "perch_v2_british-isles_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Ireland",
+              "Isle of Man",
+              "United Kingdom"
+            ],
+            "partial": [
+              "Guernsey"
+            ]
           }
         },
         {
@@ -2148,6 +3124,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/canary-islands/perch_v2_canary-islands_labels.txt",
             "filename": "perch_v2_canary-islands_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Morocco",
+              "Spain"
+            ]
           }
         },
         {
@@ -2167,6 +3149,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/canary-islands/perch_v2_canary-islands_labels.txt",
             "filename": "perch_v2_canary-islands_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Morocco",
+              "Spain"
+            ]
           }
         },
         {
@@ -2186,6 +3174,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/cape-verde/perch_v2_cape-verde_labels.txt",
             "filename": "perch_v2_cape-verde_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Cabo Verde"
+            ]
           }
         },
         {
@@ -2205,6 +3198,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/cape-verde/perch_v2_cape-verde_labels.txt",
             "filename": "perch_v2_cape-verde_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Cabo Verde"
+            ]
           }
         },
         {
@@ -2224,6 +3222,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/central-europe/perch_v2_central-europe_labels.txt",
             "filename": "perch_v2_central-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Austria",
+              "Belgium",
+              "Croatia",
+              "Czechia",
+              "France",
+              "Germany",
+              "Hungary",
+              "Liechtenstein",
+              "Luxembourg",
+              "Netherlands",
+              "Poland",
+              "Slovakia",
+              "Slovenia",
+              "Switzerland"
+            ],
+            "partial": [
+              "Bosnia and Herzegovina",
+              "Denmark",
+              "Italy",
+              "Lithuania",
+              "Republic of Serbia",
+              "Romania"
+            ]
           }
         },
         {
@@ -2243,6 +3267,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/central-europe/perch_v2_central-europe_labels.txt",
             "filename": "perch_v2_central-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Austria",
+              "Belgium",
+              "Croatia",
+              "Czechia",
+              "France",
+              "Germany",
+              "Hungary",
+              "Liechtenstein",
+              "Luxembourg",
+              "Netherlands",
+              "Poland",
+              "Slovakia",
+              "Slovenia",
+              "Switzerland"
+            ],
+            "partial": [
+              "Bosnia and Herzegovina",
+              "Denmark",
+              "Italy",
+              "Lithuania",
+              "Republic of Serbia",
+              "Romania"
+            ]
           }
         },
         {
@@ -2262,6 +3312,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-north-central/perch_v2_china-north-central_labels.txt",
             "filename": "perch_v2_china-north-central_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ]
           }
         },
         {
@@ -2281,6 +3336,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-north-central/perch_v2_china-north-central_labels.txt",
             "filename": "perch_v2_china-north-central_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ]
           }
         },
         {
@@ -2300,6 +3360,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-northeast/perch_v2_china-northeast_labels.txt",
             "filename": "perch_v2_china-northeast_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "North Korea",
+              "Russia"
+            ],
+            "partial": [
+              "Mongolia"
+            ]
           }
         },
         {
@@ -2319,6 +3389,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-northeast/perch_v2_china-northeast_labels.txt",
             "filename": "perch_v2_china-northeast_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "North Korea",
+              "Russia"
+            ],
+            "partial": [
+              "Mongolia"
+            ]
           }
         },
         {
@@ -2338,6 +3418,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-southeast/perch_v2_china-southeast_labels.txt",
             "filename": "perch_v2_china-southeast_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "Hong Kong S.A.R.",
+              "Macao S.A.R",
+              "Taiwan"
+            ]
           }
         },
         {
@@ -2357,6 +3445,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-southeast/perch_v2_china-southeast_labels.txt",
             "filename": "perch_v2_china-southeast_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China",
+              "Hong Kong S.A.R.",
+              "Macao S.A.R",
+              "Taiwan"
+            ]
           }
         },
         {
@@ -2376,6 +3472,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-southwest/perch_v2_china-southwest_labels.txt",
             "filename": "perch_v2_china-southwest_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Myanmar",
+              "Vietnam"
+            ]
           }
         },
         {
@@ -2395,6 +3500,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/china-southwest/perch_v2_china-southwest_labels.txt",
             "filename": "perch_v2_china-southwest_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Myanmar",
+              "Vietnam"
+            ]
           }
         },
         {
@@ -2414,6 +3528,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/eastern-brazil/perch_v2_eastern-brazil_labels.txt",
             "filename": "perch_v2_eastern-brazil_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Argentina"
+            ]
           }
         },
         {
@@ -2433,6 +3557,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/eastern-brazil/perch_v2_eastern-brazil_labels.txt",
             "filename": "perch_v2_eastern-brazil_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Brazil",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Argentina"
+            ]
           }
         },
         {
@@ -2452,6 +3586,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/eastern-europe/perch_v2_eastern-europe_labels.txt",
             "filename": "perch_v2_eastern-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Moldova",
+              "Romania",
+              "Russia",
+              "Ukraine"
+            ],
+            "partial": [
+              "Belarus",
+              "Poland"
+            ]
           }
         },
         {
@@ -2471,6 +3617,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/eastern-europe/perch_v2_eastern-europe_labels.txt",
             "filename": "perch_v2_eastern-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Moldova",
+              "Romania",
+              "Russia",
+              "Ukraine"
+            ],
+            "partial": [
+              "Belarus",
+              "Poland"
+            ]
           }
         },
         {
@@ -2490,6 +3648,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/galapagos/perch_v2_galapagos_labels.txt",
             "filename": "perch_v2_galapagos_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Ecuador"
+            ]
           }
         },
         {
@@ -2509,6 +3672,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/galapagos/perch_v2_galapagos_labels.txt",
             "filename": "perch_v2_galapagos_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Ecuador"
+            ]
           }
         },
         {
@@ -2528,6 +3696,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/hawaii/perch_v2_hawaii_labels.txt",
             "filename": "perch_v2_hawaii_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "United States of America"
+            ]
           }
         },
         {
@@ -2547,6 +3720,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/hawaii/perch_v2_hawaii_labels.txt",
             "filename": "perch_v2_hawaii_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "United States of America"
+            ]
           }
         },
         {
@@ -2566,6 +3744,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/himalaya/perch_v2_himalaya_labels.txt",
             "filename": "perch_v2_himalaya_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bhutan",
+              "China",
+              "India",
+              "Nepal",
+              "Siachen Glacier"
+            ],
+            "partial": [
+              "Pakistan"
+            ]
           }
         },
         {
@@ -2585,6 +3775,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/himalaya/perch_v2_himalaya_labels.txt",
             "filename": "perch_v2_himalaya_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bhutan",
+              "China",
+              "India",
+              "Nepal",
+              "Siachen Glacier"
+            ],
+            "partial": [
+              "Pakistan"
+            ]
           }
         },
         {
@@ -2604,6 +3806,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/iberia/perch_v2_iberia_labels.txt",
             "filename": "perch_v2_iberia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Andorra",
+              "Portugal",
+              "Spain"
+            ],
+            "partial": [
+              "France"
+            ]
           }
         },
         {
@@ -2623,6 +3835,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/iberia/perch_v2_iberia_labels.txt",
             "filename": "perch_v2_iberia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Andorra",
+              "Portugal",
+              "Spain"
+            ],
+            "partial": [
+              "France"
+            ]
           }
         },
         {
@@ -2642,6 +3864,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/iceland/perch_v2_iceland_labels.txt",
             "filename": "perch_v2_iceland_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Iceland"
+            ]
           }
         },
         {
@@ -2661,6 +3888,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/iceland/perch_v2_iceland_labels.txt",
             "filename": "perch_v2_iceland_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Iceland"
+            ]
           }
         },
         {
@@ -2680,6 +3912,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/indo-gangetic/perch_v2_indo-gangetic_labels.txt",
             "filename": "perch_v2_indo-gangetic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bangladesh",
+              "Bhutan",
+              "India",
+              "Nepal",
+              "Pakistan"
+            ],
+            "partial": [
+              "China"
+            ]
           }
         },
         {
@@ -2699,6 +3943,18 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/indo-gangetic/perch_v2_indo-gangetic_labels.txt",
             "filename": "perch_v2_indo-gangetic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bangladesh",
+              "Bhutan",
+              "India",
+              "Nepal",
+              "Pakistan"
+            ],
+            "partial": [
+              "China"
+            ]
           }
         },
         {
@@ -2718,6 +3974,17 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/japan/perch_v2_japan_labels.txt",
             "filename": "perch_v2_japan_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Japan",
+              "South Korea"
+            ],
+            "partial": [
+              "China",
+              "North Korea",
+              "Russia"
+            ]
           }
         },
         {
@@ -2737,6 +4004,17 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/japan/perch_v2_japan_labels.txt",
             "filename": "perch_v2_japan_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Japan",
+              "South Korea"
+            ],
+            "partial": [
+              "China",
+              "North Korea",
+              "Russia"
+            ]
           }
         },
         {
@@ -2756,6 +4034,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/madeira/perch_v2_madeira_labels.txt",
             "filename": "perch_v2_madeira_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -2775,6 +4058,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/madeira/perch_v2_madeira_labels.txt",
             "filename": "perch_v2_madeira_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Portugal"
+            ]
           }
         },
         {
@@ -2794,6 +4082,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/mauritius/perch_v2_mauritius_labels.txt",
             "filename": "perch_v2_mauritius_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Mauritius"
+            ]
           }
         },
         {
@@ -2813,6 +4106,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/mauritius/perch_v2_mauritius_labels.txt",
             "filename": "perch_v2_mauritius_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Mauritius"
+            ]
           }
         },
         {
@@ -2832,6 +4130,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/new-caledonia/perch_v2_new-caledonia_labels.txt",
             "filename": "perch_v2_new-caledonia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "New Caledonia"
+            ]
           }
         },
         {
@@ -2851,6 +4154,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/new-caledonia/perch_v2_new-caledonia_labels.txt",
             "filename": "perch_v2_new-caledonia_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "New Caledonia"
+            ]
           }
         },
         {
@@ -2870,6 +4178,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/new-zealand/perch_v2_new-zealand_labels.txt",
             "filename": "perch_v2_new-zealand_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "New Zealand"
+            ]
           }
         },
         {
@@ -2889,6 +4202,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/new-zealand/perch_v2_new-zealand_labels.txt",
             "filename": "perch_v2_new-zealand_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "New Zealand"
+            ]
           }
         },
         {
@@ -2908,6 +4226,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/nordic/perch_v2_nordic_labels.txt",
             "filename": "perch_v2_nordic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Denmark",
+              "Finland",
+              "Norway",
+              "Sweden"
+            ]
           }
         },
         {
@@ -2927,6 +4254,15 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/nordic/perch_v2_nordic_labels.txt",
             "filename": "perch_v2_nordic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Denmark",
+              "Finland",
+              "Norway",
+              "Sweden"
+            ]
           }
         },
         {
@@ -2946,6 +4282,13 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/north-america-east/perch_v2_north-america-east_labels.txt",
             "filename": "perch_v2_north-america-east_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bermuda",
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -2965,6 +4308,13 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/north-america-east/perch_v2_north-america-east_labels.txt",
             "filename": "perch_v2_north-america-east_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Bermuda",
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -2984,6 +4334,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/north-america-west/perch_v2_north-america-west_labels.txt",
             "filename": "perch_v2_north-america-west_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -3003,6 +4359,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/north-america-west/perch_v2_north-america-west_labels.txt",
             "filename": "perch_v2_north-america-west_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Canada",
+              "United States of America"
+            ]
           }
         },
         {
@@ -3022,6 +4384,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/reunion/perch_v2_reunion_labels.txt",
             "filename": "perch_v2_reunion_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "France"
+            ]
           }
         },
         {
@@ -3041,6 +4408,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/reunion/perch_v2_reunion_labels.txt",
             "filename": "perch_v2_reunion_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "France"
+            ]
           }
         },
         {
@@ -3060,6 +4432,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/sao-tome-principe/perch_v2_sao-tome-principe_labels.txt",
             "filename": "perch_v2_sao-tome-principe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "São Tomé and Principe"
+            ]
           }
         },
         {
@@ -3079,6 +4456,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/sao-tome-principe/perch_v2_sao-tome-principe_labels.txt",
             "filename": "perch_v2_sao-tome-principe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "São Tomé and Principe"
+            ]
           }
         },
         {
@@ -3098,6 +4480,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/seychelles/perch_v2_seychelles_labels.txt",
             "filename": "perch_v2_seychelles_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Seychelles"
+            ]
           }
         },
         {
@@ -3117,6 +4504,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/seychelles/perch_v2_seychelles_labels.txt",
             "filename": "perch_v2_seychelles_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Seychelles"
+            ]
           }
         },
         {
@@ -3136,6 +4528,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/south-asia-peninsular/perch_v2_south-asia-peninsular_labels.txt",
             "filename": "perch_v2_south-asia-peninsular_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "India",
+              "Sri Lanka"
+            ]
           }
         },
         {
@@ -3155,6 +4553,12 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/south-asia-peninsular/perch_v2_south-asia-peninsular_labels.txt",
             "filename": "perch_v2_south-asia-peninsular_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "India",
+              "Sri Lanka"
+            ]
           }
         },
         {
@@ -3174,6 +4578,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-africa/perch_v2_southern-africa_labels.txt",
             "filename": "perch_v2_southern-africa_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Botswana",
+              "Lesotho",
+              "Namibia",
+              "South Africa",
+              "Zimbabwe",
+              "eSwatini"
+            ]
           }
         },
         {
@@ -3193,6 +4607,16 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-africa/perch_v2_southern-africa_labels.txt",
             "filename": "perch_v2_southern-africa_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Botswana",
+              "Lesotho",
+              "Namibia",
+              "South Africa",
+              "Zimbabwe",
+              "eSwatini"
+            ]
           }
         },
         {
@@ -3212,6 +4636,19 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-cone/perch_v2_southern-cone_labels.txt",
             "filename": "perch_v2_southern-cone_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Chile",
+              "Falkland Islands",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Bolivia",
+              "Brazil"
+            ]
           }
         },
         {
@@ -3231,6 +4668,19 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-cone/perch_v2_southern-cone_labels.txt",
             "filename": "perch_v2_southern-cone_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Argentina",
+              "Chile",
+              "Falkland Islands",
+              "Paraguay",
+              "Uruguay"
+            ],
+            "partial": [
+              "Bolivia",
+              "Brazil"
+            ]
           }
         },
         {
@@ -3250,6 +4700,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-europe/perch_v2_southern-europe_labels.txt",
             "filename": "perch_v2_southern-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Albania",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Croatia",
+              "Greece",
+              "Italy",
+              "Kosovo",
+              "Malta",
+              "Monaco",
+              "Montenegro",
+              "North Macedonia",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Slovenia",
+              "Vatican"
+            ],
+            "partial": [
+              "Hungary",
+              "Switzerland",
+              "Tunisia",
+              "Turkey"
+            ]
           }
         },
         {
@@ -3269,6 +4745,32 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/southern-europe/perch_v2_southern-europe_labels.txt",
             "filename": "perch_v2_southern-europe_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Albania",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Croatia",
+              "Greece",
+              "Italy",
+              "Kosovo",
+              "Malta",
+              "Monaco",
+              "Montenegro",
+              "North Macedonia",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Slovenia",
+              "Vatican"
+            ],
+            "partial": [
+              "Hungary",
+              "Switzerland",
+              "Tunisia",
+              "Turkey"
+            ]
           }
         },
         {
@@ -3288,6 +4790,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/svalbard/perch_v2_svalbard_labels.txt",
             "filename": "perch_v2_svalbard_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Norway"
+            ]
           }
         },
         {
@@ -3307,6 +4814,11 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/svalbard/perch_v2_svalbard_labels.txt",
             "filename": "perch_v2_svalbard_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Norway"
+            ]
           }
         },
         {
@@ -3326,6 +4838,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/tibet/perch_v2_tibet_labels.txt",
             "filename": "perch_v2_tibet_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Nepal"
+            ]
           }
         },
         {
@@ -3345,6 +4865,14 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/tibet/perch_v2_tibet_labels.txt",
             "filename": "perch_v2_tibet_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "China"
+            ],
+            "partial": [
+              "Nepal"
+            ]
           }
         },
         {
@@ -3364,6 +4892,96 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/western-palearctic/perch_v2_western-palearctic_labels.txt",
             "filename": "perch_v2_western-palearctic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Albania",
+              "Algeria",
+              "Andorra",
+              "Armenia",
+              "Austria",
+              "Azerbaijan",
+              "Bahrain",
+              "Belarus",
+              "Belgium",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Chad",
+              "Croatia",
+              "Cyprus",
+              "Czechia",
+              "Denmark",
+              "Egypt",
+              "Eritrea",
+              "Estonia",
+              "Faroe Islands",
+              "Finland",
+              "France",
+              "Georgia",
+              "Germany",
+              "Greece",
+              "Guernsey",
+              "Hungary",
+              "Iran",
+              "Iraq",
+              "Ireland",
+              "Isle of Man",
+              "Israel",
+              "Italy",
+              "Jersey",
+              "Jordan",
+              "Kosovo",
+              "Kuwait",
+              "Latvia",
+              "Lebanon",
+              "Libya",
+              "Liechtenstein",
+              "Lithuania",
+              "Luxembourg",
+              "Malta",
+              "Mauritania",
+              "Moldova",
+              "Monaco",
+              "Montenegro",
+              "Morocco",
+              "Netherlands",
+              "Niger",
+              "North Macedonia",
+              "Northern Cyprus",
+              "Norway",
+              "Oman",
+              "Palestine",
+              "Poland",
+              "Portugal",
+              "Qatar",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Saudi Arabia",
+              "Slovakia",
+              "Slovenia",
+              "Spain",
+              "Sudan",
+              "Sweden",
+              "Switzerland",
+              "Syria",
+              "Tunisia",
+              "Turkey",
+              "Ukraine",
+              "United Arab Emirates",
+              "United Kingdom",
+              "Vatican",
+              "Western Sahara",
+              "Yemen"
+            ],
+            "partial": [
+              "Djibouti",
+              "Ethiopia",
+              "Mali",
+              "Russia",
+              "Turkmenistan"
+            ]
           }
         },
         {
@@ -3383,6 +5001,96 @@
           "labels": {
             "url": "https://huggingface.co/tphakala/Perch-v2-Models/resolve/main/regional/western-palearctic/perch_v2_western-palearctic_labels.txt",
             "filename": "perch_v2_western-palearctic_labels.txt"
+          },
+          "countries": {
+            "core": [
+              "Aland",
+              "Albania",
+              "Algeria",
+              "Andorra",
+              "Armenia",
+              "Austria",
+              "Azerbaijan",
+              "Bahrain",
+              "Belarus",
+              "Belgium",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Chad",
+              "Croatia",
+              "Cyprus",
+              "Czechia",
+              "Denmark",
+              "Egypt",
+              "Eritrea",
+              "Estonia",
+              "Faroe Islands",
+              "Finland",
+              "France",
+              "Georgia",
+              "Germany",
+              "Greece",
+              "Guernsey",
+              "Hungary",
+              "Iran",
+              "Iraq",
+              "Ireland",
+              "Isle of Man",
+              "Israel",
+              "Italy",
+              "Jersey",
+              "Jordan",
+              "Kosovo",
+              "Kuwait",
+              "Latvia",
+              "Lebanon",
+              "Libya",
+              "Liechtenstein",
+              "Lithuania",
+              "Luxembourg",
+              "Malta",
+              "Mauritania",
+              "Moldova",
+              "Monaco",
+              "Montenegro",
+              "Morocco",
+              "Netherlands",
+              "Niger",
+              "North Macedonia",
+              "Northern Cyprus",
+              "Norway",
+              "Oman",
+              "Palestine",
+              "Poland",
+              "Portugal",
+              "Qatar",
+              "Republic of Serbia",
+              "Romania",
+              "San Marino",
+              "Saudi Arabia",
+              "Slovakia",
+              "Slovenia",
+              "Spain",
+              "Sudan",
+              "Sweden",
+              "Switzerland",
+              "Syria",
+              "Tunisia",
+              "Turkey",
+              "Ukraine",
+              "United Arab Emirates",
+              "United Kingdom",
+              "Vatican",
+              "Western Sahara",
+              "Yemen"
+            ],
+            "partial": [
+              "Djibouti",
+              "Ethiopia",
+              "Mali",
+              "Russia",
+              "Turkmenistan"
+            ]
           }
         }
       ],

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -233,6 +233,15 @@ pub enum ModelsAction {
         /// Model ID from the registry.
         id: String,
     },
+    /// Show a model's full manifest as JSON (region-aware model catalogue).
+    ///
+    /// Best with `--output-mode json`: emits every region and variant with
+    /// class counts, download sizes, resolved URLs, and per-region country
+    /// coverage. The human form is a short summary.
+    Manifest {
+        /// Model ID from the registry.
+        id: String,
+    },
 }
 
 /// Arguments for the analyze command.

--- a/src/gen_registry.rs
+++ b/src/gen_registry.rs
@@ -9,7 +9,9 @@
 //! guards against drift are hermetic and need no network.
 
 use crate::error::{Error, Result};
-use crate::registry::types::{FileInfo, LicenseInfo, ModelEntry, ModelVariant, Registry};
+use crate::registry::types::{
+    Countries, FileInfo, LicenseInfo, ModelEntry, ModelVariant, Registry,
+};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -66,6 +68,10 @@ struct RegionMetadata {
     /// Class count, where the manifest entry itself does not carry one.
     #[serde(default)]
     classes: Option<usize>,
+    /// Countries this region covers, carried through verbatim to the variant so
+    /// a consumer can offer a country-name search over the region list.
+    #[serde(default)]
+    countries: Option<Countries>,
 }
 
 /// Curation entry from `registry-sources.toml`.
@@ -249,6 +255,7 @@ fn build_entry(root: &Path, source: &SourceModel) -> Result<ModelEntry> {
                 sha256: None,
                 size_bytes: None,
             },
+            countries: region_meta.and_then(|m| m.countries.clone()),
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1616,6 +1616,11 @@ fn handle_models_command(
                         is_default,
                         path: Some(model.path.clone()),
                         labels_path: Some(model.labels.clone()),
+                        registry_id: model.registry_id.clone(),
+                        installed_version: model.installed_version.clone(),
+                        installed_build: model.installed_build,
+                        region: model.region.clone(),
+                        variant: model.variant.clone(),
                     }
                 })
                 .collect();
@@ -1841,6 +1846,10 @@ fn handle_models_command(
         ModelsAction::Regions { id } => {
             let registry = registry::load_registry()?;
             registry::show_regions(&registry, &id)
+        }
+        ModelsAction::Manifest { id } => {
+            let registry = registry::load_registry()?;
+            registry::show_manifest(&registry, &id, output_mode)
         }
     }
 }
@@ -2248,6 +2257,17 @@ fn handle_models_install(
     let model_path = installed.model.clone();
     let labels_path = installed.labels.clone();
 
+    // Captured before the config closure below moves `installed.provenance` and
+    // consumes `installed`. `selection_reason` comes from `choice`, which
+    // records why the variant was picked; a legacy single-file install has no
+    // `choice` and no provenance, so all three stay `None`.
+    let resolved_region = installed.provenance.as_ref().and_then(|p| p.region.clone());
+    let resolved_variant = installed
+        .provenance
+        .as_ref()
+        .and_then(|p| p.variant.clone());
+    let selection_reason = choice.as_ref().map(|c| c.reason.slug().to_string());
+
     // A regional install occupies its own key, so a global and a regional model
     // coexist and both stay selectable with -m. Derived from the provenance,
     // never from user input.
@@ -2317,6 +2337,9 @@ fn handle_models_install(
             set_as_default: should_set_default,
             model_path,
             labels_path,
+            region: resolved_region,
+            variant: resolved_variant,
+            selection_reason,
         };
         emit_json_result(&payload);
     } else {

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -90,6 +90,8 @@ pub enum ResultType {
     ModelRemoved,
     /// Model installed.
     ModelInstalled,
+    /// Documented projection of a registry model's manifest.
+    ModelManifest,
 }
 
 /// Error severity level.
@@ -422,6 +424,24 @@ pub struct ModelEntry {
     /// Path to the labels file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels_path: Option<PathBuf>,
+    /// Registry id these files were installed from.
+    ///
+    /// `None` for a model added with `models add`, which has no registry
+    /// provenance, and for anything installed before provenance was recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_id: Option<String>,
+    /// Exact upstream version installed, for upgrade detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed_version: Option<String>,
+    /// Our conversion revision installed, for upgrade detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed_build: Option<u32>,
+    /// Region slug for a regional install.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Variant id installed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
 }
 
 /// Payload for model info result.
@@ -652,6 +672,101 @@ pub struct ModelInstalledPayload {
     pub model_path: PathBuf,
     /// Path to the installed labels file.
     pub labels_path: PathBuf,
+    /// Resolved region slug, `None` for a global or legacy install.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Resolved variant id, `None` for a single-file legacy model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    /// Stable slug for why this variant was picked (see `SelectionReason`).
+    ///
+    /// The human "Selected variant" line lives behind a `!is_structured()`
+    /// guard, so this is the only way a structured consumer learns what
+    /// hardware selection chose after a download.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_reason: Option<String>,
+}
+
+/// Payload for `birda models manifest <id>`: a documented projection of a
+/// registry model, not a verbatim `registry.json` dump.
+///
+/// The registry types omit fields as a version-negotiation guard (see
+/// `ModelEntry::is_variant_based`); serialising them directly would turn that
+/// internal mechanism into a public contract. This projection is built at
+/// runtime and carried in the output envelope, which a consumer feature-detects
+/// by field presence, so birda stays free to reshape its internals.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelManifestPayload {
+    /// Result type discriminator.
+    pub result_type: ResultType,
+    /// The projected manifest.
+    pub manifest: ModelManifest,
+}
+
+/// Projected manifest for one model family.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelManifest {
+    /// Registry id.
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Upstream version string.
+    pub version: String,
+    /// Our conversion revision of those weights.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build: Option<u32>,
+    /// Model type identifier.
+    pub model_type: String,
+    /// Full licence record, including attribution and share-alike obligations.
+    pub license: crate::registry::LicenseInfo,
+    /// Variant id installed when no signal identifies a better one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_variant: Option<String>,
+    /// Hardware key to variant id, as published in the manifest.
+    ///
+    /// A consumer need not evaluate these keys against the host: `models
+    /// install` echoes the resolved choice. They are exposed for completeness.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub selection: std::collections::BTreeMap<String, String>,
+    /// Every downloadable region and variant combination.
+    ///
+    /// A legacy single-file model is projected as one synthetic `global`
+    /// variant so a consumer sees one uniform shape across old and new models.
+    pub variants: Vec<ManifestVariant>,
+}
+
+/// One projected variant: registry fields plus resolved URLs and countries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestVariant {
+    /// Publisher's variant identifier (`global` for a legacy single-file model).
+    pub id: String,
+    /// Region slug, or `None` for the global model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Human-readable region name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region_name: Option<String>,
+    /// Continental group slug used to organise the region listing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    /// Human-readable continental group name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_name: Option<String>,
+    /// Display order of the continental group.
+    pub group_order: u32,
+    /// Number of classes this variant scores, when the publisher states it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classes: Option<usize>,
+    /// Model file size in bytes, when the publisher states it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    /// `HF_ENDPOINT`-resolved URL of the model file.
+    pub model_url: String,
+    /// `HF_ENDPOINT`-resolved URL of the labels file.
+    pub labels_url: String,
+    /// Countries this region covers, for a country-name search over the list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub countries: Option<crate::registry::Countries>,
 }
 
 /// Payload for species list result.
@@ -1226,12 +1341,18 @@ mod tests {
 
     #[test]
     fn test_model_installed_payload() {
+        // Legacy single-file install: region/variant/selection_reason are None
+        // and, being skip_serializing_if, must not appear in the wire form. A
+        // consumer pinned to an older birda sees byte-identical output.
         let payload = ModelInstalledPayload {
             result_type: ResultType::ModelInstalled,
             id: "birdnet-v24".to_string(),
             set_as_default: true,
             model_path: PathBuf::from("/models/birdnet.onnx"),
             labels_path: PathBuf::from("/models/labels.txt"),
+            region: None,
+            variant: None,
+            selection_reason: None,
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
@@ -1243,5 +1364,27 @@ mod tests {
             "labels_path": "/models/labels.txt"
         });
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_installed_payload_echoes_resolved_variant() {
+        // A regional variant install must report what selection resolved, so a
+        // structured consumer learns region/variant/reason without parsing the
+        // human "Selected variant" line, which a structured run never prints.
+        let payload = ModelInstalledPayload {
+            result_type: ResultType::ModelInstalled,
+            id: "birdnet-v30-nordic".to_string(),
+            set_as_default: false,
+            model_path: PathBuf::from("/models/nordic.onnx"),
+            labels_path: PathBuf::from("/models/nordic.txt"),
+            region: Some("nordic".to_string()),
+            variant: Some("fp16".to_string()),
+            selection_reason: Some("detected_library".to_string()),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(actual["region"], "nordic");
+        assert_eq!(actual["variant"], "fp16");
+        assert_eq!(actual["selection_reason"], "detected_library");
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -21,11 +21,11 @@ pub use json_envelope::{
     ClipExtractionPayload, ConfigPathPayload, ConfigPayload, DetectionInfo, DetectionsPayload,
     DownloadProgress, ErrorPayload, ErrorSeverity, EventType, ExecutionProviderInfo,
     FileCompletedPayload, FileErrorInfo, FileProgress, FileStartedPayload, FileStatus,
-    GeomodelInfo, JsonEnvelope, ModelCheckEntry, ModelCheckPayload, ModelDetails, ModelEntry,
-    ModelInfoPayload, ModelInstalledPayload, ModelListPayload, ModelRemovedPayload,
-    PipelineCompletedPayload, PipelineStartedPayload, PipelineStatus, ProgressPayload,
-    ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry,
-    SpeciesListPayload, VersionPayload,
+    GeomodelInfo, JsonEnvelope, ManifestVariant, ModelCheckEntry, ModelCheckPayload, ModelDetails,
+    ModelEntry, ModelInfoPayload, ModelInstalledPayload, ModelListPayload, ModelManifest,
+    ModelManifestPayload, ModelRemovedPayload, PipelineCompletedPayload, PipelineStartedPayload,
+    PipelineStatus, ProgressPayload, ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType,
+    SPEC_VERSION, SpeciesEntry, SpeciesListPayload, VersionPayload,
 };
 pub use kaleidoscope::KaleidoscopeWriter;
 pub use parquet::{ParquetWriter, combine_parquet_files};

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -14,7 +14,7 @@ pub use cleanup::{orphaned_files, remove_orphans};
 pub use installer::{
     GEOMODEL_INSTALL_ID, InstallProvenance, InstalledRangeFilter, download_file,
     find_obsolete_files, find_stale_part_files, geomodel_paths, install_model,
-    install_range_filter, install_variant, models_dir,
+    install_range_filter, install_variant, models_dir, resolve_url,
 };
 pub use license::{LicensedAsset, prompt_license_acceptance};
 pub use loader::{find_model, load_registry};
@@ -24,8 +24,8 @@ pub use loader::{find_model, load_registry};
 // how a variant is chosen, not part of the gallery's surface.
 pub use selection::{SystemProbe, select_variant};
 pub use types::{
-    FileInfo, LabelsInfo, LanguageVariant, LicenseInfo, ModelEntry, ModelFiles, ModelVariant,
-    RangeFilterAsset, Registry,
+    Countries, FileInfo, LabelsInfo, LanguageVariant, LicenseInfo, ModelEntry, ModelFiles,
+    ModelVariant, RangeFilterAsset, Registry,
 };
 
 use crate::error::{Error, Result};
@@ -329,6 +329,181 @@ pub fn show_info(registry: &Registry, id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Variant id used for the single synthetic variant of a legacy single-file
+/// model, which has no publisher variant id of its own.
+const LEGACY_VARIANT_ID: &str = "global";
+
+/// Emit the documented manifest projection for a model (`models manifest <id>`).
+///
+/// This is the machine-readable catalogue a consumer builds a region-aware
+/// model gallery on: every region and variant, each with its class count,
+/// download size, resolved model and labels URLs, and the countries the region
+/// covers. It is a deliberate projection, never a dump of `registry.json`,
+/// which uses field omission as a downgrade guard (see
+/// [`ModelEntry::is_variant_based`]) and must not become a public contract.
+///
+/// The human rendering is a short summary; the value here is the JSON.
+pub fn show_manifest(
+    registry: &Registry,
+    id: &str,
+    output_mode: crate::config::OutputMode,
+) -> Result<()> {
+    let model = find_model(registry, id)
+        .ok_or_else(|| Error::ModelNotFoundInRegistry { id: id.to_string() })?;
+
+    let manifest = project_manifest(model);
+
+    if output_mode.is_structured() {
+        use crate::output::{ModelManifestPayload, ResultType, emit_json_result};
+        let payload = ModelManifestPayload {
+            result_type: ResultType::ModelManifest,
+            manifest,
+        };
+        emit_json_result(&payload);
+        return Ok(());
+    }
+
+    print_manifest_human(&manifest);
+    Ok(())
+}
+
+/// Build the projection for one registry entry.
+///
+/// A variant-based entry projects every region and variant combination (unlike
+/// [`ModelEntry::regions`], which deduplicates to one tile per region). A legacy
+/// single-file entry has no variants, so it is projected as one synthetic
+/// `global` variant from its `files`, giving a consumer one uniform shape across
+/// old and new models.
+fn project_manifest(model: &ModelEntry) -> crate::output::ModelManifest {
+    let variants = if model.is_variant_based() {
+        model.variants.iter().map(project_variant).collect()
+    } else {
+        legacy_variant(model).into_iter().collect()
+    };
+
+    crate::output::ModelManifest {
+        id: model.id.clone(),
+        name: model.name.clone(),
+        version: model.version.clone(),
+        build: model.build,
+        model_type: model.model_type.clone(),
+        license: model.license.clone(),
+        default_variant: model.default_variant.clone(),
+        selection: model.selection.clone(),
+        variants,
+    }
+}
+
+/// Project one variant, resolving both URLs through `HF_ENDPOINT` once here so a
+/// consumer never reimplements mirror rewriting.
+///
+/// `ModelVariant` is destructured exhaustively on purpose: a field added to the
+/// registry type then fails to compile here until someone decides whether the
+/// projection should carry it, rather than silently dropping it from the public
+/// contract.
+fn project_variant(variant: &ModelVariant) -> crate::output::ManifestVariant {
+    let ModelVariant {
+        id,
+        region,
+        region_name,
+        group,
+        group_name,
+        group_order,
+        classes,
+        model,
+        labels,
+        countries,
+    } = variant;
+
+    crate::output::ManifestVariant {
+        id: id.clone(),
+        region: region.clone(),
+        region_name: region_name.clone(),
+        group: group.clone(),
+        group_name: group_name.clone(),
+        group_order: *group_order,
+        classes: *classes,
+        size_bytes: model.size_bytes,
+        model_url: resolve_url(&model.url),
+        labels_url: resolve_url(&labels.url),
+        countries: countries.clone(),
+    }
+}
+
+/// Synthesize a single `global` variant for a legacy single-file model.
+///
+/// A legacy entry carries `files` (one model file plus a per-language labels
+/// set), not `variants`. It projects to one variant so a consumer sees the same
+/// shape as a variant-based model; the labels URL is the default-language file,
+/// and there is no region, so no countries and no class count.
+fn legacy_variant(model: &ModelEntry) -> Option<crate::output::ManifestVariant> {
+    let files = model.files.as_ref()?;
+    let labels_url = files
+        .labels
+        .languages
+        .iter()
+        .find(|l| l.code == files.labels.default_language)
+        .or_else(|| files.labels.languages.first())
+        .map_or_else(String::new, |l| resolve_url(&l.url));
+
+    Some(crate::output::ManifestVariant {
+        id: LEGACY_VARIANT_ID.to_string(),
+        region: None,
+        region_name: None,
+        group: None,
+        group_name: None,
+        group_order: 0,
+        classes: None,
+        size_bytes: files.model.size_bytes,
+        model_url: resolve_url(&files.model.url),
+        labels_url,
+        countries: None,
+    })
+}
+
+/// Short human summary of a projected manifest, for parity with [`show_info`].
+///
+/// The full per-region detail is intentionally left to the JSON form; dumping
+/// 80 variants as text would bury the summary a person actually wants.
+fn print_manifest_human(manifest: &crate::output::ModelManifest) {
+    println!("Model: {}", manifest.name);
+    println!("ID: {}", manifest.id);
+    if let Some(build) = manifest.build {
+        println!("Version: {} (build {build})", manifest.version);
+    } else {
+        println!("Version: {}", manifest.version);
+    }
+    println!("Type: {}", manifest.model_type);
+    println!("License: {}", license_line(&manifest.license));
+    if let Some(default) = manifest.default_variant.as_deref() {
+        println!("Default variant: {default}");
+    }
+    println!();
+
+    let global: Vec<&str> = manifest
+        .variants
+        .iter()
+        .filter(|v| v.region.is_none())
+        .map(|v| v.id.as_str())
+        .collect();
+    if !global.is_empty() {
+        println!("Global variants: {}", global.join(", "));
+    }
+
+    let regions: std::collections::BTreeSet<&str> = manifest
+        .variants
+        .iter()
+        .filter_map(|v| v.region.as_deref())
+        .collect();
+    if !regions.is_empty() {
+        println!("Regions: {}", regions.len());
+    }
+
+    println!();
+    println!("Run with --output-mode json for the full machine-readable manifest,");
+    println!("including per-region country coverage and resolved download URLs.");
+}
+
 /// List the regional tiles a model publishes, grouped by continent.
 ///
 /// Regions are what a user picks; the variant is picked for them, so this lists
@@ -449,5 +624,157 @@ mod tests {
     #[test]
     fn test_license_line_adds_nothing_for_an_unrestricted_licence() {
         assert_eq!(license_line(&license(true, false)), "TEST-1.0");
+    }
+
+    fn projection_variant(id: &str, region: Option<&str>) -> ModelVariant {
+        ModelVariant {
+            id: id.to_string(),
+            region: region.map(str::to_string),
+            region_name: region.map(str::to_uppercase),
+            group: None,
+            group_name: None,
+            group_order: 0,
+            classes: Some(100),
+            model: FileInfo {
+                url: format!("https://huggingface.co/o/r/resolve/main/{id}.onnx"),
+                filename: format!("{id}.onnx"),
+                sha256: None,
+                size_bytes: Some(123),
+            },
+            labels: FileInfo {
+                url: "https://huggingface.co/o/r/resolve/main/labels.txt".to_string(),
+                filename: "labels.txt".to_string(),
+                sha256: None,
+                size_bytes: None,
+            },
+            countries: region.map(|_| Countries {
+                core: vec!["Brazil".to_string()],
+                partial: Vec::new(),
+            }),
+        }
+    }
+
+    fn projection_entry() -> ModelEntry {
+        ModelEntry {
+            id: "birdnet-v30".to_string(),
+            name: "BirdNET v3.0".to_string(),
+            description: "d".to_string(),
+            vendor: "v".to_string(),
+            version: "3.0".to_string(),
+            model_type: "birdnet-v30".to_string(),
+            license: license(false, true),
+            files: None,
+            build: Some(1),
+            default_variant: Some("fp32".to_string()),
+            selection: std::iter::once(("cuda".to_string(), "fp16".to_string())).collect(),
+            variants: vec![
+                projection_variant("fp32", None),
+                projection_variant("fp16", None),
+                projection_variant("fp32", Some("nordic")),
+                projection_variant("fp16", Some("nordic")),
+            ],
+            recommended: true,
+        }
+    }
+
+    fn legacy_projection_entry() -> ModelEntry {
+        ModelEntry {
+            id: "birdnet-v24".to_string(),
+            name: "BirdNET v2.4".to_string(),
+            description: "d".to_string(),
+            vendor: "v".to_string(),
+            version: "2.4".to_string(),
+            model_type: "birdnet-v24".to_string(),
+            license: license(false, true),
+            files: Some(ModelFiles {
+                model: FileInfo {
+                    url: "https://huggingface.co/o/r/resolve/main/birdnet.onnx".to_string(),
+                    filename: "birdnet.onnx".to_string(),
+                    sha256: None,
+                    size_bytes: Some(50),
+                },
+                labels: LabelsInfo {
+                    default_language: "en".to_string(),
+                    languages: vec![
+                        LanguageVariant {
+                            code: "fr".to_string(),
+                            name: "French".to_string(),
+                            url: "https://example.com/labels-fr.txt".to_string(),
+                            filename: "labels-fr.txt".to_string(),
+                        },
+                        LanguageVariant {
+                            code: "en".to_string(),
+                            name: "English".to_string(),
+                            url: "https://example.com/labels-en.txt".to_string(),
+                            filename: "labels-en.txt".to_string(),
+                        },
+                    ],
+                },
+                bsg_calibration: None,
+                bsg_migration: None,
+                bsg_distribution_maps: None,
+            }),
+            build: None,
+            default_variant: None,
+            selection: std::collections::BTreeMap::new(),
+            variants: Vec::new(),
+            recommended: false,
+        }
+    }
+
+    #[test]
+    fn test_project_manifest_keeps_every_region_variant_combination() {
+        // Unlike regions(), which lists one tile per region, the manifest keeps
+        // every combination so a consumer can enumerate every download.
+        let manifest = project_manifest(&projection_entry());
+        assert_eq!(manifest.variants.len(), 4);
+        assert_eq!(manifest.default_variant.as_deref(), Some("fp32"));
+        assert_eq!(
+            manifest.selection.get("cuda").map(String::as_str),
+            Some("fp16")
+        );
+        // A resolved URL is present; it is identity without a mirror, and the
+        // filename stem survives the rewrite either way.
+        assert!(manifest.variants[0].model_url.contains("fp32"));
+        assert!(manifest.variants[0].labels_url.contains("labels"));
+    }
+
+    #[test]
+    fn test_project_manifest_carries_countries_only_on_regional_variants() {
+        let manifest = project_manifest(&projection_entry());
+        let nordic = manifest
+            .variants
+            .iter()
+            .find(|v| v.region.as_deref() == Some("nordic"))
+            .unwrap();
+        assert_eq!(
+            nordic.countries.as_ref().unwrap().core,
+            vec!["Brazil".to_string()]
+        );
+        let global = manifest
+            .variants
+            .iter()
+            .find(|v| v.region.is_none())
+            .unwrap();
+        assert!(global.countries.is_none());
+    }
+
+    #[test]
+    fn test_project_manifest_synthesizes_one_global_variant_for_a_legacy_model() {
+        // birdnet-v24 has `files`, not `variants`; it must still project to one
+        // uniform variant so a consumer never branches on an empty list.
+        let manifest = project_manifest(&legacy_projection_entry());
+        assert_eq!(manifest.variants.len(), 1);
+        let only = &manifest.variants[0];
+        assert_eq!(only.id, LEGACY_VARIANT_ID);
+        assert!(only.region.is_none());
+        assert!(only.countries.is_none());
+        assert!(only.classes.is_none());
+        // The default-language labels file, not simply the first listed.
+        assert!(
+            only.labels_url.contains("labels-en"),
+            "should pick the default language, got: {}",
+            only.labels_url
+        );
     }
 }

--- a/src/registry/selection.rs
+++ b/src/registry/selection.rs
@@ -51,6 +51,22 @@ impl SelectionReason {
             Self::FamilyDefault => "default, supported on every backend",
         }
     }
+
+    /// Stable machine token for the selection reason, for structured consumers.
+    ///
+    /// [`describe`](Self::describe) returns a human sentence that can be
+    /// reworded at will; this is a value a consumer switches on, so it must
+    /// stay stable across releases.
+    #[must_use]
+    pub const fn slug(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::ConfiguredDevice => "configured_device",
+            Self::DetectedLibrary => "detected_library",
+            Self::ArchDefault => "arch_default",
+            Self::FamilyDefault => "family_default",
+        }
+    }
 }
 
 /// The variant to download and why.
@@ -310,6 +326,7 @@ mod tests {
             classes: Some(10),
             model: file(&format!("{id}.onnx")),
             labels: file("labels.txt"),
+            countries: None,
         }
     }
 
@@ -613,5 +630,20 @@ mod tests {
         e.selection.clear();
         let err = select_variant(&e, None, None, InferenceDevice::Auto, &cpu_probe()).unwrap_err();
         assert!(err.to_string().contains("default"));
+    }
+
+    #[test]
+    fn test_selection_reason_slug_is_stable() {
+        // A structured consumer switches on these tokens, so they are part of
+        // the wire contract; describe() is prose and may be reworded, these
+        // must not be.
+        assert_eq!(SelectionReason::Explicit.slug(), "explicit");
+        assert_eq!(
+            SelectionReason::ConfiguredDevice.slug(),
+            "configured_device"
+        );
+        assert_eq!(SelectionReason::DetectedLibrary.slug(), "detected_library");
+        assert_eq!(SelectionReason::ArchDefault.slug(), "arch_default");
+        assert_eq!(SelectionReason::FamilyDefault.slug(), "family_default");
     }
 }

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -128,6 +128,13 @@ pub struct ModelVariant {
     pub model: FileInfo,
     /// Labels file matching this variant's class list.
     pub labels: FileInfo,
+    /// Countries this region covers, from the vendored region metadata.
+    ///
+    /// `None` on the global model, which has no region, and on any entry
+    /// generated before this field existed, so an older `registry.json` still
+    /// deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub countries: Option<Countries>,
 }
 
 impl ModelEntry {
@@ -248,6 +255,22 @@ pub struct FileInfo {
     pub size_bytes: Option<u64>,
 }
 
+/// Countries a regional model covers, split by how completely.
+///
+/// Vendored per region in `manifests/<family>.regions.json` as
+/// `countries.core` / `countries.partial`. Carried through unchanged so a
+/// consumer can offer a country-name search over the region list: region slugs
+/// like `nordic` are not what a user with Finnish recordings would type.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Countries {
+    /// Countries wholly inside this region's coverage.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub core: Vec<String>,
+    /// Countries only partially covered by this region.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub partial: Vec<String>,
+}
+
 /// Labels with language variants.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LabelsInfo {
@@ -295,6 +318,10 @@ mod tests {
                 sha256: Some("def".to_string()),
                 size_bytes: Some(1),
             },
+            countries: region.map(|_| Countries {
+                core: vec!["Testland".to_string()],
+                partial: Vec::new(),
+            }),
         }
     }
 
@@ -445,6 +472,49 @@ mod tests {
     #[test]
     fn test_variant_ids_for_an_unknown_region_is_empty() {
         assert!(variant_entry().variant_ids_for(Some("atlantis")).is_empty());
+    }
+
+    #[test]
+    fn test_regional_variant_carries_countries_through_find_variant() {
+        let entry = variant_entry();
+        let nordic = entry.find_variant(Some("nordic"), "fp32").unwrap();
+        assert_eq!(
+            nordic
+                .countries
+                .as_ref()
+                .expect("a regional variant carries countries")
+                .core,
+            vec!["Testland".to_string()]
+        );
+        // The global model is not a region, so it carries no countries.
+        assert!(
+            entry
+                .find_variant(None, "fp32")
+                .unwrap()
+                .countries
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_countries_are_omitted_from_json_when_absent() {
+        // skip_serializing_if keeps the global model's variant free of an empty
+        // countries object, so a consumer pinned to an older birda that never
+        // knew the field sees unchanged bytes.
+        let global = variant("fp32", None, 11560);
+        assert!(
+            !serde_json::to_string(&global)
+                .unwrap()
+                .contains("countries"),
+            "the global variant must not carry a countries key"
+        );
+        let nordic = variant("fp32", Some("nordic"), 422);
+        assert!(
+            serde_json::to_string(&nordic)
+                .unwrap()
+                .contains("countries"),
+            "a regional variant must carry its countries"
+        );
     }
 
     #[test]

--- a/tests/model_manifest.rs
+++ b/tests/model_manifest.rs
@@ -1,0 +1,185 @@
+//! `models manifest <id>` projection surface.
+//!
+//! These drive the real binary against the bundled registry, so they exercise
+//! clap wiring, the projection, and the JSON envelope together. Nothing is
+//! downloaded: every assertion is about the emitted manifest.
+// Integration test crate. `unwrap`, `expect` and `panic` are how a test reports
+// failure, not unhandled error paths, so rewriting them into propagated errors
+// would only hide which assertion fired. The crate-level deny still governs
+// everything birda ships.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// Isolation here rides on HOME / XDG_*, which `directories` honours on Linux and
+// macOS only. On Windows it resolves the config and data directories through
+// SHGetKnownFolderPath, which reads no environment variable, so the command
+// under test would read and rewrite the developer's real registry cache
+// (issue #328). The redirection only holds on Unix, so gate the suite to it;
+// CI runs on Linux, so coverage is unaffected.
+#![cfg(unix)]
+
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+
+/// `load_registry` can rewrite the cached registry, so keep commands bounded.
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run birda against an isolated HOME.
+///
+/// `load_registry` writes an updated registry cache into the user's data
+/// directory. Without this isolation the suite would read, and on some
+/// platforms rewrite, the developer's real config.
+fn run(extra_env: &[(&str, &str)], args: &[&str]) -> std::process::Output {
+    let home = tempfile::tempdir().expect("create temp home");
+    let mut cmd = cargo_bin_cmd!("birda");
+    cmd.env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join("config"))
+        .env("XDG_DATA_HOME", home.path().join("data"))
+        // `--output-mode` also reads BIRDA_OUTPUT_MODE; a developer with it
+        // exported would flip the human-output assertions below.
+        .env_remove("BIRDA_OUTPUT_MODE")
+        .env_remove("HF_ENDPOINT")
+        .timeout(COMMAND_TIMEOUT);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("birda should run")
+}
+
+/// Run in JSON mode and return the parsed result envelope's payload.
+fn manifest_payload(id: &str) -> Value {
+    let output = run(&[], &["--output-mode", "json", "models", "manifest", id]);
+    assert!(
+        output.status.success(),
+        "`models manifest {id}` failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8");
+    let envelope: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(envelope["event"], "result");
+    assert_eq!(envelope["payload"]["result_type"], "model_manifest");
+    envelope["payload"].clone()
+}
+
+#[test]
+fn test_manifest_projects_every_region_and_variant() {
+    let payload = manifest_payload("birdnet-v30");
+    let manifest = &payload["manifest"];
+    assert_eq!(manifest["id"], "birdnet-v30");
+    // The full catalogue: 2 global + 39 regions x 2 variants = 80.
+    let variants = manifest["variants"].as_array().expect("variants array");
+    assert_eq!(variants.len(), 80, "manifest keeps every combination");
+    // The licence record travels whole, so a consumer can show the share-alike
+    // obligation (this was the gap #300 closed for `list-available`).
+    assert!(manifest["license"]["share_alike"].is_boolean());
+    assert!(manifest["default_variant"].is_string());
+    assert!(manifest["selection"].is_object());
+}
+
+#[test]
+fn test_manifest_carries_country_coverage_for_a_region() {
+    let payload = manifest_payload("birdnet-v30");
+    let variants = payload["manifest"]["variants"].as_array().unwrap();
+    let amazonia = variants
+        .iter()
+        .find(|v| v["region"] == "amazonia")
+        .expect("amazonia is a published region");
+    let core = amazonia["countries"]["core"]
+        .as_array()
+        .expect("core country list");
+    assert!(
+        core.iter().any(|c| c == "Brazil"),
+        "amazonia core coverage should list Brazil, got: {core:?}"
+    );
+    assert!(amazonia["region_name"].is_string());
+}
+
+#[test]
+fn test_manifest_emits_resolved_download_urls() {
+    let payload = manifest_payload("birdnet-v30");
+    let variants = payload["manifest"]["variants"].as_array().unwrap();
+    let v = &variants[0];
+    assert!(
+        v["model_url"].as_str().unwrap().starts_with("https://"),
+        "model_url must be a resolved URL: {v}"
+    );
+    assert!(
+        v["labels_url"].as_str().unwrap().starts_with("https://"),
+        "labels_url must be a resolved URL: {v}"
+    );
+}
+
+#[test]
+fn test_manifest_applies_hf_endpoint_once_in_birda() {
+    // The GUI derives the coverage-map URL from the model URL and fetches
+    // through the same mirror, so the rewrite has to happen here, not there.
+    let output = run(
+        &[("HF_ENDPOINT", "https://hf-mirror.com")],
+        &["--output-mode", "json", "models", "manifest", "birdnet-v30"],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let envelope: Value = serde_json::from_str(&stdout).unwrap();
+    let v = &envelope["payload"]["manifest"]["variants"][0];
+    assert!(
+        v["model_url"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://hf-mirror.com/"),
+        "model_url should be rewritten to the mirror: {v}"
+    );
+    assert!(
+        v["labels_url"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://hf-mirror.com/"),
+        "labels_url should be rewritten to the mirror: {v}"
+    );
+}
+
+#[test]
+fn test_manifest_projects_a_legacy_model_as_one_global_variant() {
+    // birdnet-v24 has `files`, not `variants`. It must still project to one
+    // uniform variant so a consumer never branches on an empty list.
+    let payload = manifest_payload("birdnet-v24");
+    let variants = payload["manifest"]["variants"].as_array().unwrap();
+    assert_eq!(
+        variants.len(),
+        1,
+        "one synthetic variant for a legacy model"
+    );
+    let only = &variants[0];
+    assert_eq!(only["id"], "global");
+    assert!(only["region"].is_null(), "a legacy model has no region");
+    assert!(
+        only["countries"].is_null(),
+        "no region means no country coverage"
+    );
+    assert!(only["model_url"].as_str().unwrap().starts_with("https://"));
+}
+
+#[test]
+fn test_manifest_rejects_an_unknown_model() {
+    let output = run(&[], &["models", "manifest", "not-a-model"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("not-a-model"),
+        "the error should name the id the user typed"
+    );
+}
+
+#[test]
+fn test_manifest_human_form_is_a_short_summary() {
+    let output = run(&[], &["models", "manifest", "birdnet-v30"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Global variants:"), "got: {stdout}");
+    assert!(stdout.contains("Regions:"), "got: {stdout}");
+    assert!(
+        stdout.contains("--output-mode json"),
+        "should point at the machine-readable form: {stdout}"
+    );
+}

--- a/tests/registry_generation.rs
+++ b/tests/registry_generation.rs
@@ -121,6 +121,45 @@ fn test_every_regional_variant_has_display_metadata() {
 }
 
 #[test]
+fn test_every_regional_variant_carries_country_coverage() {
+    // The vendored region metadata declares core/partial countries, and the
+    // manifest projection exposes them as the search index for the region
+    // picker. If the generator drops them, that search has nothing to match.
+    for model in parsed().models.iter().filter(|m| m.is_variant_based()) {
+        for variant in model.variants.iter().filter(|v| v.region.is_some()) {
+            let countries = variant.countries.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "{} region {:?} lost its countries",
+                    model.id, variant.region
+                )
+            });
+            assert!(
+                !countries.core.is_empty(),
+                "{} region {:?} has empty core country coverage",
+                model.id,
+                variant.region
+            );
+        }
+    }
+}
+
+#[test]
+fn test_global_variants_carry_no_country_coverage() {
+    // The global model is not a region, so it must not gain a countries object;
+    // that is what keeps the field a reliable regional/global discriminator.
+    for model in parsed().models.iter().filter(|m| m.is_variant_based()) {
+        for variant in model.variants.iter().filter(|v| v.region.is_none()) {
+            assert!(
+                variant.countries.is_none(),
+                "{} global variant {} must not carry countries",
+                model.id,
+                variant.id
+            );
+        }
+    }
+}
+
+#[test]
 fn test_every_variant_entry_declares_a_default_variant_that_exists() {
     // Selection falls back to this, so an entry naming a variant it does not
     // publish would fail at install time on exactly the hosts with no better


### PR DESCRIPTION
Implements #336: emit the model manifest over JSON so a consumer can build a region-aware model gallery, and fill the two provenance gaps the issue called out.

## New command: `birda models manifest <id>`

A documented projection of a registry entry, deliberately not a dump of `registry.json` (which uses field omission as a downgrade guard and must not become a public contract). With `--output-mode json` it emits, per entry: `version`, `build`, `model_type`, the full `license` record, `default_variant`, `selection`, and `variants`. Per variant: `id`, `region`, `region_name`, `group`, `group_name`, `group_order`, `classes`, `size_bytes`, resolved `model_url` and `labels_url`, and `countries` for regional tiles.

- URLs are resolved through `HF_ENDPOINT` once here, so a mirror rewrite is not reimplemented against a mirror I cannot test. The per-region coverage map is derivable as `regional/<region>/coverage.png` beside the model.
- A legacy single-file model (`birdnet-v24`, `bsg-fi-v44`) projects as one synthetic `global` variant, so a consumer sees one uniform shape and never branches on an empty list. Nothing is dropped and no one is forced to re-download; custom classifiers keep working.
- `project_variant` destructures `ModelVariant` exhaustively, so a future field added to the registry type fails to compile until someone decides whether the projection should carry it.
- The human form is a short summary; the value is the JSON.

## countries passthrough

The vendored `manifests/*.regions.json` already carry `countries.core` / `countries.partial` for all 39 regions, but the data died in `gen_registry`. It now flows `ModelVariant` -> `registry.json` -> manifest. It is the search index for the picker: region slugs like `nordic` are not what someone with Finnish recordings would type. `registry.json` is regenerated and `registry_version` bumps 6 to 7.

## Install provenance

- `models list` now serializes `registry_id`, `installed_version`, `installed_build`, `region` and `variant`, so a consumer recovers what a model was installed from, and can detect a superseded build, without parsing the id string.
- `models install` now echoes the resolved `region`, `variant` and `selection_reason`, so a structured consumer learns what hardware selection picked (the human "Selected variant" line sits behind a non-structured guard).

## Compatibility

Every new field is optional and skip-serialized, or omitted when empty, so an older consumer sees byte-identical output and can feature-detect by field presence. `SPEC_VERSION` stays `1.1` (additive). The `registry.json` downgrade guard is untouched: an older birda that does not know `countries` still deserializes the new registry, since serde ignores unknown fields.

## Tests

- New integration suite `tests/model_manifest.rs` drives the real binary: projection shape, country coverage, resolved URLs, the `HF_ENDPOINT` rewrite, legacy to one `global` variant, unknown-id failure, and the human summary. It isolates `HOME`/`XDG_*` so it never reads or rewrites a developer's real config.
- Unit tests for the projection (every combination kept, countries only on regional variants, legacy synthesis using the default-language labels), the countries passthrough and serde omission, `SelectionReason::slug` stability, and the install-echo payload.
- `registry_generation` now guards that every regional variant carries non-empty `core` countries and no global variant carries any.

`docs/json-output.md` is updated with the new result type, a manifest example, and the provenance fields.
