### PR TITLE
fix: retry the Windows sharing violation on both publish-by-rename paths (#366)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -195,6 +195,55 @@ pub mod config_lock {
     pub const RETRY_INTERVAL: Duration = Duration::from_millis(50);
 }
 
+/// Retry policy for publishing a finished file over its final path by rename or
+/// persist (both call Windows `MoveFileExW`).
+///
+/// On Windows a concurrent reader that holds the destination open without
+/// `FILE_SHARE_DELETE` (antivirus, the search indexer, or birda-gui reading
+/// `registry.json`) makes the rename fail with a sharing violation for a moment.
+/// A bounded exponential backoff rides out that window, restoring what a plain
+/// `fs::write` used to survive. On non-Windows the transient-error predicate is a
+/// compile-time `false`, so only the first attempt ever runs.
+pub mod publish {
+    use std::time::Duration;
+
+    /// Total publish attempts, including the first. With the backoff below the
+    /// worst case is roughly 0.7s of waiting before a persistent sharing
+    /// violation is surfaced.
+    pub const MAX_ATTEMPTS: u32 = 8;
+
+    /// Backoff before the second attempt; doubles each retry up to `MAX_BACKOFF`.
+    pub const BASE_BACKOFF: Duration = Duration::from_millis(10);
+
+    /// Ceiling for the exponential backoff between attempts.
+    pub const MAX_BACKOFF: Duration = Duration::from_millis(200);
+
+    /// `MoveFileExW`'s access-denied code.
+    ///
+    /// Raised while another process holds the destination open without
+    /// `FILE_SHARE_DELETE`; in practice it comes up as often as the dedicated
+    /// sharing-violation code.
+    pub const ERROR_ACCESS_DENIED: i32 = 5;
+
+    /// `MoveFileExW`'s dedicated sharing-violation code.
+    pub const ERROR_SHARING_VIOLATION: i32 = 32;
+
+    /// `MoveFileExW` fails with `ERROR_LOCK_VIOLATION` when a byte-range lock is
+    /// held on the destination.
+    pub const ERROR_LOCK_VIOLATION: i32 = 33;
+
+    /// The Windows OS error codes a transient publish should retry.
+    ///
+    /// Raised by a concurrent reader (antivirus, the search indexer, or birda-gui
+    /// reading `registry.json`) holding the destination open without
+    /// `FILE_SHARE_DELETE`.
+    pub const TRANSIENT_PUBLISH_ERRORS: [i32; 3] = [
+        ERROR_ACCESS_DENIED,
+        ERROR_SHARING_VIOLATION,
+        ERROR_LOCK_VIOLATION,
+    ];
+}
+
 /// Output file extensions by format.
 pub mod output_extensions {
     /// CSV output extension.

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -207,7 +207,15 @@ pub async fn download_verified(
         return Err(e);
     }
 
-    finalize_download(&part, dest)?;
+    // Run the publish on a blocking thread: its Windows sharing-violation backoff
+    // sleeps, which must not park this async worker. `part` is owned and unused
+    // afterwards, so it moves in; `dest` is cloned for the 'static closure.
+    let dest_owned = dest.to_path_buf();
+    tokio::task::spawn_blocking(move || finalize_download(&part, &dest_owned))
+        .await
+        .map_err(|e| Error::Internal {
+            message: format!("download finalization task failed to run: {e}"),
+        })??;
     pb.finish_with_message("Download complete");
 
     Ok(())
@@ -266,7 +274,32 @@ fn finalize_download(part: &Path, dest: &Path) -> Result<()> {
     // resource busy (os error 16)" with neither path in it. That EBUSY is a real
     // case: a destination bind-mounted as a file cannot be renamed over, and it is
     // the same failure this change documents for the registry one directory away.
-    if let Err(source) = std::fs::rename(part, dest) {
+    // Retried, not a single rename: on Windows a concurrent reader holding the
+    // destination open without FILE_SHARE_DELETE makes MoveFileExW fail with a
+    // transient sharing violation. The backoff rides that out; `roll_back` below
+    // fires only once the retries are exhausted, so the `.part` file survives to
+    // be renamed on a later attempt. On non-Windows this is a single rename.
+    let published = {
+        let mut backoff = crate::constants::publish::BASE_BACKOFF;
+        let mut attempt = 1u32;
+        loop {
+            match std::fs::rename(part, dest) {
+                Ok(()) => break Ok(()),
+                Err(source) => {
+                    if crate::utils::fs::backoff_after_transient_publish(
+                        &source,
+                        attempt,
+                        &mut backoff,
+                    ) {
+                        attempt += 1;
+                        continue;
+                    }
+                    break Err(source);
+                }
+            }
+        }
+    };
+    if let Err(source) = published {
         // The part file is useless without the rename, and nothing sweeps it up:
         // `find_obsolete_files` matches a fixed list of names that does not include
         // it, and `part_path` qualifies the name with this process's id, so the

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -220,7 +220,7 @@ where
     // the write bit on the file itself, so a file the user can plainly write can
     // now fail to be written. The `io::Error` names the temporary, and so the
     // directory with it.
-    let temp = new_temp_in(dir, mode)?;
+    let mut temp = new_temp_in(dir, mode)?;
 
     // Both modes are read once, here, because `fill` runs in between and the
     // target may be replaced by the time it returns.
@@ -240,7 +240,27 @@ where
     temp.as_file().sync_all()?;
 
     // Drops the temporary on failure, so a rejected write leaves nothing behind.
-    temp.persist(target).map_err(|e| e.error)?;
+    //
+    // Retried rather than persisted once: on Windows a concurrent reader holding
+    // the target open without FILE_SHARE_DELETE makes MoveFileExW fail with a
+    // transient sharing violation. `PersistError` hands the temporary back, so a
+    // failed attempt reclaims it and tries again; the mode and `sync_all` set
+    // above live on the inode and survive. On non-Windows the predicate is a
+    // compile-time false, so this persists exactly once.
+    let mut backoff = crate::constants::publish::BASE_BACKOFF;
+    let mut attempt = 1u32;
+    loop {
+        match temp.persist(target) {
+            Ok(_) => break,
+            Err(e) => {
+                if !backoff_after_transient_publish(&e.error, attempt, &mut backoff) {
+                    return Err(E::from(e.error));
+                }
+                temp = e.file;
+                attempt += 1;
+            }
+        }
+    }
 
     // The leaf directory holds the file's new entry.
     sync_directory(dir);
@@ -252,6 +272,69 @@ where
     }
 
     Ok(())
+}
+
+/// True for the transient Windows errors raised while another process briefly
+/// holds the publish destination open without `FILE_SHARE_DELETE` (antivirus,
+/// the search indexer, or birda-gui reading `registry.json`):
+/// `ERROR_ACCESS_DENIED` (5), `ERROR_SHARING_VIOLATION` (32), and
+/// `ERROR_LOCK_VIOLATION` (33). `MoveFileExW` returns 5 rather than 32 as often
+/// as not, so all three are needed. Retrying rides out that short window, which a
+/// plain `fs::write` used to survive.
+#[cfg(windows)]
+pub(crate) fn is_transient_publish_error(err: &std::io::Error) -> bool {
+    err.raw_os_error()
+        .is_some_and(|code| crate::constants::publish::TRANSIENT_PUBLISH_ERRORS.contains(&code))
+}
+
+/// Off Windows a rename or persist over an open file does not raise a sharing
+/// violation, so a publish is always a single attempt and never transient. A
+/// compile-time `false` lets the retry branch fold away entirely.
+#[cfg(not(windows))]
+pub(crate) fn is_transient_publish_error(_err: &std::io::Error) -> bool {
+    false
+}
+
+/// Decide whether a failed publish (a rename or a persist) should be retried,
+/// waiting first if so.
+///
+/// Returns `false` (stop, surface `err`) when `err` is not a transient publish
+/// error or `attempt` has reached [`crate::constants::publish::MAX_ATTEMPTS`].
+/// Otherwise sleeps for `backoff`, doubles it up to
+/// [`crate::constants::publish::MAX_BACKOFF`], and returns `true`.
+///
+/// Callers start `attempt` at 1 and increment it on each `true`. The wait is a
+/// `std::thread::sleep`, so an async caller must run the publish on a blocking
+/// thread (e.g. `tokio::task::spawn_blocking`) to avoid parking a worker. On
+/// non-Windows this always returns `false` on the first call, so the publish is a
+/// single attempt with no sleep, behaviour unchanged.
+pub(crate) fn backoff_after_transient_publish(
+    err: &std::io::Error,
+    attempt: u32,
+    backoff: &mut std::time::Duration,
+) -> bool {
+    if attempt >= crate::constants::publish::MAX_ATTEMPTS || !is_transient_publish_error(err) {
+        return false;
+    }
+
+    tracing::debug!(
+        "publish attempt {attempt} hit a transient sharing violation ({err}); retrying in {backoff:?}"
+    );
+    std::thread::sleep(*backoff);
+    advance_backoff(backoff);
+    true
+}
+
+/// Double the publish backoff, saturating at [`crate::constants::publish::MAX_BACKOFF`].
+///
+/// Pulled out of [`backoff_after_transient_publish`] so the exponential curve,
+/// which is the one platform-independent piece of the retry, can be unit-tested
+/// directly on every platform rather than only on a Windows runner where the
+/// transient predicate is live.
+fn advance_backoff(backoff: &mut std::time::Duration) {
+    *backoff = (*backoff)
+        .saturating_mul(2)
+        .min(crate::constants::publish::MAX_BACKOFF);
 }
 
 /// The ancestors of `dir`, from deepest to shallowest, that do not exist yet.
@@ -517,6 +600,95 @@ fn sync_directory(_dir: &Path) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transient_publish_error_matches_only_windows_sharing_violations() {
+        // The three MoveFileExW codes a concurrent reader raises. They are
+        // transient only on Windows; everywhere else the same publish never hits
+        // a sharing violation, so the predicate is false and the publish is a
+        // single attempt. `cfg!(windows)` is the expected answer per platform.
+        for code in crate::constants::publish::TRANSIENT_PUBLISH_ERRORS {
+            let err = std::io::Error::from_raw_os_error(code);
+            assert_eq!(
+                is_transient_publish_error(&err),
+                cfg!(windows),
+                "os error {code} should be transient exactly on Windows"
+            );
+        }
+
+        // Never transient on any platform: ERROR_FILE_NOT_FOUND / ENOENT (2) is a
+        // real failure, not a lock to wait out.
+        let not_found = std::io::Error::from_raw_os_error(2);
+        assert!(!is_transient_publish_error(&not_found));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn publish_is_a_single_attempt_off_windows() {
+        // Even for a code Windows would retry, the first call must refuse to retry
+        // and must not sleep or advance the backoff: off Windows every publish
+        // stays one attempt, exactly as before this change.
+        let mut backoff = crate::constants::publish::BASE_BACKOFF;
+        let would_be_transient = std::io::Error::from_raw_os_error(5);
+        assert!(!backoff_after_transient_publish(
+            &would_be_transient,
+            1,
+            &mut backoff
+        ));
+        assert_eq!(
+            backoff,
+            crate::constants::publish::BASE_BACKOFF,
+            "a single-attempt publish must not have slept or advanced the backoff"
+        );
+    }
+
+    #[test]
+    fn backoff_stops_at_the_attempt_cap() {
+        // At the final attempt the loop must terminate rather than spin, even for
+        // an otherwise-transient error. The cap check precedes the sleep, so the
+        // last attempt never adds a wait.
+        let mut backoff = crate::constants::publish::BASE_BACKOFF;
+        let transient = std::io::Error::from_raw_os_error(32);
+        assert!(!backoff_after_transient_publish(
+            &transient,
+            crate::constants::publish::MAX_ATTEMPTS,
+            &mut backoff
+        ));
+    }
+
+    #[test]
+    fn advance_backoff_doubles_then_saturates_at_the_cap() {
+        use crate::constants::publish::{BASE_BACKOFF, MAX_BACKOFF};
+        use std::time::Duration;
+
+        // The exponential curve is the one platform-independent piece of the
+        // retry, so it is exercised directly here rather than only on a Windows
+        // runner where the transient predicate is live.
+        let mut backoff = BASE_BACKOFF;
+        let mut seen = vec![backoff];
+        for _ in 0..7 {
+            advance_backoff(&mut backoff);
+            seen.push(backoff);
+        }
+
+        assert_eq!(
+            seen,
+            vec![
+                Duration::from_millis(10),
+                Duration::from_millis(20),
+                Duration::from_millis(40),
+                Duration::from_millis(80),
+                Duration::from_millis(160),
+                MAX_BACKOFF, // 320ms doubled from 160ms, clamped to the 200ms cap
+                MAX_BACKOFF, // and it stays there
+                MAX_BACKOFF,
+            ]
+        );
+        assert!(
+            seen.iter().all(|d| *d <= MAX_BACKOFF),
+            "backoff must never exceed the cap"
+        );
+    }
 
     /// Every entry in `dir` that the caller did not expect to be there.
     ///


### PR DESCRIPTION
## Summary

Fixes #366. On Windows, publishing a file by rename fails transiently when another process holds the destination open without `FILE_SHARE_DELETE`, and birda's two publish-by-rename sites did not recover from it. Both now retry that transient failure with a bounded exponential backoff.

`std::fs::rename` and `NamedTempFile::persist` both call `MoveFileExW`, which returns `ERROR_ACCESS_DENIED` (5), `ERROR_SHARING_VIOLATION` (32), or `ERROR_LOCK_VIOLATION` (33) while an antivirus scanner, the search indexer, or the GUI (which reads `registry.json` straight off disk) briefly holds the target open. The old plain `fs::write` survived that window; publishing by rename regressed it on a platform CI never exercises.

## What changed

- One shared retry policy in `utils::fs`: `is_transient_publish_error` (the three Windows codes; a compile-time `false` off Windows) and `backoff_after_transient_publish`, tuned by the new `constants::publish` module (8 attempts, 10ms base doubling to a 200ms cap, ~0.7s worst case).
- Applied to both publish sites: `write_atomic_with`'s `temp.persist` (reclaiming the temporary from `PersistError` to retry in place) and `finalize_download`'s `std::fs::rename` (rolling back the `.part` only once the retries are exhausted).
- `download_verified` runs `finalize_download` through `tokio::task::spawn_blocking`, so the backoff's sleeps never park a Tokio worker.
- Off Windows the predicate is a compile-time constant `false`, so every publish stays a single attempt with no sleep: behaviour on Linux and macOS is unchanged.

## Related issues

Fixes #366.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test --no-default-features` suite pass (618 lib + integration tests).
- [x] New unit tests cover the transient-error predicate, the single-attempt-off-Windows guarantee, the attempt cap, and the backoff doubling/cap curve (the one platform-independent algorithm, so it runs on Linux CI).
- [x] The Windows-only retry path (which cannot run on Linux CI) was validated on a Windows 11 VM with a standalone repro: a single rename over a destination held open without `FILE_SHARE_DELETE` fails with error 5, and the retry recovers on a later attempt once the holder releases.

## Deliberately out of scope

The issue's "Related, lower priority" items (moving `verify_sha256` / `extract_binary` off the async executor, and sweeping stale `birda-update-*` orphans) are separate concerns and left for their own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when installing or publishing files, especially when files are temporarily locked or in use.
  * Added automatic retries with increasing delays for temporary publishing failures.
  * Prevented temporary files from being removed until all publishing attempts are complete.
  * Improved error handling when background download finalization cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->