### PR TITLE
fix: let `config set` repair a config with two independent faults (#305)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -458,7 +458,7 @@ pub struct AnalyzeArgs {
     //
     // The bound lives in `constants::day_of_year`. `parse_day_of_year` applies
     // it to this flag and to `BIRDA_DAY_OF_YEAR`, the same parser applies it
-    // through `config set`, and `validate_defaults` applies it to config.toml,
+    // through `config set`, and `collect_defaults_violations` applies it to config.toml,
     // which is the route that had no check at all before #312. The parser
     // replaced an inline `clap::value_parser!(u32).range(1..=366)`, whose bound
     // no other route could read.

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -64,7 +64,7 @@ pub fn parse_bounded_float(s: &str, min: f64, max: f64, name: &str) -> Result<f6
 /// Parse and validate a latitude in degrees.
 ///
 /// Reads `coordinates::LATITUDE_MIN`/`MAX`, the same pair
-/// `config::validate::validate_range_filter` and `Error::InvalidLatitude` read.
+/// `config::validate::collect_range_filter_violations` and `Error::InvalidLatitude` read.
 /// `test_parse_latitude_matches_the_config_file_rule` drives this and the file
 /// rule together and compares verdicts (#340).
 pub fn parse_latitude(s: &str) -> Result<f64, String> {
@@ -91,7 +91,7 @@ pub fn parse_longitude(s: &str) -> Result<f64, String> {
 /// Parse and validate segment overlap in seconds (finite and non-negative).
 ///
 /// The rule is deliberately identical to the config-file one in
-/// `validate_defaults`, wording included, because the two are the same setting
+/// `collect_defaults_violations`, wording included, because the two are the same setting
 /// reached by different routes: `--overlap` and `BIRDA_OVERLAP` both win over
 /// `defaults.overlap`, so a rule enforced on the file alone left the channels
 /// disagreeing. `overlap = -1` in config.toml was a hard error while
@@ -132,7 +132,7 @@ pub fn parse_overlap(s: &str) -> Result<f32, String> {
 /// `MAX_BATCH_SIZE`).
 ///
 /// The same range is applied to `defaults.batch_size` by
-/// `config::validate::validate_defaults`, and
+/// `config::validate::collect_defaults_violations`, and
 /// `test_parse_batch_size_matches_the_config_file_rule` drives both and
 /// compares their verdicts. Before #312 only this side carried the upper
 /// bound, so `--batch-size 100000` was refused while the same value in
@@ -162,14 +162,14 @@ pub fn parse_batch_size(s: &str) -> Result<usize, String> {
 
 /// Parse and validate the day of year used for BSG SDM adjustment (1-366).
 ///
-/// Shared with the config-file rule in `validate_defaults` for the reason
+/// Shared with the config-file rule in `collect_defaults_violations` for the reason
 /// `parse_overlap` documents: `--day-of-year` and `BIRDA_DAY_OF_YEAR` both win
 /// over `defaults.day_of_year`, so a bound enforced on one route left the
 /// routes disagreeing about one setting.
 ///
 /// This replaces an inline `clap::value_parser!(u32).range(1..=366)` on the
 /// argument. That bounded the flag, but the bound was a literal only clap could
-/// read, so neither `handle_config_set` nor `validate_defaults` could apply it.
+/// read, so neither `handle_config_set` nor `collect_defaults_violations` could apply it.
 pub fn parse_day_of_year(s: &str) -> Result<u32, String> {
     // Trimmed; see `parse_confidence`. This one backs `--day-of-year` and
     // `BIRDA_DAY_OF_YEAR`.
@@ -373,8 +373,8 @@ mod tests {
         //
         // This drives BOTH rules and compares their verdicts, rather than
         // asserting `parse_overlap` against a list of inputs a comment claims
-        // `validate_defaults` agrees on. The list version was the shape this
-        // test had first, and it did not work: giving `validate_defaults` an
+        // `collect_defaults_violations` agrees on. The list version was the shape this
+        // test had first, and it did not work: giving `collect_defaults_violations` an
         // upper bound the CLI does not have left every config test green, so
         // the guard the doc comments on both sides advertise was not a guard at
         // all. Comparing verdicts means the two cannot diverge on any input
@@ -499,7 +499,7 @@ mod tests {
         // above. Three routes reach `defaults.latitude`: the flag, `config set`
         // (which routes through this parser), and a hand-edited config.toml.
         // Before this the bound was written out in `cli::validators`, in
-        // `config::validate::validate_range_filter` and a third time in the
+        // `config::validate::collect_range_filter_violations` and a third time in the
         // `Error::InvalidLatitude` message, with nothing keeping the three
         // equal. They agreed, so there was no live defect; this is what keeps
         // that true.
@@ -647,7 +647,7 @@ mod tests {
     #[test]
     fn test_parse_day_of_year_matches_the_config_file_rule() {
         // The other half of #312. `--day-of-year` carried an inline
-        // `range(1..=366)`, `validate_defaults` did not look at the field at
+        // `range(1..=366)`, `collect_defaults_violations` did not look at the field at
         // all, and `config set` had no arm for the key, so config.toml was the
         // only route that could set `defaults.day_of_year` and the only one
         // with no check. The flag and `BIRDA_DAY_OF_YEAR` could set the value

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -108,11 +108,25 @@ fn write_error(path: &Path, source: std::io::Error) -> Error {
 /// This is only the validated atomic-write primitive, not the serialisation of a
 /// PAIR of writes. That is [`update_config`]'s job: it holds a lock across the
 /// whole load-mutate-save, so two concurrent writers cannot both load the same
-/// base and lose one of the two edits (#313). Reach for `update_config`, not
+/// base and lose one of the two edits (#313). Reach for `update_config` (or
+/// [`update_config_repairing`], the `config set` variant that may persist a
+/// still-invalid config to make forward progress on repairing it, #305), not
 /// `save_config` directly, for any read-modify-write of the live config.
 pub fn save_config(config: &Config, path: &Path) -> Result<()> {
     super::validate_config(config)?;
+    write_config_to_disk(config, path)
+}
 
+/// Serialise `config` and write it to `path` atomically, WITHOUT validating it.
+///
+/// Split out of [`save_config`] so the `config set` repair path can reuse the
+/// exact symlink resolution, serialisation and atomic write while making its own
+/// decision about validity (#305). Deliberately private: skipping validation is
+/// reserved for the two callers in this module. `save_config` reaches it only
+/// after validating, and [`update_config_repairing_at`] only after confirming
+/// the edit adds no new fault. Every other writer goes through `save_config`, so
+/// the "no writer persists an invalid config" invariant still holds for them.
+fn write_config_to_disk(config: &Config, path: &Path) -> Result<()> {
     // Rename replaces the name it is given, where a write follows it. A user
     // whose config.toml is a symlink into a dotfiles repository would have the
     // link replaced by a regular file and their real config left stale, so the
@@ -242,6 +256,75 @@ fn update_config_at<T>(
     })
 }
 
+/// Load-mutate-save for `config set`, permitting forward progress on a config
+/// that is already invalid.
+///
+/// Like [`update_config`], but where that (through [`save_config`]) refuses to
+/// write unless the whole config is valid, this one writes as long as the edit
+/// introduces no NEW rule failure: it may leave faults that were already present
+/// in place, but must not add one to a field that was clean (#305). It is the
+/// only writer allowed to persist an invalid config, and only when it is
+/// strictly no worse than the one it loaded, so the "no writer persists an
+/// invalid config" invariant still holds for every other caller.
+///
+/// Returns the mutate closure's value, the saved config, the path written, and a
+/// human-readable list of the rule failures that still stand after the edit, so
+/// the caller can tell the user what is left to fix.
+pub fn update_config_repairing<T>(
+    mutate: impl FnOnce(&mut Config) -> Result<T>,
+) -> Result<(T, Config, PathBuf, Vec<String>)> {
+    let path = super::config_file_path()?;
+    let (out, config, remaining) = update_config_repairing_at(&path, mutate)?;
+    Ok((out, config, path, remaining))
+}
+
+/// [`update_config_repairing`] against an explicit `path`.
+///
+/// Split out so a test can drive the real load-lock-mutate-save against a
+/// temporary file rather than the user's platform config path.
+fn update_config_repairing_at<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut Config) -> Result<T>,
+) -> Result<(T, Config, Vec<String>)> {
+    use std::collections::HashSet;
+
+    crate::locking::with_config_lock(path, || {
+        let mut config = load_config_file(path)?;
+
+        // The fields already in breach before the edit. A single `config set`
+        // changes exactly one field, so at most one field's verdict can flip;
+        // anything in `after` but not here was put there by this edit.
+        let before: HashSet<super::validate::ViolationField> =
+            super::validate::collect_violations(&config)
+                .into_iter()
+                .map(|violation| violation.field)
+                .collect();
+
+        let out = mutate(&mut config)?;
+
+        let mut after = super::validate::collect_violations(&config);
+        if let Some(index) = after
+            .iter()
+            .position(|violation| !before.contains(&violation.field))
+        {
+            // The edit added a fault to a field that was clean (which, on a
+            // valid config, is any fault at all): refuse it and report it
+            // exactly as `save_config` would have, leaving the file untouched.
+            return Err(after.swap_remove(index).error);
+        }
+
+        write_config_to_disk(&config, path)?;
+
+        // Whatever still stands: faults this edit deliberately left in place,
+        // for the caller to surface as "still to fix".
+        let remaining = after
+            .into_iter()
+            .map(|violation| violation.error.to_string())
+            .collect();
+        Ok((out, config, remaining))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,7 +375,7 @@ min_confidence = 0.25
 
     /// A config that `config set` would reject, for the save-path tests.
     ///
-    /// `min_confidence` is used because `validate_defaults` checks it first, so
+    /// `min_confidence` is used because `collect_defaults_violations` checks it first, so
     /// these assert the whole chain runs and not just the range-filter half.
     fn invalid_config() -> Config {
         let mut config = Config::default();
@@ -774,5 +857,93 @@ min_confidence = 0.25
             "the overlap edit was lost to an interleaved save: {}",
             loaded.defaults.overlap
         );
+    }
+
+    /// The #305 core at unit level: repairing one of two standing faults writes,
+    /// leaves the untouched fault in place, and reports it in `remaining`.
+    #[test]
+    fn test_update_config_repairing_at_repairs_one_of_two_faults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[defaults]\nlatitude = 200.0\nrange_threshold = nan\n",
+        )
+        .unwrap();
+
+        let ((), config, remaining) = update_config_repairing_at(&path, |config| {
+            config.defaults.latitude = Some(60.17);
+            Ok(())
+        })
+        .unwrap();
+
+        assert!((config.defaults.latitude.unwrap() - 60.17).abs() < f64::EPSILON);
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only the untouched threshold fault should remain: {remaining:?}"
+        );
+        assert!(
+            remaining[0].contains("range threshold"),
+            "the standing fault should be the range threshold: {remaining:?}"
+        );
+
+        // The edit reached disk, and the standing fault did not block it.
+        let loaded = load_config_file(&path).unwrap();
+        assert!((loaded.defaults.latitude.unwrap() - 60.17).abs() < f64::EPSILON);
+    }
+
+    /// An edit that would newly break a clean field is refused, and the file is
+    /// left byte-for-byte as it was. `defaults.model` is the reachable case (no
+    /// `parse_*` bound), so an already-broken config plus a missing model is a
+    /// second, distinct fault.
+    #[test]
+    fn test_update_config_repairing_at_refuses_a_new_fault_and_leaves_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let seeded = "[defaults]\nlatitude = 200.0\n";
+        std::fs::write(&path, seeded).unwrap();
+
+        let err = update_config_repairing_at(&path, |config| {
+            config.defaults.model = Some("no-such-model".to_string());
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(
+            matches!(err, crate::error::Error::ModelNotFound { .. }),
+            "the newly-introduced fault should be reported, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            seeded,
+            "a refused repair must leave the file byte-for-byte untouched"
+        );
+    }
+
+    /// An edit to an unrelated, valid field is allowed even though the fault
+    /// count does not drop, because it introduces no NEW faulty field. This is
+    /// the case a strict "the count must decrease" rule would wrongly refuse.
+    #[test]
+    fn test_update_config_repairing_at_allows_an_unrelated_edit_on_a_broken_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[defaults]\nrange_threshold = nan\n").unwrap();
+
+        let ((), config, remaining) = update_config_repairing_at(&path, |config| {
+            config.defaults.overlap = 0.5;
+            Ok(())
+        })
+        .unwrap();
+
+        assert!((config.defaults.overlap - 0.5).abs() < f32::EPSILON);
+        assert_eq!(
+            remaining.len(),
+            1,
+            "the threshold fault still stands: {remaining:?}"
+        );
+
+        let loaded = load_config_file(&path).unwrap();
+        assert!((loaded.defaults.overlap - 0.5).abs() < f32::EPSILON);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,9 @@ mod types;
 mod validate;
 
 pub use bat::{BatConfig, BatRegion};
-pub use file::{load_config_file, load_default_config, save_config, update_config};
+pub use file::{
+    load_config_file, load_default_config, save_config, update_config, update_config_repairing,
+};
 pub use geomodel::{GeomodelRequest, GeomodelResolution, resolve_geomodel};
 pub use paths::{config_dir, config_file_path, tensorrt_cache_dir};
 pub use types::{

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -7,15 +7,79 @@ use crate::constants::{
 use crate::error::{Error, Result};
 
 /// Validate the entire configuration.
+///
+/// Fail-fast: returns the first rule failure, exactly as the individual rules
+/// below produce it, so every writer that persists a config through
+/// [`crate::config::save_config`] still refuses to write an invalid one. For
+/// every failure at once (and the one writer allowed to persist a config that
+/// is invalid but no worse than it already was, #305) see [`collect_violations`].
 pub fn validate_config(config: &Config) -> Result<()> {
-    validate_defaults(config)?;
-    validate_range_filter(config)?;
-    Ok(())
+    collect_violations(config)
+        .into_iter()
+        .next()
+        .map_or(Ok(()), |violation| Err(violation.error))
+}
+
+/// A single configuration rule failure.
+///
+/// [`collect_violations`] returns every one at once rather than stopping at the
+/// first. That is what lets `config set` tell "this edit left the existing
+/// faults alone" apart from "this edit introduced a new one" (#305), and what
+/// lets a diagnostic list them all instead of one per run.
+pub struct Violation {
+    /// Which configuration field the failure concerns.
+    pub field: ViolationField,
+    /// The exact error the fail-fast path raises for this rule, so a caller can
+    /// surface the message the user has always seen.
+    pub error: Error,
+}
+
+/// The configuration field a [`Violation`] concerns.
+///
+/// Identity is by field, not by value: two different out-of-range latitudes are
+/// the same violation here. That is the granularity `config set` compares on
+/// when it decides whether an edit added a fault to a field that was previously
+/// clean. A value-level identity is neither needed (the `parse_*` validators
+/// reject a malformed new value before the write) nor available (`Error` embeds
+/// `std::io::Error`, which is not `PartialEq`).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum ViolationField {
+    /// `defaults.min_confidence`.
+    MinConfidence,
+    /// `defaults.overlap`.
+    Overlap,
+    /// `defaults.batch_size`.
+    BatchSize,
+    /// `defaults.day_of_year`.
+    DayOfYear,
+    /// `defaults.formats`.
+    Formats,
+    /// `defaults.csv_columns.include`.
+    CsvColumns,
+    /// `defaults.model`.
+    Model,
+    /// `defaults.latitude`.
+    Latitude,
+    /// `defaults.longitude`.
+    Longitude,
+    /// `defaults.range_threshold`.
+    RangeThreshold,
+}
+
+/// Collect every configuration rule failure rather than stopping at the first.
+///
+/// The rules are the ones [`validate_config`] enforces, in the same order, so
+/// the first element (if any) is exactly what the fail-fast path returns.
+pub fn collect_violations(config: &Config) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    collect_defaults_violations(config, &mut violations);
+    collect_range_filter_violations(config, &mut violations);
+    violations
 }
 
 /// Recovery advice for the two keys `birda config set` cannot reach.
 ///
-/// Every other rule in `validate_defaults` guards a key with a `config set`
+/// Every other rule in `collect_defaults_violations` guards a key with a `config set`
 /// arm, so the tool can repair it and the message can stay short. `formats` and
 /// `csv_columns` have no arm, and a bad value in either is refused by
 /// `save_config` as well, so `config set` on any OTHER key is refused too until
@@ -24,19 +88,22 @@ pub fn validate_config(config: &Config) -> Result<()> {
 const EDIT_THE_FILE: &str = "This key has no 'birda config set' arm, so edit config.toml directly; \
      'birda config path' prints where it is.";
 
-/// Validate default settings.
-fn validate_defaults(config: &Config) -> Result<()> {
+/// Collect `[defaults]` rule failures into `violations`. See [`collect_violations`].
+fn collect_defaults_violations(config: &Config, violations: &mut Vec<Violation>) {
     let defaults = &config.defaults;
 
     // Validate min_confidence range
     if !(confidence::MIN..=confidence::MAX).contains(&defaults.min_confidence) {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "min_confidence must be between {} and {}, got {}",
-                confidence::MIN,
-                confidence::MAX,
-                defaults.min_confidence
-            ),
+        violations.push(Violation {
+            field: ViolationField::MinConfidence,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "min_confidence must be between {} and {}, got {}",
+                    confidence::MIN,
+                    confidence::MAX,
+                    defaults.min_confidence
+                ),
+            },
         });
     }
 
@@ -44,7 +111,7 @@ fn validate_defaults(config: &Config) -> Result<()> {
     //
     // The `is_finite` half is what catches NaN, and NaN is the case that
     // matters: a bare `overlap < 0.0` is the hand-rolled comparison
-    // `validate_range_filter` warns against below, and `NaN < 0.0` is false, so
+    // `collect_range_filter_violations` warns against below, and `NaN < 0.0` is false, so
     // it was accepted. `overlap * sample_rate` is then cast to `usize`, and Rust
     // saturates that cast rather than trapping, so NaN became 0 and the setting
     // was silently ignored. That is the reported bug's signature exactly: a
@@ -70,11 +137,14 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // upper bound here, for instance, fails that test rather than silently
     // making config.toml stricter than the flag.
     if !defaults.overlap.is_finite() || defaults.overlap < 0.0 {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "overlap must be a finite non-negative number, got {}",
-                defaults.overlap
-            ),
+        violations.push(Violation {
+            field: ViolationField::Overlap,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "overlap must be a finite non-negative number, got {}",
+                    defaults.overlap
+                ),
+            },
         });
     }
 
@@ -105,10 +175,13 @@ fn validate_defaults(config: &Config) -> Result<()> {
     if let Some(batch_size) = defaults.batch_size
         && !(MIN_BATCH_SIZE..=MAX_BATCH_SIZE).contains(&batch_size)
     {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}, got {batch_size}"
-            ),
+        violations.push(Violation {
+            field: ViolationField::BatchSize,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "batch_size must be between {MIN_BATCH_SIZE} and {MAX_BATCH_SIZE}, got {batch_size}"
+                ),
+            },
         });
     }
 
@@ -123,12 +196,15 @@ fn validate_defaults(config: &Config) -> Result<()> {
     if let Some(day) = defaults.day_of_year
         && !(day_of_year::MIN..=day_of_year::MAX).contains(&day)
     {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "day_of_year must be between {} and {}, got {day}",
-                day_of_year::MIN,
-                day_of_year::MAX
-            ),
+        violations.push(Violation {
+            field: ViolationField::DayOfYear,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "day_of_year must be between {} and {}, got {day}",
+                    day_of_year::MIN,
+                    day_of_year::MAX
+                ),
+            },
         });
     }
 
@@ -171,11 +247,14 @@ fn validate_defaults(config: &Config) -> Result<()> {
     // have none, so a hand edit is the only way out and the message is the only
     // place to say so.
     if defaults.formats.is_empty() {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "defaults.formats must list at least one output format; with an empty list a \
-                 run writes no output at all\n\n{EDIT_THE_FILE}"
-            ),
+        violations.push(Violation {
+            field: ViolationField::Formats,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "defaults.formats must list at least one output format; with an empty list a \
+                     run writes no output at all\n\n{EDIT_THE_FILE}"
+                ),
+            },
         });
     }
 
@@ -195,12 +274,15 @@ fn validate_defaults(config: &Config) -> Result<()> {
         .iter()
         .find(|column| !csv_columns::RECOGNISED.contains(&column.as_str()))
     {
-        return Err(Error::ConfigValidation {
-            message: format!(
-                "defaults.csv_columns.include has an unknown column '{unknown}'; the accepted \
-                 columns are {}\n\n{EDIT_THE_FILE}",
-                csv_columns::RECOGNISED.join(", ")
-            ),
+        violations.push(Violation {
+            field: ViolationField::CsvColumns,
+            error: Error::ConfigValidation {
+                message: format!(
+                    "defaults.csv_columns.include has an unknown column '{unknown}'; the accepted \
+                     columns are {}\n\n{EDIT_THE_FILE}",
+                    csv_columns::RECOGNISED.join(", ")
+                ),
+            },
         });
     }
 
@@ -208,12 +290,13 @@ fn validate_defaults(config: &Config) -> Result<()> {
     if let Some(ref model_name) = defaults.model
         && !config.models.contains_key(model_name)
     {
-        return Err(Error::ModelNotFound {
-            name: model_name.clone(),
+        violations.push(Violation {
+            field: ViolationField::Model,
+            error: Error::ModelNotFound {
+                name: model_name.clone(),
+            },
         });
     }
-
-    Ok(())
 }
 
 /// Validate a model configuration and check files exist.
@@ -268,8 +351,21 @@ pub fn get_model<'a>(config: &'a Config, name: &str) -> Result<&'a ModelConfig> 
     })
 }
 
-/// Validate range filter configuration.
-pub fn validate_range_filter(config: &Config) -> Result<()> {
+/// Fail-fast view of just the range-filter rules, for the unit tests that
+/// exercise them in isolation. Not needed outside tests: production always goes
+/// through [`validate_config`], which covers every rule.
+#[cfg(test)]
+fn validate_range_filter(config: &Config) -> Result<()> {
+    let mut violations = Vec::new();
+    collect_range_filter_violations(config, &mut violations);
+    violations
+        .into_iter()
+        .next()
+        .map_or(Ok(()), |violation| Err(violation.error))
+}
+
+/// Collect range filter rule failures into `violations`. See [`collect_violations`].
+fn collect_range_filter_violations(config: &Config, violations: &mut Vec<Violation>) {
     // Both bounds read `constants::coordinates`, which `cli::validators` and the
     // `Error` message text also read (#340). Those three were the copies of the
     // numbers; the routes to the setting are a different set, being the flag
@@ -278,13 +374,19 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
     if let Some(lat) = config.defaults.latitude
         && !(coordinates::LATITUDE_MIN..=coordinates::LATITUDE_MAX).contains(&lat)
     {
-        return Err(Error::InvalidLatitude { value: lat });
+        violations.push(Violation {
+            field: ViolationField::Latitude,
+            error: Error::InvalidLatitude { value: lat },
+        });
     }
 
     if let Some(lon) = config.defaults.longitude
         && !(coordinates::LONGITUDE_MIN..=coordinates::LONGITUDE_MAX).contains(&lon)
     {
-        return Err(Error::InvalidLongitude { value: lon });
+        violations.push(Violation {
+            field: ViolationField::Longitude,
+            error: Error::InvalidLongitude { value: lon },
+        });
     }
 
     // `--range-threshold` is bounds-checked by `parse_confidence`, but nothing
@@ -299,14 +401,15 @@ pub fn validate_range_filter(config: &Config) -> Result<()> {
     // hand-rolled `threshold < 0.0` test would let NaN straight through.
     let threshold = config.defaults.range_threshold;
     if !(confidence::MIN..=confidence::MAX).contains(&threshold) {
-        return Err(Error::InvalidRangeThreshold { value: threshold });
+        violations.push(Violation {
+            field: ViolationField::RangeThreshold,
+            error: Error::InvalidRangeThreshold { value: threshold },
+        });
     }
 
     // The geomodel is resolved and acquired at analysis time rather than
     // validated here: it is a shared asset that birda can offer to download,
     // so a missing file is not a configuration error.
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -438,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_out_of_range_day_of_year() {
-        // The field `validate_defaults` did not look at at all (#312). 999 is
+        // The field `collect_defaults_violations` did not look at at all (#312). 999 is
         // the value from the issue; it reached the BSG SDM path and was
         // rejected there by birdnet-onnx, far from the config key that set it.
         let err = validate_config(&config_with_day_of_year(999)).unwrap_err();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -93,7 +93,7 @@ pub mod time {
 /// Three routes reach one setting: `--lat`/`--lon` and their `BIRDA_LATITUDE`/
 /// `BIRDA_LONGITUDE` variables, `birda config set defaults.latitude`, and a
 /// hand-edited config.toml. Before #340 each of `cli::validators`,
-/// `config::validate::validate_range_filter` and the `Error::InvalidLatitude`
+/// `config::validate::collect_range_filter_violations` and the `Error::InvalidLatitude`
 /// message text carried its own copy of these numbers, with nothing keeping
 /// them equal. `test_parse_latitude_matches_the_config_file_rule` and its
 /// longitude twin drive the flag and the file together and compare verdicts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1417,7 +1417,7 @@ fn handle_config_command(action: cli::ConfigAction, output_mode: OutputMode) -> 
 /// an enum do not come through here and never parsed.
 ///
 /// The key prefix is not only for the reader. It is what tells this layer's
-/// rejection apart from `validate_defaults`', so a test for this arm cannot be
+/// rejection apart from `collect_defaults_violations`', so a test for this arm cannot be
 /// satisfied by the save-side check firing instead.
 fn parse_config_value<T>(
     key: &str,
@@ -1430,7 +1430,7 @@ fn parse_config_value<T>(
 }
 
 fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<()> {
-    let ((), config, config_path) = config::update_config(|config| {
+    let ((), config, config_path, remaining) = config::update_config_repairing(|config| {
         match key {
             "defaults.model" => {
                 config.defaults.model = if value.is_empty() {
@@ -1487,7 +1487,7 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
                 };
             }
             // No arm existed for this key, so hand-editing config.toml was the only
-            // way to set it, and that was the one route `validate_defaults` did not
+            // way to set it, and that was the one route `collect_defaults_violations` did not
             // check either (#312). Both halves are closed now.
             "defaults.day_of_year" => {
                 config.defaults.day_of_year = if value.is_empty() {
@@ -1567,14 +1567,30 @@ fn handle_config_set(key: &str, value: &str, output_mode: OutputMode) -> Result<
         Ok(())
     })?;
 
-    // `update_config` validates the whole config inside `save_config` before
-    // writing, and holds the config lock across the load-mutate-save so a
-    // concurrent writer cannot lose this edit (#313).
+    // `update_config_repairing` holds the config lock across the load-mutate-save
+    // so a concurrent writer cannot lose this edit (#313). Unlike `update_config`
+    // it does not require the whole config to be valid: it writes as long as this
+    // edit introduces no new rule failure, so a file carrying two independent
+    // faults can be repaired one key at a time (#305). Any faults the edit left
+    // in place come back in `remaining` for us to report.
     //
-    // Note the validation covers the whole config, not just the key being set,
-    // so a file carrying two independent faults cannot be repaired one key at a
-    // time here. That predates #295 and is tracked separately; the load gate is
-    // scoped to analysis so it does not turn that into a lockout.
+    // The recovery hint goes to stderr with `eprintln!`, not through the
+    // `tracing` warn path, so it always shows (a user with `RUST_LOG=error` set
+    // still needs to see what is left to fix) and never lands on stdout, where a
+    // JSON consumer is reading the envelope.
+    if !remaining.is_empty() {
+        eprintln!(
+            "warning: '{key}' was saved, but the configuration still has {} unresolved problem(s):",
+            remaining.len()
+        );
+        for problem in &remaining {
+            eprintln!("  - {problem}");
+        }
+        eprintln!(
+            "Fix each with 'birda config set <key> <value>', or edit the file directly \
+             ('birda config path' prints where it is)."
+        );
+    }
 
     if output_mode.is_structured() {
         let config_json = serde_json::to_value(&config).map_err(|e| Error::ConfigValidation {

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -45,6 +45,14 @@ const OUT_OF_RANGE_LATITUDE: &str = "[defaults]\nlatitude = 200.0\n";
 /// "0 species in range".
 const NAN_RANGE_THRESHOLD: &str = "[defaults]\nrange_threshold = nan\n";
 
+/// Two independent faults on distinct keys (#305).
+///
+/// The lockout case: before the fix, each `config set` revalidated the whole
+/// file inside `save_config`, so with two faults present every single-key
+/// repair was rejected by the fault it was not touching, and the file could not
+/// be fixed one key at a time at all.
+const TWO_INDEPENDENT_FAULTS: &str = "[defaults]\nlatitude = 200.0\nrange_threshold = nan\n";
+
 /// An empty output-format list (#339).
 ///
 /// The reason this rule needs a binary-level test more than its siblings do:
@@ -298,7 +306,7 @@ const BATCH_SIZE_CLI_ADVICE: &str = "GPU memory exhaustion";
 /// The prefix `handle_config_set` puts on a value it refused itself.
 ///
 /// Same purpose as [`BATCH_SIZE_CLI_ADVICE`]: it names the key the user typed,
-/// which neither `validate_defaults` nor clap can do.
+/// which neither `collect_defaults_violations` nor clap can do.
 const CONFIG_SET_REJECTION: &str = "invalid value for";
 
 /// The exit code birda uses for an application error, as opposed to a clap
@@ -334,7 +342,7 @@ fn assert_command_succeeds(home: &Path, args: &[&str]) {
 
 #[test]
 fn test_out_of_range_latitude_is_rejected_on_load() {
-    // Accepted on load before the fix. `validate_range_filter` has checked
+    // Accepted on load before the fix. `collect_range_filter_violations` has checked
     // latitude since long before this change; nothing called it.
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
@@ -368,11 +376,14 @@ fn test_an_unknown_csv_column_is_rejected_on_load() {
 
 #[test]
 fn test_neither_new_rule_has_a_config_set_arm_to_repair_it() {
-    // Pins the reason both messages carry recovery advice that the sibling
-    // rules do not. `config set` cannot reach either key, and because
-    // `save_config` validates the whole file, the fault also blocks `config
-    // set` on every OTHER key. Hand-editing config.toml is the only way out,
-    // and the README says so; this is what stops that becoming untrue quietly.
+    // `formats` and `csv_columns` have no `config set` arm, so editing the file
+    // is the only way to fix either; that is why both rule messages carry the
+    // extra recovery advice their siblings omit. Before #305 this fault also
+    // blocked `config set` on every OTHER key, and this test pinned that lockout.
+    // It no longer holds: an unrelated edit now goes through (a fault the tool
+    // cannot repair must not freeze the ones it can), and the standing fault
+    // comes back as a warning carrying the same recovery advice, so the pointer
+    // to the file is still surfaced, now on a write that succeeded.
     let home = tempfile::tempdir().unwrap();
     seed_config(home.path(), EMPTY_FORMATS);
 
@@ -390,22 +401,28 @@ fn test_neither_new_rule_has_a_config_set_arm_to_repair_it() {
         );
     }
 
+    // An unrelated, valid edit is no longer blocked by the unreachable fault
+    // (#305): it succeeds, leaving the formats fault in place.
     let other = run_in(
         home.path(),
         &["config", "set", "defaults.min_confidence", "0.2"],
     );
-    assert_eq!(other.status.code(), Some(APPLICATION_ERROR));
     assert!(
-        stderr_of(&other).contains(EMPTY_FORMATS_VIOLATION),
-        "an unrelated key must also be refused while the file is invalid, got: {}",
+        other.status.success(),
+        "an unrelated key must not be frozen by a fault it cannot repair, got: {}",
         stderr_of(&other)
     );
 
-    // The recovery advice itself is user-facing output with nothing else
-    // asserting a word of it.
+    // The fault it left in place is still reported, with the advice that points
+    // at the file, since editing it is the only route to clearing this one.
+    assert!(
+        stderr_of(&other).contains(EMPTY_FORMATS_VIOLATION),
+        "the standing formats fault must be reported, got: {}",
+        stderr_of(&other)
+    );
     assert!(
         stderr_of(&other).contains("birda config path"),
-        "the message must point at the file, got: {}",
+        "the message must still point at the file, got: {}",
         stderr_of(&other)
     );
 }
@@ -509,6 +526,222 @@ fn test_config_set_refuses_to_persist_an_invalid_value() {
 }
 
 #[test]
+fn test_config_set_repairs_a_config_with_two_independent_faults() {
+    // The #305 lockout, end to end. With two faults present, fixing either one
+    // must be accepted even though the other still stands, so the file can be
+    // repaired one key at a time. Before the fix, `save_config` revalidated the
+    // whole config and the untouched fault rejected every single-key write.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), TWO_INDEPENDENT_FAULTS);
+
+    // Fixing the first fault is accepted while the second remains.
+    let first = run_in(
+        home.path(),
+        &["config", "set", "defaults.latitude", "60.17"],
+    );
+    assert!(
+        first.status.success(),
+        "`config set` must repair one fault while another stands: {}",
+        stderr_of(&first)
+    );
+    assert_eq!(
+        config_value(home.path(), "latitude"),
+        60.17,
+        "the repaired latitude should have been written"
+    );
+
+    // Fixing the second returns the file to a fully valid state. 0.5 rather than
+    // an arbitrary threshold because it round-trips exactly through the f32
+    // field and the JSON envelope, so the equality assertion is not at the mercy
+    // of float widening.
+    let second = run_in(
+        home.path(),
+        &["config", "set", "defaults.range_threshold", "0.5"],
+    );
+    assert!(
+        second.status.success(),
+        "`config set` must repair the remaining fault: {}",
+        stderr_of(&second)
+    );
+    assert_eq!(
+        config_value(home.path(), "range_threshold"),
+        0.5,
+        "the repaired threshold should have been written"
+    );
+
+    // The end state now loads on the one path that validates on load.
+    assert_validation_did_not_reject(home.path());
+}
+
+#[test]
+fn test_config_set_warns_about_the_faults_it_left_unresolved() {
+    // Repairing one fault must not hide the others: the user is told, on stderr,
+    // which faults still stand, so a partial repair does not look complete.
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), TWO_INDEPENDENT_FAULTS);
+
+    let repair = run_in(
+        home.path(),
+        &["config", "set", "defaults.latitude", "60.17"],
+    );
+    assert!(
+        repair.status.success(),
+        "the repair should be accepted: {}",
+        stderr_of(&repair)
+    );
+    assert!(
+        stderr_of(&repair).contains(THRESHOLD_VIOLATION),
+        "`config set` should warn about the range_threshold fault it did not fix, got: {}",
+        stderr_of(&repair)
+    );
+    // The fault it JUST FIXED must not be reported as still standing. This pins
+    // `remaining` to the POST-edit fault set: a regression that built it from the
+    // pre-edit set, or one that always warns, would list the repaired latitude
+    // here and still pass every other assertion, since before and after share
+    // the threshold fault.
+    assert!(
+        !stderr_of(&repair).contains(LATITUDE_VIOLATION),
+        "the repaired latitude must not be reported as still unresolved, got: {}",
+        stderr_of(&repair)
+    );
+
+    // The same warning goes to stderr in JSON mode, leaving stdout a clean
+    // envelope for a machine consumer.
+    let json_home = tempfile::tempdir().unwrap();
+    seed_config(json_home.path(), TWO_INDEPENDENT_FAULTS);
+    let json = run_in(
+        json_home.path(),
+        &[
+            "config",
+            "set",
+            "defaults.latitude",
+            "60.17",
+            "--output-mode",
+            "json",
+        ],
+    );
+    assert!(
+        json.status.success(),
+        "the JSON-mode repair should be accepted: {}",
+        stderr_of(&json)
+    );
+    serde_json::from_str::<serde_json::Value>(&String::from_utf8_lossy(&json.stdout))
+        .expect("stdout must stay a parseable JSON envelope, not carry the warning");
+    assert!(
+        stderr_of(&json).contains(THRESHOLD_VIOLATION),
+        "the warning belongs on stderr in JSON mode too, got: {}",
+        stderr_of(&json)
+    );
+
+    // A repair that leaves nothing unresolved says nothing. With the latitude
+    // its only fault, fixing it must NOT print an unresolved-problems warning,
+    // so a clean repair does not cry wolf (and an always-warn regression fails
+    // here).
+    let clean_home = tempfile::tempdir().unwrap();
+    seed_config(clean_home.path(), OUT_OF_RANGE_LATITUDE);
+    let clean = run_in(
+        clean_home.path(),
+        &["config", "set", "defaults.latitude", "60.17"],
+    );
+    assert!(
+        clean.status.success(),
+        "the clean repair should be accepted: {}",
+        stderr_of(&clean)
+    );
+    assert!(
+        !stderr_of(&clean).contains("unresolved problem"),
+        "resolving the last fault must not print an unresolved-problems warning, got: {}",
+        stderr_of(&clean)
+    );
+}
+
+#[test]
+fn test_config_set_edits_an_unrelated_key_while_the_config_is_broken() {
+    // The case a plain "write only when the fault count drops" rule gets wrong.
+    // Editing a DIFFERENT, valid key leaves the fault count unchanged, yet it
+    // must still be allowed, or an unrelated setting could not be touched until
+    // someone else's fault was fixed. The rule is "introduce no new fault", not
+    // "reduce the count".
+    let home = tempfile::tempdir().unwrap();
+    seed_config(home.path(), NAN_RANGE_THRESHOLD);
+
+    let output = run_in(home.path(), &["config", "set", "defaults.overlap", "0.5"]);
+    assert!(
+        output.status.success(),
+        "editing a valid unrelated key must be allowed while another fault stands: {}",
+        stderr_of(&output)
+    );
+    assert_eq!(
+        config_value(home.path(), "overlap"),
+        0.5,
+        "the unrelated edit should have been written"
+    );
+    assert!(
+        stderr_of(&output).contains(THRESHOLD_VIOLATION),
+        "the standing fault should still be reported, got: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn test_config_set_will_not_add_a_new_fault_to_a_broken_config() {
+    // The relaxation permits forward progress, never a fresh fault. With one
+    // fault already present, pointing `defaults.model` at a model that is not
+    // configured introduces a SECOND, distinct fault, so the write is refused
+    // and the file is left as it was. `defaults.model` is what makes this
+    // reachable: unlike the numeric keys it has no `parse_*` bound, so this rule
+    // is the only thing standing between it and a bad value.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), OUT_OF_RANGE_LATITUDE);
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.model", "no-such-model"],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "adding a new fault to a broken config must be refused as an application error, got: {}",
+        stderr_of(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a refused `config set` must leave the file untouched"
+    );
+}
+
+#[test]
+fn test_config_set_will_not_break_a_valid_config() {
+    // The empty-`before` boundary: on a config with NO faults the repair path
+    // must behave exactly like the strict one and refuse any edit that would
+    // introduce a fault, so `config set` can never silently turn a good config
+    // into a broken one. `defaults.model` is the reachable case (no `parse_*`
+    // bound), so pointing it at a model that is not configured must be rejected
+    // and leave the file untouched.
+    let home = tempfile::tempdir().unwrap();
+    let path = seed_config(home.path(), "[defaults]\nlatitude = 60.17\n");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let output = run_in(
+        home.path(),
+        &["config", "set", "defaults.model", "no-such-model"],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(APPLICATION_ERROR),
+        "config set must not introduce a fault into a valid config, got: {}",
+        stderr_of(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        before,
+        "a refused `config set` must leave the valid file untouched"
+    );
+}
+
+#[test]
 fn test_bare_invocation_prints_help_with_an_invalid_config() {
     // Refusing to print help because the config is wrong is the least useful
     // moment to refuse, so the no-command no-inputs path is exempt too.
@@ -564,9 +797,9 @@ fn test_repair_and_diagnostic_commands_are_not_gated() {
 
 #[test]
 fn test_an_overlap_rule_violation_is_rejected_on_load() {
-    // `validate_config` runs two halves and only `validate_range_filter` was
-    // reached end to end: swapping the gate call to `validate_range_filter`
-    // alone left the whole suite green. This drives a `validate_defaults` rule
+    // `validate_config` runs two halves and only `collect_range_filter_violations` was
+    // reached end to end: swapping the gate call to `collect_range_filter_violations`
+    // alone left the whole suite green. This drives a `collect_defaults_violations` rule
     // through the binary, so the gate is pinned to the full check rather than
     // half of it.
     //
@@ -740,7 +973,7 @@ fn test_an_oversized_batch_size_is_rejected_on_load() {
 
 #[test]
 fn test_an_out_of_range_day_of_year_is_rejected_on_load() {
-    // The other #312 field, and the wider hole of the two: `validate_defaults`
+    // The other #312 field, and the wider hole of the two: `collect_defaults_violations`
     // did not look at it at all and `config set` had no arm for it, so
     // config.toml was the only route to `defaults.day_of_year` and the only one
     // with no check. (`--day-of-year` and `BIRDA_DAY_OF_YEAR` set it for a
@@ -884,7 +1117,7 @@ fn test_config_set_writes_a_valid_day_of_year() {
 #[test]
 fn test_config_set_rejects_an_out_of_range_day_of_year() {
     // The rejecting half of the arm above. Pinned on CONFIG_SET_REJECTION
-    // because `validate_defaults` now emits the same rule message with the same
+    // because `collect_defaults_violations` now emits the same rule message with the same
     // exit code, so the key prefix is the only thing that tells the two apart.
     let home = tempfile::tempdir().unwrap();
     let path = seed_config(home.path(), VALID_SEED);
@@ -1038,7 +1271,7 @@ fn test_a_valid_config_still_loads() {
     // fail further on (no model is configured here), so this asserts only that
     // it got past validation.
     // `batch_size` and `day_of_year` are set at their inclusive maxima rather
-    // than left out. Omitted, `validate_defaults` short-circuits on `None` and
+    // than left out. Omitted, `collect_defaults_violations` short-circuits on `None` and
     // the two rule messages this control asserts absent could never have
     // appeared, so those assertions held by construction. At 512 and 366 they
     // are real, and the upper bounds get end-to-end coverage they otherwise


### PR DESCRIPTION
## Summary

`birda config set <key> <value>` loaded the whole config, mutated one key, then revalidated the entire config in `save_config`. With two independent invalid values present, every single-key repair was rejected by the fault it was not touching, so a doubly-invalid config could not be fixed one key at a time at all, and fail-fast validation hid how many faults there were. The documented workaround was to hand-edit `config.toml`, which defeats the point of having a `config set` at all.

This makes `config set` use a repair-aware write that persists the edit as long as it introduces no new rule failure. It may leave faults that were already present in place, but never adds one to a field that was clean, so an edit can make forward progress on a broken config (fixing one fault, or touching an unrelated valid key) while any faults left standing are reported on stderr with recovery advice. Every other writer stays strict through `save_config`, so the "no writer persists an invalid config" invariant (#295) is unchanged for them; only `config set` is relaxed, and only to a config that is strictly no worse than the one it loaded.

## How it works

- `collect_violations` runs every rule and is the single source of truth; `validate_config` now returns the first violation from it, with the same error variant, message and rule order as before, so every existing caller (the analyze load gate, all writers) and every exit code is unchanged.
- `Violation`/`ViolationField` tag each failure by field, so `config set` can tell "left an existing fault alone" apart from "introduced a new one". The rule is subset-by-field (the set of violated fields after the edit must be a subset of the set before), not a fault-count comparison, so editing an unrelated valid key while another fault stands is still allowed rather than being blocked for not reducing the count.
- `save_config` is split into validate + `write_config_to_disk`; the repair path reuses the exact same atomic write after its own no-new-fault check, and the whole load/check/mutate/check/write sequence runs under the existing config lock (#313).
- The unresolved-faults warning goes to stderr via `eprintln!`, so it always shows regardless of log level and never lands on stdout where a JSON consumer is reading the envelope.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (743 passing, 0 failing)
- [x] New integration tests: two-fault repair one key at a time, unrelated-key edit while broken, refuse a new fault into a broken config, refuse a new fault into a valid config, and the stderr warning in both human and JSON mode (asserting stdout stays a parseable envelope)
- [x] New unit tests over `update_config_repairing_at` (repair one of two, refuse-and-leave-file, unrelated edit)
- [ ] Manual: `config set defaults.latitude` then `config set defaults.range_threshold` on a config carrying both faults

## Notes and follow-ups

- Structured (`--output-mode json`) consumers get the unresolved-faults list on stderr only; the JSON envelope is intentionally unchanged in this PR. Surfacing it in `ConfigPayload` would be an additive, cross-repo (birda-gui) change, so it is left as a follow-up rather than widening this PR's contract. This is not a regression: before this change the same edit hard-failed, so a machine consumer is strictly better off.
- Other config writers (`models add --default`, model/geomodel installs) intentionally stay strict; `config set` is the designated repair surface.

## Related issues

Fixes #305