### PR TITLE
fix: isolate the integration suite's config and model dirs on every platform (#328)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,7 @@ pub use file::{
     load_config_file, load_default_config, save_config, update_config, update_config_repairing,
 };
 pub use geomodel::{GeomodelRequest, GeomodelResolution, resolve_geomodel};
-pub use paths::{config_dir, config_file_path, tensorrt_cache_dir};
+pub use paths::{config_dir, config_file_path, data_dir, tensorrt_cache_dir};
 pub use types::{
     Config, CsvColumnsConfig, DefaultsConfig, InferenceConfig, InferenceDevice, ModelConfig,
     ModelType, OutputConfig, OutputFormat, OutputMode, UnmatchedPolicy,

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -1,26 +1,70 @@
 //! Platform-specific configuration paths.
 
-use crate::constants::{APP_NAME, tensorrt};
+use crate::constants::{APP_NAME, CONFIG_DIR_ENV, tensorrt};
 use crate::error::{Error, Result};
 use directories::ProjectDirs;
+use std::ffi::OsString;
 use std::path::PathBuf;
+
+/// Returns the [`CONFIG_DIR_ENV`] override root, if it is set to a non-empty
+/// value.
+///
+/// Both [`config_dir`] and [`data_dir`] honour this, so the integration suite
+/// can redirect every path birda reads or writes into a temporary directory on
+/// any platform, Windows included. See [`CONFIG_DIR_ENV`].
+fn config_dir_override() -> Option<PathBuf> {
+    override_root(std::env::var_os(CONFIG_DIR_ENV))
+}
+
+/// Pure core of [`config_dir_override`], split out so the empty/unset handling
+/// can be unit-tested without mutating the process environment.
+///
+/// An unset variable and one set to the empty string both mean "no override";
+/// the value is otherwise used verbatim so a path containing spaces survives.
+fn override_root(value: Option<OsString>) -> Option<PathBuf> {
+    value.filter(|v| !v.is_empty()).map(PathBuf::from)
+}
 
 /// Get the configuration directory for the current platform.
 ///
+/// Honours the [`CONFIG_DIR_ENV`] override when it is set. Otherwise:
 /// - Linux: `~/.config/birda/`
 /// - macOS: `~/Library/Application Support/birda/`
-/// - Windows: `%APPDATA%\birda\`
+/// - Windows: `%APPDATA%\birda\config\`
 pub fn config_dir() -> Result<PathBuf> {
+    if let Some(dir) = config_dir_override() {
+        return Ok(dir);
+    }
     ProjectDirs::from("", "", APP_NAME)
         .map(|dirs| dirs.config_dir().to_path_buf())
         .ok_or(Error::ConfigDirNotFound)
 }
 
+/// Get the data directory for the current platform.
+///
+/// Home of installed models. Honours the [`CONFIG_DIR_ENV`] override when set,
+/// returning the same root as [`config_dir`]. Otherwise:
+/// - Linux: `~/.local/share/birda/`
+/// - macOS: `~/Library/Application Support/birda/`
+/// - Windows: `%APPDATA%\birda\data\`
+pub fn data_dir() -> Result<PathBuf> {
+    if let Some(dir) = config_dir_override() {
+        return Ok(dir);
+    }
+    ProjectDirs::from("", "", APP_NAME)
+        .map(|dirs| dirs.data_dir().to_path_buf())
+        .ok_or(Error::DataDirNotFound)
+}
+
 /// Get the cache directory for the current platform.
+///
+/// Deliberately NOT covered by the [`CONFIG_DIR_ENV`] override: it holds only
+/// the regenerable `TensorRT` engine cache, which no test writes, so redirecting
+/// it would widen the override's scope for no isolation benefit.
 ///
 /// - Linux: `~/.cache/birda/`
 /// - macOS: `~/Library/Caches/birda/`
-/// - Windows: `%LOCALAPPDATA%\birda\`
+/// - Windows: `%LOCALAPPDATA%\birda\cache\`
 pub fn cache_dir() -> Result<PathBuf> {
     ProjectDirs::from("", "", APP_NAME)
         .map(|dirs| dirs.cache_dir().to_path_buf())
@@ -41,7 +85,7 @@ pub fn config_file_path() -> Result<PathBuf> {
 ///
 /// - Linux: `~/.cache/birda/tensorrt_cache/`
 /// - macOS: `~/Library/Caches/birda/tensorrt_cache/`
-/// - Windows: `%LOCALAPPDATA%\birda\tensorrt_cache\`
+/// - Windows: `%LOCALAPPDATA%\birda\cache\tensorrt_cache\`
 pub fn tensorrt_cache_dir() -> Result<PathBuf> {
     Ok(cache_dir()?.join(tensorrt::CACHE_DIR))
 }
@@ -49,15 +93,68 @@ pub fn tensorrt_cache_dir() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    fn override_root_unset_is_none() {
+        assert_eq!(override_root(None), None);
+    }
+
+    #[test]
+    fn override_root_empty_is_none() {
+        // An exported-but-empty variable must not redirect anywhere.
+        assert_eq!(override_root(Some(OsString::new())), None);
+    }
+
+    #[test]
+    fn override_root_uses_value_verbatim() {
+        // Paths with spaces are legitimate, so the value is not trimmed.
+        let raw = "/tmp/birda test home";
+        assert_eq!(
+            override_root(Some(OsString::from(raw))),
+            Some(PathBuf::from(raw))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn override_redirects_config_and_data_dirs() {
+        // Pins the override branch on every platform, including Linux CI where
+        // the integration suites also set HOME/XDG at the same dir and would
+        // therefore stay green even if this short-circuit were dropped (#328).
+        // The override wins over the real platform dirs: both resolve to `root`,
+        // not `~/.config/birda`, and config_dir and data_dir collapse together.
+        let root = tempfile::TempDir::new().unwrap();
+        temp_env::with_var(CONFIG_DIR_ENV, Some(root.path()), || {
+            assert_eq!(config_dir().unwrap().as_path(), root.path());
+            assert_eq!(data_dir().unwrap().as_path(), root.path());
+        });
+    }
+
+    #[test]
+    #[serial]
     fn test_config_dir_returns_path() {
         let result = config_dir();
         assert!(result.is_ok());
         let path = result.ok();
         assert!(path.is_some());
         let path = path.unwrap();
-        assert!(path.to_string_lossy().contains("birda"));
+        // Under the override the path is the caller's root, which need not carry
+        // the app name; only the default platform layout does.
+        if config_dir_override().is_none() {
+            assert!(path.to_string_lossy().contains("birda"));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_data_dir_returns_path() {
+        let result = data_dir();
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        if config_dir_override().is_none() {
+            assert!(path.to_string_lossy().contains("birda"));
+        }
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,6 +6,21 @@
 /// Application name used for config directories and user-facing messages.
 pub const APP_NAME: &str = "birda";
 
+/// Environment variable that redirects birda's config and data directories to a
+/// single root.
+///
+/// When set to a non-empty path, [`crate::config::config_dir`] (which holds
+/// `config.toml` and the cached `registry.json`) and [`crate::config::data_dir`]
+/// both resolve to it, so [`crate::registry::models_dir`] lands at `<root>/models`.
+/// The cache directory, holding only the regenerable `TensorRT` engine cache,
+/// is deliberately excluded.
+///
+/// This exists for test isolation. The integration suite must never read or
+/// write the developer's real config, and on Windows the `directories` crate
+/// resolves through `SHGetKnownFolderPath`, which ignores `HOME`/`XDG_*`; this
+/// override is the only redirection that works on every platform (issue #328).
+pub const CONFIG_DIR_ENV: &str = "BIRDA_CONFIG_DIR";
+
 /// Default minimum confidence threshold for detections.
 pub const DEFAULT_MIN_CONFIDENCE: f32 = 0.1;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,10 @@ pub enum Error {
     #[error("could not determine configuration directory for this platform")]
     ConfigDirNotFound,
 
+    /// Data directory could not be determined.
+    #[error("could not determine data directory for this platform")]
+    DataDirNotFound,
+
     /// Cache directory could not be determined.
     #[error("could not determine cache directory for this platform")]
     CacheDirNotFound,

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -356,13 +356,12 @@ async fn stream_to_file(
 }
 
 /// Get models directory path.
+///
+/// The `models` subdirectory of the platform data directory, which honours the
+/// [`crate::constants::CONFIG_DIR_ENV`] override (see [`crate::config::data_dir`])
+/// so the integration suite can isolate model installs on any platform.
 pub fn models_dir() -> Result<PathBuf> {
-    let data_dir = directories::ProjectDirs::from("", "", "birda")
-        .ok_or(Error::ConfigDirNotFound)?
-        .data_dir()
-        .to_path_buf();
-
-    Ok(data_dir.join("models"))
+    Ok(crate::config::data_dir()?.join("models"))
 }
 
 /// Expected on-disk paths for the shared range filter asset. Performs no I/O.
@@ -1381,13 +1380,29 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_models_dir_path() {
         let result = models_dir();
         assert!(result.is_ok());
 
         let path = result.unwrap();
-        assert!(path.to_string_lossy().contains("birda"));
+        // Under the CONFIG_DIR_ENV override the root is the caller's temp dir,
+        // which need not carry the app name; only the default layout does.
+        if std::env::var_os(crate::constants::CONFIG_DIR_ENV).is_none() {
+            assert!(path.to_string_lossy().contains("birda"));
+        }
         assert!(path.to_string_lossy().ends_with("models"));
+    }
+
+    #[test]
+    #[serial]
+    fn models_dir_honors_override() {
+        // Pins models_dir's override branch on Linux CI (issue #328): a dropped
+        // short-circuit would resolve to the real data dir and fail this.
+        let root = tempfile::TempDir::new().unwrap();
+        temp_env::with_var(crate::constants::CONFIG_DIR_ENV, Some(root.path()), || {
+            assert_eq!(models_dir().unwrap(), root.path().join("models"));
+        });
     }
 
     #[test]

--- a/tests/config_validation.rs
+++ b/tests/config_validation.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use birda::constants::CONFIG_DIR_ENV;
 
 /// These commands are local (no network, no ONNX runtime), so they should be
 /// quick. Bound them anyway so a hang fails rather than stalls the suite.
@@ -122,6 +123,10 @@ fn run_in_with_env(home: &Path, env: &[(&str, &str)], args: &[&str]) -> std::pro
     cmd.env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join("config"))
         .env("XDG_DATA_HOME", home.join("data"))
+        // The override is what actually isolates on Windows, where `directories`
+        // ignores HOME/XDG_*; it points the config dir (config.toml and the
+        // cached registry.json) and the models dir at `home` (issue #328).
+        .env(CONFIG_DIR_ENV, home)
         .timeout(COMMAND_TIMEOUT);
     for var in BIRDA_ENV_VARS {
         cmd.env_remove(var);

--- a/tests/geomodel_discoverability.rs
+++ b/tests/geomodel_discoverability.rs
@@ -25,6 +25,7 @@
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use birda::constants::CONFIG_DIR_ENV;
 use serde_json::Value;
 
 /// Registry commands are local, but `load_registry` can rewrite the cached
@@ -48,6 +49,10 @@ fn run_in(home: &std::path::Path, args: &[&str]) -> std::process::Output {
     cmd.env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join("config"))
         .env("XDG_DATA_HOME", home.join("data"))
+        // The override is what actually isolates on Windows, where `directories`
+        // ignores HOME/XDG_*; it points both the config dir (config.toml and the
+        // cached registry.json) and the models dir at `home` (issue #328).
+        .env(CONFIG_DIR_ENV, home)
         // `--output-mode` reads BIRDA_OUTPUT_MODE. A developer with that
         // exported turns every human-output assertion below into a failure, so
         // the isolation has to cover the environment, not just the filesystem.

--- a/tests/model_gallery_regional.rs
+++ b/tests/model_gallery_regional.rs
@@ -18,11 +18,66 @@
     clippy::float_cmp
 )]
 
-use assert_cmd::Command;
-use predicates::prelude::*;
+use std::sync::LazyLock;
 
+use assert_cmd::Command;
+use birda::constants::CONFIG_DIR_ENV;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// A throwaway config/data home shared by every test in this file.
+///
+/// Even the listing and reject-early cases reach `load_registry`, which
+/// bootstraps `registry.json` into the config directory on a cache miss and
+/// would otherwise read and write the developer's real profile (issue #328).
+/// The override isolates on every platform, unlike HOME/XDG which `directories`
+/// ignores on Windows.
+///
+/// The initializer primes the cache once, single-threaded, so the parallel
+/// tests below all find `registry.json` already present and none of them races
+/// to bootstrap it into the shared directory. The `TempDir` lives in the
+/// `LazyLock` so it outlives every command; that intentionally leaks one
+/// directory per test-binary run, which the OS temp reaper reclaims.
+///
+/// Every test here is read-only or rejects before writing, so one shared home
+/// is safe. A test that mutates state (a real install, `config set`) must use
+/// its own `TempDir` instead, or it would leak that state into its siblings.
+static ISOLATED_HOME: LazyLock<TempDir> = LazyLock::new(|| {
+    let home = TempDir::new().expect("create isolated home");
+    let primed = Command::cargo_bin("birda")
+        .expect("binary builds")
+        .env(CONFIG_DIR_ENV, home.path())
+        .env_remove("BIRDA_OUTPUT_MODE")
+        .args(["models", "list-available"])
+        .output()
+        .expect("birda should run");
+    assert!(
+        primed.status.success(),
+        "priming the registry cache failed: {}",
+        String::from_utf8_lossy(&primed.stderr)
+    );
+    // Priming exists for its side effect: registry.json must now be present
+    // under the override root (config_dir == home), or the parallel tests would
+    // each bootstrap it and race. Assert it landed, so a future change that made
+    // `list-available` stop caching fails loudly here instead of as an
+    // occasional torn-read flake.
+    assert!(
+        home.path().join("registry.json").exists(),
+        "priming did not create registry.json under the isolated home"
+    );
+    home
+});
+
+/// A birda invocation pinned to [`ISOLATED_HOME`].
+///
+/// `BIRDA_OUTPUT_MODE` is stripped because a developer with it exported would
+/// otherwise flip every human-output assertion in this file to JSON, the same
+/// scrub the sibling suites do.
 fn birda() -> Command {
-    Command::cargo_bin("birda").expect("binary builds")
+    let mut cmd = Command::cargo_bin("birda").expect("binary builds");
+    cmd.env(CONFIG_DIR_ENV, ISOLATED_HOME.path())
+        .env_remove("BIRDA_OUTPUT_MODE");
+    cmd
 }
 
 #[test]

--- a/tests/model_manifest.rs
+++ b/tests/model_manifest.rs
@@ -8,17 +8,18 @@
 // would only hide which assertion fired. The crate-level deny still governs
 // everything birda ships.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-// Isolation here rides on HOME / XDG_*, which `directories` honours on Linux and
-// macOS only. On Windows it resolves the config and data directories through
-// SHGetKnownFolderPath, which reads no environment variable, so the command
-// under test would read and rewrite the developer's real registry cache
-// (issue #328). The redirection only holds on Unix, so gate the suite to it;
-// CI runs on Linux, so coverage is unaffected.
-#![cfg(unix)]
+// Isolation rides on the BIRDA_CONFIG_DIR override (see `run` below), which
+// points the config and data directories at a temp dir on every platform. It
+// replaced a `#![cfg(unix)]` gate this suite carried because HOME / XDG_*
+// redirect `directories` on Unix only: on Windows it resolves the config and
+// data directories through SHGetKnownFolderPath, which reads no environment
+// variable, so the command under test would have read and rewritten the
+// developer's real registry cache (issue #328).
 
 use std::time::Duration;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use birda::constants::CONFIG_DIR_ENV;
 use serde_json::Value;
 
 /// `load_registry` can rewrite the cached registry, so keep commands bounded.
@@ -35,6 +36,10 @@ fn run(extra_env: &[(&str, &str)], args: &[&str]) -> std::process::Output {
     cmd.env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join("config"))
         .env("XDG_DATA_HOME", home.path().join("data"))
+        // The override is what actually isolates on Windows, where `directories`
+        // ignores HOME/XDG_*; it points the config dir (config.toml and the
+        // cached registry.json) and the models dir at `home` (issue #328).
+        .env(CONFIG_DIR_ENV, home.path())
         // `--output-mode` also reads BIRDA_OUTPUT_MODE; a developer with it
         // exported would flip the human-output assertions below.
         .env_remove("BIRDA_OUTPUT_MODE")


### PR DESCRIPTION
## What

Adds a `BIRDA_CONFIG_DIR` override so the integration suite can isolate its config and model directories on every platform, and routes the config/registry-writing test suites through it. Fixes #328.

## Why

birda's integration tests read the developer's real config directory, and on Windows a plain `cargo test` would rewrite it. The three suites that isolate today do so through `HOME` / `XDG_*`, which the `directories` crate honours on Linux and macOS but ignores on Windows (it resolves through `SHGetKnownFolderPath`). So on Windows those suites wrote the real `%APPDATA%\birda` profile, and `tests/model_manifest.rs` carried a `#![cfg(unix)]` gate for exactly this reason.

## How

- `config_dir()` and a new `data_dir()` honour `BIRDA_CONFIG_DIR` when it is set to a non-empty path, returning it as a single isolation root. `config_dir()` covers `config.toml` and the cached `registry.json`; `models_dir()` now builds on `data_dir()` and lands at `<root>/models`. The cache dir (regenerable TensorRT engines, untouched by tests) is deliberately excluded.
- Without the override, behaviour is byte-identical to before (the models path already used `data_dir().join("models")`; the literal `"birda"` is now `APP_NAME`).
- The three isolating suites set `.env(BIRDA_CONFIG_DIR, home)`, `model_manifest.rs` drops its `#![cfg(unix)]` gate, and `model_gallery_regional.rs` (whose `models` commands bootstrap `registry.json` via `load_registry`) gains a primed, shared isolation home.

## Scope

The remaining binary-spawning suites (`cli_output_integration`, `clip_integration_test`, `providers_command_test`, `stdout_integration`, `runtime_init_test`) never reach `load_registry`, so they are environment-dependent but not destructive. They are left for a follow-up; `cli_output_integration` additionally needs a test model provisioned before it can be isolated.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --no-default-features` all pass. New unit tests cover the override's empty/unset/verbatim handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `BIRDA_CONFIG_DIR` environment variable to redirect configuration, data, and model storage to a shared directory.
  * Added platform-independent configuration and data directory resolution.
  * Added a clear error message when the data directory cannot be determined.

* **Bug Fixes**
  * Model storage now consistently follows the configured data directory.
  * Improved isolation of configuration and model paths across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->