### PR TITLE
feat: auto-install bat embedding backbone and resolve --bat without -m

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,28 +573,34 @@ Birda supports bat species detection using [BattyBirdNET](https://github.com/rdz
 
 Bat echolocation calls are ultrasonic (20-120 kHz). BattyBirdNET exploits a "slow-down trick": 256 kHz bat recordings are fed directly to BirdNET without resampling. BirdNET's spectrogram pipeline (trained on 48 kHz bird audio) treats the samples as 48 kHz, shifting ultrasonic frequencies into the audible range where its learned features can extract useful embeddings. Regional bat classifiers then map these 1024-dim embeddings to bat species.
 
-### Prerequisites
+### Setup
 
-1. **BirdNET v2.4 with embeddings**: A patched model that exposes the embedding layer. Create it with [birdnet-onnx-converter](https://github.com/tphakala/birdnet-onnx-converter):
+Install a regional bat classifier. birda downloads the classifier and, on the
+first bat install, the shared BirdNET v2.4 embeddings backbone it runs on. Both
+are verified against published checksums. There is nothing to convert or place
+by hand.
 
-   ```bash
-   python expose_embeddings.py --input birdnet-v24.onnx --output birdnet-v24-embeddings.onnx
-   ```
+```bash
+# Downloads the EU classifier plus the shared embeddings backbone
+birda models install bat-eu
+```
 
-2. **Regional bat classifier models**: ONNX models converted from BattyBirdNET. Place them in the birda models directory:
-   - Linux: `~/.local/share/birda/models/bat/`
-   - macOS: `~/Library/Application Support/birda/models/bat/`
-   - Windows: `%APPDATA%\birda\models\bat\`
+List every region with `birda models list-available` (they appear under "Bat
+classifiers"), and see one with `birda models info bat-eu`. The install ids are
+`bat-<region>` (for example `bat-bavaria`, `bat-usa-east-high`).
 
 ### Usage
 
+Once a region is installed, `--bat <region>` is all you need: birda resolves the
+embeddings backbone automatically, so no `-m` is required.
+
 ```bash
 # Analyze bat recordings with the Bavaria classifier
-birda -m birdnet-v24-embeddings --bat bavaria bat_recording.wav
+birda --bat bavaria bat_recording.wav
 
-# Other available regions
-birda -m birdnet-v24-embeddings --bat uk bat_recording.wav
-birda -m birdnet-v24-embeddings --bat eu bat_recording.wav
+# Other installed regions
+birda --bat uk bat_recording.wav
+birda --bat eu bat_recording.wav
 ```
 
 ### Available Regions
@@ -622,7 +628,8 @@ birda -m birdnet-v24-embeddings --bat eu bat_recording.wav
 ### Notes
 
 - Bat mode overrides segment duration to 0.5625s (144,000 samples at 256 kHz) with 25% overlap
-- The backbone model must be BirdNET v2.4 with the embedding output exposed
+- The shared BirdNET v2.4 embeddings backbone installs automatically with the first bat region and is reused by the rest
+- Bat models are licensed CC-BY-NC-SA-4.0 (non-commercial); crediting BirdNET is required wherever they are used
 - All standard output formats are supported (CSV, Raven, Audacity, JSON, Parquet, Kaleidoscope)
 
 ## Performance Tips

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "registry_version": 7,
+  "registry_version": 8,
   "models": [
     {
       "id": "birdnet-v24",
@@ -5122,5 +5122,229 @@
       "sha256": "92cdca7ca95beb7ed16a0a39f4010fa9a8b468b854b6e8083f732647f136ee1c",
       "size_bytes": 479350
     }
+  },
+  "bat": {
+    "backbone": {
+      "id": "birdnet-v24-embeddings",
+      "name": "BirdNET v2.4 (embeddings backbone)",
+      "version": "2.4",
+      "vendor": "Cornell Lab of Ornithology & Chemnitz University of Technology",
+      "license": {
+        "type": "CC-BY-NC-SA-4.0",
+        "url": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+        "commercial_use": false,
+        "attribution_required": true,
+        "share_alike": true
+      },
+      "model": {
+        "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/birdnet-v2.4-embeddings-fp32-dfttrunc.onnx",
+        "filename": "birdnet-v24-embeddings.onnx",
+        "sha256": "b91139d3c63d55d742779a56531078bc88366a09bcc9bd6a9b703d425914c380",
+        "size_bytes": 58763257
+      },
+      "labels": {
+        "url": "https://github.com/tphakala/birda/raw/main/data/labels/birdnet_v2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt",
+        "filename": "birdnet-v24-embeddings-labels.txt",
+        "sha256": "487937b6ad132b8506215523209a87b86adc9dce8e5ed3048ce9268189dddd3d",
+        "size_bytes": 259894
+      }
+    },
+    "version": "1.0",
+    "license": {
+      "type": "CC-BY-NC-SA-4.0",
+      "url": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+      "commercial_use": false,
+      "attribution_required": true,
+      "share_alike": true
+    },
+    "regions": [
+      {
+        "region": "bavaria",
+        "name": "BattyBirdNET Bavaria",
+        "species_count": 32,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-Bavaria-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-Bavaria-256kHz_fp32.onnx",
+          "sha256": "7ee3936621d180b9fe42f3732703339662b154135ce205f711797bca7daa44ea",
+          "size_bytes": 131827
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-Bavaria-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-Bavaria-256kHz_Labels.txt",
+          "sha256": "ff4a3f9a351f202c8712c807c6bb8b29df0b1c75ddab48e543ec76a88a42715c",
+          "size_bytes": 966
+        }
+      },
+      {
+        "region": "bavaria-high",
+        "name": "BattyBirdNET Bavaria (high confidence)",
+        "species_count": 24,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-Bavaria-256kHz-high_fp32.onnx",
+          "filename": "BattyBirdNET-Bavaria-256kHz-high_fp32.onnx",
+          "sha256": "3d1d5bc174ed70bfc22a53439fe468a2a4aa317b755600d1e193cefbae307a30",
+          "size_bytes": 99026
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-Bavaria-256kHz-high_Labels.txt",
+          "filename": "BattyBirdNET-Bavaria-256kHz-high_Labels.txt",
+          "sha256": "26bc12ecf6c5ca9ce8837cd1bebe6e1cb2ce95f0261355a827383c85a0dd9d96",
+          "size_bytes": 904
+        }
+      },
+      {
+        "region": "eu",
+        "name": "BattyBirdNET EU",
+        "species_count": 30,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-EU-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-EU-256kHz_fp32.onnx",
+          "sha256": "f316073482ab95f48d65ca76e8b2aaa572019b3d286ab07a68ba57cea52d12f7",
+          "size_bytes": 123626
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-EU-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-EU-256kHz_Labels.txt",
+          "sha256": "9ad705d4bcd93040929a059854df968acebefee9f7513e97a558871c3997e65e",
+          "size_bytes": 1081
+        }
+      },
+      {
+        "region": "scotland",
+        "name": "BattyBirdNET Scotland",
+        "species_count": 11,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-Scotland-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-Scotland-256kHz_fp32.onnx",
+          "sha256": "003e3da16d3607d52dd5c963d71eec89fdfd58224dccc02bc6a27d58d21cbd85",
+          "size_bytes": 45725
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-Scotland-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-Scotland-256kHz_Labels.txt",
+          "sha256": "3dc657a38f691c20f351fa19e36b9919927aec2e30dc32f61ae9fd9bb319331b",
+          "size_bytes": 356
+        }
+      },
+      {
+        "region": "south-wales",
+        "name": "BattyBirdNET South Wales",
+        "species_count": 29,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-SouthWales-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-SouthWales-256kHz_fp32.onnx",
+          "sha256": "14534d34fc54b0bc267ba07a6eaddc10e360195b11d0c4b5f47460a4f1d5aea4",
+          "size_bytes": 119526
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-SouthWales-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-SouthWales-256kHz_Labels.txt",
+          "sha256": "fc7ed8bd55c28b66cdcecc8d8acb8ea05850d9301aa65467fd5d192ee00e8214",
+          "size_bytes": 1072
+        }
+      },
+      {
+        "region": "sweden",
+        "name": "BattyBirdNET Sweden",
+        "species_count": 23,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-Sweden-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-Sweden-256kHz_fp32.onnx",
+          "sha256": "85fe47431c275b5370e0c8d0aa9b049f54d32035f736afcec4ac5d62c1adb591",
+          "size_bytes": 94926
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-Sweden-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-Sweden-256kHz_Labels.txt",
+          "sha256": "c43042ebd458eed4cc7258fcd6526e0299a61e27146e3ca989300f696d1f2e02",
+          "size_bytes": 737
+        }
+      },
+      {
+        "region": "uk",
+        "name": "BattyBirdNET UK",
+        "species_count": 20,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-UK-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-UK-256kHz_fp32.onnx",
+          "sha256": "aa9d45a5e3e64b6c28a131d16a98346ee1095c2d4c9f4785e2ff1d5a6e4b27b6",
+          "size_bytes": 82625
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-UK-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-UK-256kHz_Labels.txt",
+          "sha256": "4cc63b7cfd0a8e4380857fc3f5d576e8ec48d80cbdc9060873abb20c4ef78740",
+          "size_bytes": 649
+        }
+      },
+      {
+        "region": "usa",
+        "name": "BattyBirdNET USA",
+        "species_count": 38,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-USA-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-USA-256kHz_fp32.onnx",
+          "sha256": "9230fb49c87b9953f311fa1d408eac8359a1c8761264204f51b796406bcfcc63",
+          "size_bytes": 156427
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-USA-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-USA-256kHz_Labels.txt",
+          "sha256": "3cf597702b5f0f558b227df3a01648da7eb52cc632ec70a148fd159763ba4399",
+          "size_bytes": 1222
+        }
+      },
+      {
+        "region": "usa-east",
+        "name": "BattyBirdNET USA East",
+        "species_count": 23,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-USA-EAST-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-USA-EAST-256kHz_fp32.onnx",
+          "sha256": "403901ce25c3daecdbd4d83017da8ff54c802f0feb78fc66355677f5c8905241",
+          "size_bytes": 94926
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-USA-EAST-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-USA-EAST-256kHz_Labels.txt",
+          "sha256": "db88ade98f2680af786911f1de49e5c29425335bbbc814c4a40c1e71ef888713",
+          "size_bytes": 663
+        }
+      },
+      {
+        "region": "usa-east-high",
+        "name": "BattyBirdNET USA East (high confidence)",
+        "species_count": 17,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-USA-EAST-256kHz-high_fp32.onnx",
+          "filename": "BattyBirdNET-USA-EAST-256kHz-high_fp32.onnx",
+          "sha256": "cb3fd538fb8adc87f775fad4fe5f9b3e1f56e78c5c7acd9abed4da7034e39772",
+          "size_bytes": 70325
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-USA-EAST-256kHz-high_Labels.txt",
+          "filename": "BattyBirdNET-USA-EAST-256kHz-high_Labels.txt",
+          "sha256": "438b01d917b3833f707cdf9e9d13f0b13eee2318ad23eeb34089b76b9f22e566",
+          "size_bytes": 613
+        }
+      },
+      {
+        "region": "usa-west",
+        "name": "BattyBirdNET USA West",
+        "species_count": 28,
+        "model": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/fp32/BattyBirdNET-USA-WEST-256kHz_fp32.onnx",
+          "filename": "BattyBirdNET-USA-WEST-256kHz_fp32.onnx",
+          "sha256": "d1d3573a379e9e8561a66dc27ab768342d7d3823268440ec9ab624b8fb4640fa",
+          "size_bytes": 115426
+        },
+        "labels": {
+          "url": "https://huggingface.co/tphakala/BattyBirdNET-onnx/resolve/main/labels/BattyBirdNET-USA-WEST-256kHz_Labels.txt",
+          "filename": "BattyBirdNET-USA-WEST-256kHz_Labels.txt",
+          "sha256": "f01a993b749f455636de5811e6ab9de96537f05dc191ec1919acf4365a6e6386",
+          "size_bytes": 867
+        }
+      }
+    ]
   }
 }

--- a/src/config/bat.rs
+++ b/src/config/bat.rs
@@ -38,6 +38,28 @@ pub enum BatRegion {
 }
 
 impl BatRegion {
+    /// Region slug, matching the `--bat` value and the `bat-<slug>` install id.
+    ///
+    /// Kept in sync with the `#[value(name = ...)]` attributes above so a
+    /// `bat-<slug>` install id round-trips through
+    /// [`parse_bat_install_id`](crate::registry::parse_bat_install_id) and back.
+    #[must_use]
+    pub fn slug(&self) -> &'static str {
+        match self {
+            Self::Bavaria => "bavaria",
+            Self::BavariaHigh => "bavaria-high",
+            Self::Eu => "eu",
+            Self::Scotland => "scotland",
+            Self::SouthWales => "south-wales",
+            Self::Sweden => "sweden",
+            Self::Uk => "uk",
+            Self::Usa => "usa",
+            Self::UsaEast => "usa-east",
+            Self::UsaEastHigh => "usa-east-high",
+            Self::UsaWest => "usa-west",
+        }
+    }
+
     /// Model filename stem for this region.
     #[must_use]
     pub fn model_stem(&self) -> &'static str {
@@ -165,5 +187,32 @@ mod tests {
     fn test_bat_config_resolve_missing_model() {
         let result = BatConfig::resolve(BatRegion::Uk, std::path::Path::new("/nonexistent"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_slug_matches_clap_value_name_for_every_region() {
+        use clap::ValueEnum;
+        for region in BatRegion::value_variants() {
+            let name = region
+                .to_possible_value()
+                .expect("every region has a value")
+                .get_name()
+                .to_string();
+            assert_eq!(
+                region.slug(),
+                name,
+                "slug() must match the clap --bat value so bat-<slug> round-trips"
+            );
+        }
+    }
+
+    #[test]
+    fn test_slug_round_trips_through_clap_from_str() {
+        use clap::ValueEnum;
+        for region in BatRegion::value_variants() {
+            let parsed = BatRegion::from_str(region.slug(), false)
+                .expect("slug must parse back to its region");
+            assert_eq!(*region, parsed);
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -350,6 +350,45 @@ pub enum Error {
     #[error("registry does not describe a range filter asset; update birda to a newer version")]
     RangeFilterAssetMissing,
 
+    /// Registry does not describe the bat detection catalog.
+    #[error("registry does not describe bat models; update birda to a newer version")]
+    BatCatalogMissing,
+
+    /// Registry has no entry for the requested bat region.
+    #[error("bat region '{region}' is not in the registry. Available: {available}")]
+    BatRegionNotInRegistry {
+        /// Region slug the user asked for.
+        region: String,
+        /// Comma-separated list of valid region slugs.
+        available: String,
+    },
+
+    /// Bat mode was requested but the embeddings backbone is not installed.
+    #[error("bat mode needs the BirdNET v2.4 embeddings backbone, which is not installed: {hint}")]
+    BatBackboneNotInstalled {
+        /// What the user should do next.
+        hint: String,
+    },
+
+    /// A bat region was requested but its classifier is not installed.
+    #[error(
+        "bat region '{region}' is not installed. Install it with 'birda models install bat-{region}'"
+    )]
+    BatRegionNotInstalled {
+        /// Region slug that is not installed.
+        region: String,
+    },
+
+    /// The model used as a bat backbone does not expose an embeddings output.
+    #[error(
+        "model '{model}' has no embeddings output, so it cannot be a bat backbone. \
+         Install the backbone with 'birda models install bat-<region>'"
+    )]
+    BatBackboneNoEmbeddings {
+        /// Name of the offending model.
+        model: String,
+    },
+
     /// The geomodel is not installed and could not be acquired.
     #[error("BirdNET Geomodel v3.0.2 is not installed: {hint}")]
     GeomodelNotInstalled {

--- a/src/gen_registry.rs
+++ b/src/gen_registry.rs
@@ -169,6 +169,10 @@ pub fn generate_from_repo_root(root: &str) -> Result<String> {
         registry_version: existing.registry_version,
         models,
         range_filter: existing.range_filter.clone(),
+        // Hand-maintained like `range_filter`: carried through verbatim so a
+        // `gen-registry` run never drops the bat catalog. Edits to it, including
+        // the `registry_version` bump, are made directly in `registry.json`.
+        bat: existing.bat.clone(),
     };
     registry.registry_version = next_registry_version(&registry, &existing);
 
@@ -357,6 +361,7 @@ mod tests {
             registry_version: version,
             models: Vec::new(),
             range_filter: None,
+            bat: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,14 +188,27 @@ fn resolve_model_config(args: &AnalyzeArgs, config: &Config) -> Result<(ModelCon
 /// [`Error::BatBackboneNotInstalled`] with the install command rather than
 /// letting `validate_model_files` report a bare missing-file path.
 fn resolve_bat_backbone_config(args: &AnalyzeArgs) -> Result<(ModelConfig, String)> {
-    // A custom backbone must bring its own labels; do not pair it with the
-    // registry's v2.4 labels.
-    if args.model_path.is_some() && args.labels_path.is_none() {
-        return Err(Error::ConfigValidation {
-            message: "--labels-path is required with --model-path in bat mode, because the \
-                      backbone's label count must match its prediction head"
-                .into(),
-        });
+    // In bat mode a custom backbone and its labels are all-or-nothing. Overriding
+    // only one is a config error: a custom model paired with the registry v2.4
+    // labels (or the registry backbone paired with custom labels) risks a
+    // label-count mismatch that fails classifier construction with a cryptic
+    // tensor-dimension error instead of this clean message.
+    match (args.model_path.is_some(), args.labels_path.is_some()) {
+        (true, false) => {
+            return Err(Error::ConfigValidation {
+                message: "--labels-path is required with --model-path in bat mode, because the \
+                          backbone's label count must match its prediction head"
+                    .into(),
+            });
+        }
+        (false, true) => {
+            return Err(Error::ConfigValidation {
+                message: "--model-path is required with --labels-path in bat mode; the registry \
+                          backbone's labels cannot be overridden on their own"
+                    .into(),
+            });
+        }
+        _ => {}
     }
 
     let registry = registry::load_registry()?;
@@ -474,8 +487,11 @@ pub fn run() -> Result<()> {
     let reporter: Arc<dyn ProgressReporter> = Arc::from(create_reporter(output_mode));
 
     // Initialize ONNX Runtime only for commands that will touch it. This keeps
-    // non-inference commands like `clip` working without a runtime install.
-    if command_requires_runtime(cli.command.as_ref(), cli.inputs.is_empty()) {
+    // non-inference commands like `clip` working without a runtime install. The
+    // analyze path is deliberately excluded here and initializes the runtime
+    // inside `analyze_files` AFTER validation, so config errors fail fast with
+    // an actionable message even without the runtime installed.
+    if command_requires_runtime(cli.command.as_ref()) {
         inference::ensure_runtime_available()?;
     }
 
@@ -551,17 +567,19 @@ fn command_requires_valid_config(command: Option<&Command>, has_no_inputs: bool)
     }
 }
 
-fn command_requires_runtime(command: Option<&Command>, has_no_inputs: bool) -> bool {
-    match command {
-        Some(
-            Command::Config { .. }
-            | Command::Models { .. }
-            | Command::Clip(_)
-            | Command::Update { .. },
-        ) => false,
-        Some(Command::Providers | Command::Species { .. }) => true,
-        None => !has_no_inputs,
-    }
+/// Whether the top-level command must initialize the ONNX runtime before it
+/// runs.
+///
+/// The default (analyze) path returns `false`: `analyze_files` initializes the
+/// runtime itself, AFTER model resolution and argument validation, so a config
+/// error (a missing bat backbone, or `--model-path` without `--labels-path`)
+/// surfaces with its actionable message even on a machine without the runtime,
+/// rather than a `libonnxruntime.so not found` error that hides the real cause.
+fn command_requires_runtime(command: Option<&Command>) -> bool {
+    // Only `providers` and `species` init the runtime up front. Everything else,
+    // including the default analyze path (`None`), does not: analyze defers to
+    // `analyze_files`, and config/clip/models/update never touch the runtime.
+    matches!(command, Some(Command::Providers | Command::Species { .. }))
 }
 
 fn validate_analyze_args_preflight(inputs: &[PathBuf], args: &AnalyzeArgs) -> Result<()> {
@@ -963,8 +981,10 @@ fn analyze_files(
     let (model_config, model_name) = resolve_model_config(args, config)?;
     validate_model_files(&model_config)?;
 
-    // Bat mode: validate backbone is BirdNET v2.4 and build custom classifier
-    let bat_classifier: Option<birdnet_onnx::CustomClassifier> = if let Some(region) = args.bat {
+    // Bat mode: validate the backbone family and resolve the region's files,
+    // BEFORE touching the runtime, so a wrong `-m` or an uninstalled region
+    // reports its own actionable error even on a machine without the runtime.
+    let bat_config: Option<crate::config::BatConfig> = if let Some(region) = args.bat {
         // Bat mode requires BirdNET v2.4 as the backbone (for embedding extraction)
         if model_config.model_type != ModelType::BirdnetV24 {
             return Err(Error::ConfigValidation {
@@ -980,7 +1000,7 @@ fn analyze_files(
         // A missing region head means that region was never installed; turn the
         // bare missing-file error into the actionable install hint, matching the
         // backbone's BatBackboneNotInstalled.
-        let bat_config = BatConfig::resolve(region, &bat_models_dir).map_err(|e| match e {
+        let resolved = BatConfig::resolve(region, &bat_models_dir).map_err(|e| match e {
             Error::ModelFileNotFound { .. } | Error::LabelsFileNotFound { .. } => {
                 Error::BatRegionNotInstalled {
                     region: region.slug().to_string(),
@@ -988,30 +1008,45 @@ fn analyze_files(
             }
             other => other,
         })?;
-
         info!(
             "Bat mode: region={}, classifier={}",
             region,
-            bat_config.classifier_path.display()
+            resolved.classifier_path.display()
         );
-
-        let cc = birdnet_onnx::CustomClassifier::builder()
-            .model_path(&bat_config.classifier_path)
-            .labels_path(&bat_config.labels_path)
-            .build()
-            .map_err(|e| Error::ClassifierBuild {
-                reason: format!("failed to build bat classifier: {e}"),
-            })?;
-
-        info!(
-            "Bat classifier loaded: {} classes, {}-dim embeddings",
-            cc.num_classes(),
-            cc.input_dim()
-        );
-
-        Some(cc)
+        Some(resolved)
     } else {
         None
+    };
+
+    // Initialize the ONNX runtime only after every cheap config, argument, and
+    // filesystem-presence check above has passed. Doing it here rather than in
+    // `run()` means a config error (a missing bat backbone, a wrong `-m` under
+    // `--bat`, an uninstalled region, `--model-path` without `--labels-path`)
+    // reports its actionable message even when the runtime is not installed,
+    // instead of a `libonnxruntime.so not found` error. Every classifier built
+    // below this line needs the runtime.
+    inference::ensure_runtime_available()?;
+
+    // Build the bat custom classifier from the already-resolved paths.
+    let bat_classifier: Option<birdnet_onnx::CustomClassifier> = match bat_config {
+        Some(bat_config) => {
+            let cc = birdnet_onnx::CustomClassifier::builder()
+                .model_path(&bat_config.classifier_path)
+                .labels_path(&bat_config.labels_path)
+                .build()
+                .map_err(|e| Error::ClassifierBuild {
+                    reason: format!("failed to build bat classifier: {e}"),
+                })?;
+
+            info!(
+                "Bat classifier loaded: {} classes, {}-dim embeddings",
+                cc.num_classes(),
+                cc.input_dim()
+            );
+
+            Some(cc)
+        }
+        None => None,
     };
 
     // Collect input files only after config is validated
@@ -2303,13 +2338,14 @@ fn handle_models_install(
     // report the id as an unknown model. An unrecognised region after the `bat-`
     // prefix gets a bat-specific error listing the valid regions.
     if let Some(slug) = id.strip_prefix(registry::BAT_INSTALL_PREFIX) {
+        // A registry predating bat support has no catalog at all; say so ("update
+        // birda") rather than reporting the region as unknown against an empty
+        // list.
+        let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
         let region =
             registry::parse_bat_install_id(id).ok_or_else(|| Error::BatRegionNotInRegistry {
                 region: slug.to_string(),
-                available: registry
-                    .bat
-                    .as_ref()
-                    .map_or_else(String::new, registry::BatCatalog::available_regions),
+                available: catalog.available_regions(),
             })?;
         return handle_bat_install(&registry, region, interactive, assume_yes, output_mode);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,38 +193,60 @@ fn resolve_bat_backbone_config(args: &AnalyzeArgs) -> Result<(ModelConfig, Strin
     // labels (or the registry backbone paired with custom labels) risks a
     // label-count mismatch that fails classifier construction with a cryptic
     // tensor-dimension error instead of this clean message.
-    match (args.model_path.is_some(), args.labels_path.is_some()) {
-        (true, false) => {
+    match (args.model_path.as_ref(), args.labels_path.as_ref()) {
+        (Some(_), None) => {
             return Err(Error::ConfigValidation {
                 message: "--labels-path is required with --model-path in bat mode, because the \
                           backbone's label count must match its prediction head"
                     .into(),
             });
         }
-        (false, true) => {
+        (None, Some(_)) => {
             return Err(Error::ConfigValidation {
                 message: "--model-path is required with --labels-path in bat mode; the registry \
                           backbone's labels cannot be overridden on their own"
                     .into(),
             });
         }
-        _ => {}
+        (Some(path), Some(labels)) => {
+            // A fully specified custom backbone. Do NOT touch the registry: the
+            // user supplied both files, so requiring a bat catalog here would
+            // wrongly reject a power user on a registry that predates bat support
+            // (the custom paths are all this run needs). `validate_model_files`
+            // checks the paths exist; `ensure_bat_backbone_has_embeddings`
+            // confirms the model exposes embeddings.
+            let model_config = ModelConfig {
+                registry_id: None,
+                installed_version: None,
+                installed_build: None,
+                region: None,
+                variant: None,
+                path: path.clone(),
+                labels: labels.clone(),
+                model_type: ModelType::BirdnetV24,
+                meta_model: None,
+                bsg_calibration: None,
+                bsg_migration: None,
+                bsg_distribution_maps: None,
+            };
+            return Ok((model_config, ADHOC_MODEL_NAME.to_string()));
+        }
+        (None, None) => {}
     }
 
+    // No overrides: use the registry-managed backbone.
     let registry = registry::load_registry()?;
     let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
     let backbone = &catalog.backbone;
     let paths = registry::bat_backbone_paths(backbone)?;
 
-    // Only vouch for the registry-managed backbone; a custom --model-path is the
-    // caller's responsibility and is checked by validate_model_files.
-    if args.model_path.is_none() && (!paths.model.is_file() || !paths.labels.is_file()) {
+    if !paths.model.is_file() || !paths.labels.is_file() {
         return Err(Error::BatBackboneNotInstalled {
             hint: "run 'birda models install bat-<region>' (for example, bat-eu)".to_string(),
         });
     }
 
-    let mut model_config = ModelConfig {
+    let model_config = ModelConfig {
         registry_id: Some(backbone.id.clone()),
         installed_version: Some(backbone.version.clone()),
         installed_build: None,
@@ -238,7 +260,6 @@ fn resolve_bat_backbone_config(args: &AnalyzeArgs) -> Result<(ModelConfig, Strin
         bsg_migration: None,
         bsg_distribution_maps: None,
     };
-    apply_model_overrides(&mut model_config, args);
     Ok((model_config, backbone.id.clone()))
 }
 
@@ -3177,6 +3198,60 @@ mod tests {
     /// Create default `AnalyzeArgs` (all None/false).
     fn default_args() -> AnalyzeArgs {
         AnalyzeArgs::default()
+    }
+
+    #[test]
+    fn test_resolve_bat_backbone_custom_paths_skip_the_registry() {
+        // Both overrides given: the custom backbone is used directly, with no
+        // registry lookup. `registry_id: None` proves the registry-managed
+        // backbone was not resolved, so this works even on a registry that
+        // predates bat support (the misleading BatCatalogMissing the reviewer
+        // flagged).
+        let args = AnalyzeArgs {
+            bat: Some(crate::config::BatRegion::Eu),
+            model_path: Some(std::path::PathBuf::from("/custom/backbone.onnx")),
+            labels_path: Some(std::path::PathBuf::from("/custom/labels.txt")),
+            ..default_args()
+        };
+        let (config, name) =
+            resolve_bat_backbone_config(&args).expect("a fully specified custom backbone resolves");
+        assert_eq!(
+            config.path,
+            std::path::PathBuf::from("/custom/backbone.onnx")
+        );
+        assert_eq!(
+            config.labels,
+            std::path::PathBuf::from("/custom/labels.txt")
+        );
+        assert_eq!(config.model_type, ModelType::BirdnetV24);
+        assert!(
+            config.registry_id.is_none(),
+            "a custom backbone is not a registry-managed model"
+        );
+        assert_eq!(name, ADHOC_MODEL_NAME);
+    }
+
+    #[test]
+    fn test_resolve_bat_backbone_rejects_a_lone_override() {
+        let only_model = AnalyzeArgs {
+            bat: Some(crate::config::BatRegion::Eu),
+            model_path: Some(std::path::PathBuf::from("/custom/backbone.onnx")),
+            ..default_args()
+        };
+        assert!(matches!(
+            resolve_bat_backbone_config(&only_model),
+            Err(Error::ConfigValidation { .. })
+        ));
+
+        let only_labels = AnalyzeArgs {
+            bat: Some(crate::config::BatRegion::Eu),
+            labels_path: Some(std::path::PathBuf::from("/custom/labels.txt")),
+            ..default_args()
+        };
+        assert!(matches!(
+            resolve_bat_backbone_config(&only_labels),
+            Err(Error::ConfigValidation { .. })
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,18 @@ fn resolve_model_config(args: &AnalyzeArgs, config: &Config) -> Result<(ModelCon
         return Ok((model_config, ADHOC_MODEL_NAME.to_string()));
     }
 
+    // Bat mode with no explicit model: the primary model is the shared BirdNET
+    // v2.4 embeddings backbone, resolved from the bat models directory. This
+    // runs BEFORE the config default on purpose. `defaults.model` is set by
+    // essentially every normal install, and a v2.4 or v3.0 default there would
+    // otherwise be loaded as the bat backbone and fail deep in inference (a
+    // plain v2.4 exposes no embeddings; v3.0/Perch fail the model-type check).
+    // Auto-resolving here is what makes `birda --bat <region> file.wav` work
+    // with nothing but the install.
+    if args.bat.is_some() {
+        return resolve_bat_backbone_config(args);
+    }
+
     // Priority 3: Implicit default model from config
     if let Some(ref name) = config.defaults.model {
         let mut model_config = config::get_model(config, name)?.clone();
@@ -158,6 +170,99 @@ fn resolve_model_config(args: &AnalyzeArgs, config: &Config) -> Result<(ModelCon
     Err(Error::ConfigValidation {
         message: "no model specified (use -m, set defaults.model in config, or provide --model-path with --labels-path and --model-type)".into(),
     })
+}
+
+/// Build the model configuration for bat mode's shared v2.4 embeddings backbone.
+///
+/// Bat detection is a two-stage pipeline whose primary model is a `BirdNET` v2.4
+/// export with its embedding layer exposed. The user never names it: installing
+/// any bat region places it at `<models_dir>/bat/`, and this resolves it from
+/// the registry so `--bat <region>` needs no `-m`.
+///
+/// A power user can still point `--model-path` at a custom backbone, but must
+/// then also pass `--labels-path`: the backbone's label count is model-specific
+/// (a stripped embeddings-only export has a different prediction head than the
+/// stock 6522-class v2.4), so silently pairing a custom model with the registry
+/// labels would crash at load with a tensor-dimension mismatch. When neither
+/// override is set and the backbone is not installed, this returns
+/// [`Error::BatBackboneNotInstalled`] with the install command rather than
+/// letting `validate_model_files` report a bare missing-file path.
+fn resolve_bat_backbone_config(args: &AnalyzeArgs) -> Result<(ModelConfig, String)> {
+    // A custom backbone must bring its own labels; do not pair it with the
+    // registry's v2.4 labels.
+    if args.model_path.is_some() && args.labels_path.is_none() {
+        return Err(Error::ConfigValidation {
+            message: "--labels-path is required with --model-path in bat mode, because the \
+                      backbone's label count must match its prediction head"
+                .into(),
+        });
+    }
+
+    let registry = registry::load_registry()?;
+    let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
+    let backbone = &catalog.backbone;
+    let paths = registry::bat_backbone_paths(backbone)?;
+
+    // Only vouch for the registry-managed backbone; a custom --model-path is the
+    // caller's responsibility and is checked by validate_model_files.
+    if args.model_path.is_none() && (!paths.model.is_file() || !paths.labels.is_file()) {
+        return Err(Error::BatBackboneNotInstalled {
+            hint: "run 'birda models install bat-<region>' (for example, bat-eu)".to_string(),
+        });
+    }
+
+    let mut model_config = ModelConfig {
+        registry_id: Some(backbone.id.clone()),
+        installed_version: Some(backbone.version.clone()),
+        installed_build: None,
+        region: None,
+        variant: None,
+        path: paths.model,
+        labels: paths.labels,
+        model_type: ModelType::BirdnetV24,
+        meta_model: None,
+        bsg_calibration: None,
+        bsg_migration: None,
+        bsg_distribution_maps: None,
+    };
+    apply_model_overrides(&mut model_config, args);
+    Ok((model_config, backbone.id.clone()))
+}
+
+/// Ensure a bat run's backbone actually exposes an embeddings output.
+///
+/// Bat mode discards the backbone's species predictions and classifies its
+/// embeddings, so a backbone with no embeddings output cannot work. Checking it
+/// the moment the classifier is built turns the cryptic per-segment "got 0 of N
+/// segments" failure from deep in the pipeline into one clear message before any
+/// audio is decoded. A no-op when bat mode is not requested.
+fn ensure_bat_backbone_has_embeddings(
+    bat_requested: bool,
+    config: &birdnet_onnx::ModelConfig,
+    model_name: &str,
+) -> Result<()> {
+    if bat_requested && config.embeddings_index.is_none() {
+        return Err(Error::BatBackboneNoEmbeddings {
+            model: model_name.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Look up a bat region entry by slug, or return the actionable
+/// [`Error::BatRegionNotInRegistry`] that names the bad region and lists the
+/// valid ones. Shared by the install, info, and analyze paths so they report an
+/// unknown region the same way.
+fn require_bat_region<'a>(
+    catalog: &'a registry::BatCatalog,
+    slug: &str,
+) -> Result<&'a registry::BatRegionEntry> {
+    catalog
+        .region(slug)
+        .ok_or_else(|| Error::BatRegionNotInRegistry {
+            region: slug.to_string(),
+            available: catalog.available_regions(),
+        })
 }
 
 /// Resolve the shared geomodel for range filtering, if it is wanted at all.
@@ -871,8 +976,18 @@ fn analyze_files(
         }
 
         // Resolve bat models directory: <data_dir>/models/bat/
-        let bat_models_dir = registry::models_dir()?.join("bat");
-        let bat_config = BatConfig::resolve(region, &bat_models_dir)?;
+        let bat_models_dir = registry::bat_models_dir()?;
+        // A missing region head means that region was never installed; turn the
+        // bare missing-file error into the actionable install hint, matching the
+        // backbone's BatBackboneNotInstalled.
+        let bat_config = BatConfig::resolve(region, &bat_models_dir).map_err(|e| match e {
+            Error::ModelFileNotFound { .. } | Error::LabelsFileNotFound { .. } => {
+                Error::BatRegionNotInstalled {
+                    region: region.slug().to_string(),
+                }
+            }
+            other => other,
+        })?;
 
         info!(
             "Bat mode: region={}, classifier={}",
@@ -1029,6 +1144,14 @@ fn analyze_files(
         range_filter_config,
         species_list,
     )?;
+
+    // Fail fast if bat mode's backbone exposes no embeddings output. Without
+    // this the run warms up, decodes, and only then dies per-file with the
+    // cryptic "bat mode requires embeddings from backbone, but got 0 of N
+    // segments" (see pipeline::processor). The backbone install guarantees a
+    // 2-output model; this catches a user who pointed --model-path at a plain
+    // single-output v2.4.
+    ensure_bat_backbone_has_embeddings(args.bat.is_some(), classifier.config(), &model_name)?;
 
     // Determine final batch size: user choice > smart default based on actual EP
     let batch_size = requested_batch_size.unwrap_or_else(|| {
@@ -1690,6 +1813,10 @@ fn handle_models_command(
                 .and_then(|dir| registry::find_stale_part_files(&dir))
                 .unwrap_or_default();
 
+            // Loaded once and shared by both the geomodel and bat checks below,
+            // rather than each re-parsing the ~200 KB registry.json.
+            let reg = registry::load_registry()?;
+
             // JSON/NDJSON output: collect all results then emit
             if output_mode.is_structured() {
                 let models: Vec<ModelCheckEntry> = config
@@ -1707,8 +1834,9 @@ fn handle_models_command(
                 let payload = ModelCheckPayload {
                     result_type: ResultType::ModelCheck,
                     models,
-                    geomodel: check_geomodel()?,
+                    geomodel: check_geomodel(&reg)?,
                     leftover_downloads,
+                    installed_bat: installed_bat_region_ids(&reg),
                 };
                 emit_json_result(&payload);
                 return Ok(());
@@ -1720,7 +1848,11 @@ fn handle_models_command(
                 println!("  {name}: OK");
             }
 
-            report_geomodel_status(&check_geomodel()?);
+            report_geomodel_status(&check_geomodel(&reg)?);
+            let installed_bat = installed_bat_region_ids(&reg);
+            if !installed_bat.is_empty() {
+                println!("  Bat classifiers: {} installed", installed_bat.join(", "));
+            }
             for path in &leftover_downloads {
                 println!(
                     "  {} is a leftover partial download (safe to remove if no download is running)",
@@ -1785,6 +1917,32 @@ fn handle_models_command(
                     );
                 } else {
                     registry::show_range_filter_info(asset);
+                }
+                return Ok(());
+            }
+
+            // Bat regions install under `bat-<region>` ids and live in
+            // `registry.bat`, so `find_model` below never matches them. Intercept
+            // the `bat-` prefix here (mirroring the install branch) so
+            // `models info bat-eu` works and `models info bat-<typo>` reports the
+            // valid regions rather than a generic unknown-model error.
+            if let Some(slug) = id.strip_prefix(registry::BAT_INSTALL_PREFIX) {
+                let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
+                let entry = require_bat_region(catalog, slug)?;
+                if output_mode.is_structured() {
+                    let payload = ModelInfoPayload {
+                        result_type: ResultType::ModelInfo,
+                        model: ModelDetails {
+                            id: format!("{}{}", registry::BAT_INSTALL_PREFIX, entry.region),
+                            model_type: "bat".to_string(),
+                            path: None,
+                            labels_path: None,
+                            source: "registry".to_string(),
+                        },
+                    };
+                    emit_json_result(&payload);
+                } else {
+                    registry::show_bat_info(catalog, entry);
                 }
                 return Ok(());
             }
@@ -1996,6 +2154,14 @@ fn handle_models_remove(
 ) -> Result<()> {
     use std::io::Write;
 
+    // Bat classifiers are not `config.models` entries (they install under
+    // `<models_dir>/bat/` and are selected with `--bat`), so the config-based
+    // removal below would fail for a `bat-<region>` id. Intercept it, mirroring
+    // the install and info dispatch.
+    if let Some(slug) = name.strip_prefix(registry::BAT_INSTALL_PREFIX) {
+        return handle_bat_remove(slug, output_mode, assume_yes);
+    }
+
     // Confirm before deleting files (skip in structured mode).
     //
     // `--yes` is honoured here because the flag is global and therefore appears
@@ -2130,6 +2296,22 @@ fn handle_models_install(
     // is used by every classifier rather than belonging to any one of them.
     if id == registry::GEOMODEL_INSTALL_ID {
         return handle_geomodel_install(&registry, interactive, assume_yes, output_mode);
+    }
+
+    // Bat regions install under `bat-<region>` ids. Intercepted before
+    // `find_model`, which knows nothing of the bat catalog and would otherwise
+    // report the id as an unknown model. An unrecognised region after the `bat-`
+    // prefix gets a bat-specific error listing the valid regions.
+    if let Some(slug) = id.strip_prefix(registry::BAT_INSTALL_PREFIX) {
+        let region =
+            registry::parse_bat_install_id(id).ok_or_else(|| Error::BatRegionNotInRegistry {
+                region: slug.to_string(),
+                available: registry
+                    .bat
+                    .as_ref()
+                    .map_or_else(String::new, registry::BatCatalog::available_regions),
+            })?;
+        return handle_bat_install(&registry, region, interactive, assume_yes, output_mode);
     }
 
     let model = registry::find_model(&registry, id)
@@ -2379,8 +2561,7 @@ fn handle_models_install(
 }
 
 /// Collect the status of the shared range filter for `birda models check`.
-fn check_geomodel() -> Result<output::GeomodelInfo> {
-    let registry = registry::load_registry()?;
+fn check_geomodel(registry: &registry::Registry) -> Result<output::GeomodelInfo> {
     let asset = registry
         .range_filter
         .as_ref()
@@ -2400,6 +2581,27 @@ fn check_geomodel() -> Result<output::GeomodelInfo> {
         labels_path: installed.then(|| paths.labels.clone()),
         obsolete_files,
     })
+}
+
+/// Install ids (`bat-<region>`) of the bat classifiers present on disk.
+///
+/// A region counts as installed only when its head, its labels, and the shared
+/// backbone are all present, which is what `--bat` needs to run. Returns empty
+/// when the registry has no bat catalog or none are installed.
+fn installed_bat_region_ids(registry: &registry::Registry) -> Vec<String> {
+    let Some(catalog) = registry.bat.as_ref() else {
+        return Vec::new();
+    };
+    catalog
+        .regions
+        .iter()
+        .filter_map(|region| {
+            let paths = registry::bat_paths(catalog, region).ok()?;
+            paths
+                .is_installed()
+                .then(|| format!("{}{}", registry::BAT_INSTALL_PREFIX, region.region))
+        })
+        .collect()
 }
 
 /// Print the shared range filter status for `birda models check`.
@@ -2476,10 +2678,215 @@ fn handle_geomodel_install(
     Ok(())
 }
 
+/// Install a bat regional classifier and its shared embeddings backbone.
+///
+/// Unlike a normal model install this writes nothing to `config.models` and
+/// never touches `defaults.model`: bat classifiers are selected with
+/// `--bat <region>`, which resolves the backbone and the head from
+/// `<models_dir>/bat/` directly. The backbone is installed once and reused by
+/// every region.
+fn handle_bat_install(
+    registry: &registry::Registry,
+    region: crate::config::BatRegion,
+    interactive: bool,
+    assume_yes: bool,
+    output_mode: OutputMode,
+) -> Result<()> {
+    let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
+    let entry = require_bat_region(catalog, region.slug())?;
+
+    // Bat heads and the backbone share BirdNET's CC BY-NC-SA terms; prompt once.
+    let vendor = "rdz-oss (BattyBirdNET-Analyzer), built on BirdNET";
+    let licensed = registry::LicensedAsset {
+        name: &entry.name,
+        vendor,
+        version: &catalog.version,
+        license: &catalog.license,
+    };
+    if !registry::prompt_license_acceptance(licensed, interactive, assume_yes)? {
+        if !output_mode.is_structured() {
+            println!("Installation cancelled.");
+        }
+        return Ok(());
+    }
+
+    if !output_mode.is_structured() {
+        // The backbone is a one-time ~56 MB download; only charge the user for it
+        // when it is not already present from an earlier region install.
+        let backbone_installed = registry::bat_backbone_paths(&catalog.backbone)
+            .is_ok_and(|p| p.model.is_file() && p.labels.is_file());
+        let head_size = registry::combined_size(entry.model.size_bytes, entry.labels.size_bytes);
+        let total = if backbone_installed {
+            head_size
+        } else {
+            let backbone_size = registry::combined_size(
+                catalog.backbone.model.size_bytes,
+                catalog.backbone.labels.size_bytes,
+            );
+            registry::combined_size(head_size, backbone_size)
+        };
+        println!(
+            "Installing {} ({} bat species, {} download).",
+            entry.name,
+            entry.species_count,
+            config::geomodel::human_size(total)
+        );
+        if !backbone_installed {
+            println!("  Includes the shared BirdNET v2.4 embeddings backbone.");
+        }
+        println!();
+    }
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| Error::Internal {
+        message: format!("Failed to create async runtime: {e}"),
+    })?;
+    let installed = runtime.block_on(registry::install_bat(catalog, entry))?;
+
+    if output_mode.is_structured() {
+        let payload = ModelInstalledPayload {
+            result_type: ResultType::ModelInstalled,
+            id: format!("{}{}", registry::BAT_INSTALL_PREFIX, region.slug()),
+            set_as_default: false,
+            model_path: installed.region_model,
+            labels_path: installed.region_labels,
+            region: Some(region.slug().to_string()),
+            variant: None,
+            selection_reason: None,
+        };
+        emit_json_result(&payload);
+    } else {
+        println!("Installation complete!");
+        println!();
+        println!("Model files saved to:");
+        println!("  {}", installed.region_model.display());
+        println!("  {}", installed.region_labels.display());
+        println!("  {}", installed.backbone_model.display());
+        println!("  {}", installed.backbone_labels.display());
+        println!();
+        println!("Ready to analyze:");
+        println!("  birda --bat {} recording.wav", region.slug());
+        println!();
+        println!("Powered by BirdNET (https://birdnet.cornell.edu/)");
+    }
+
+    Ok(())
+}
+
+/// Remove an installed bat regional classifier's files.
+///
+/// Bat classifiers write nothing to `config.models`, so removal is purely file
+/// deletion: the region head and its labels, plus the shared embeddings backbone
+/// when no other region still needs it. Confirms first unless `--yes` or a
+/// structured output mode is in effect, matching `handle_models_remove`.
+fn handle_bat_remove(slug: &str, output_mode: OutputMode, assume_yes: bool) -> Result<()> {
+    use std::io::Write;
+
+    let registry = registry::load_registry()?;
+    let catalog = registry.bat.as_ref().ok_or(Error::BatCatalogMissing)?;
+    let entry = require_bat_region(catalog, slug)?;
+    let paths = registry::bat_paths(catalog, entry)?;
+
+    if !output_mode.is_structured() && !assume_yes {
+        print!("This will delete bat classifier files for '{slug}' from disk. Continue? [y/N]: ");
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Removal cancelled.");
+            return Ok(());
+        }
+    }
+
+    // The shared backbone is deleted only when this was the last region using it,
+    // so removing one region never breaks another.
+    let backbone_still_needed = catalog.regions.iter().any(|r| {
+        r.region != entry.region
+            && registry::bat_paths(catalog, r)
+                .is_ok_and(|p| p.region_model.is_file() && p.region_labels.is_file())
+    });
+
+    let mut targets = vec![&paths.region_model, &paths.region_labels];
+    if !backbone_still_needed {
+        targets.push(&paths.backbone_model);
+        targets.push(&paths.backbone_labels);
+    }
+
+    let mut removed: Vec<PathBuf> = Vec::new();
+    let mut first_error: Option<(PathBuf, std::io::Error)> = None;
+    for file in targets {
+        if !file.is_file() {
+            continue;
+        }
+        match std::fs::remove_file(file) {
+            Ok(()) => {
+                if !output_mode.is_structured() {
+                    println!("  Deleted: {}", file.display());
+                }
+                removed.push(file.clone());
+            }
+            Err(e) if first_error.is_none() => first_error = Some((file.clone(), e)),
+            Err(_) => {}
+        }
+    }
+
+    if let Some((path, source)) = first_error {
+        return Err(Error::FileDeletionFailed { path, source });
+    }
+
+    if output_mode.is_structured() {
+        let payload = ModelRemovedPayload {
+            result_type: ResultType::ModelRemoved,
+            id: format!("{}{}", registry::BAT_INSTALL_PREFIX, entry.region),
+            purge_requested: true,
+            new_default: None,
+        };
+        emit_json_result(&payload);
+    } else if removed.is_empty() {
+        println!("Bat region '{slug}' was not installed; nothing to remove.");
+    } else {
+        println!("Removed bat region '{slug}'.");
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    /// A `birdnet_onnx::ModelConfig` shaped like the v2.4 backbone, with the
+    /// embeddings output present or absent.
+    fn backbone_model_config(embeddings_index: Option<usize>) -> birdnet_onnx::ModelConfig {
+        birdnet_onnx::ModelConfig {
+            model_type: birdnet_onnx::ModelType::BirdNetV24,
+            sample_rate: 48_000,
+            segment_duration: 3.0,
+            sample_count: 144_000,
+            num_species: 6522,
+            embedding_dim: embeddings_index.map(|_| 1024),
+            predictions_index: 0,
+            embeddings_index,
+        }
+    }
+
+    #[test]
+    fn test_ensure_bat_backbone_has_embeddings() {
+        // A 2-output backbone (embeddings present) is accepted in bat mode.
+        let with = backbone_model_config(Some(1));
+        assert!(ensure_bat_backbone_has_embeddings(true, &with, "backbone").is_ok());
+
+        // A 1-output v2.4 (no embeddings) fails fast in bat mode with the
+        // actionable error, instead of the cryptic per-segment failure later.
+        let without = backbone_model_config(None);
+        assert!(matches!(
+            ensure_bat_backbone_has_embeddings(true, &without, "backbone"),
+            Err(Error::BatBackboneNoEmbeddings { .. })
+        ));
+
+        // Outside bat mode the check is a no-op, even without embeddings.
+        assert!(ensure_bat_backbone_has_embeddings(false, &without, "backbone").is_ok());
+    }
 
     #[test]
     fn test_reclaim_stale_lock_removes_an_aged_lock_when_enabled() {

--- a/src/output/json_envelope.rs
+++ b/src/output/json_envelope.rs
@@ -527,6 +527,13 @@ pub struct AvailableModelsPayload {
     /// `None` when the registry predates the geomodel.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub available_range_filter: Option<AvailableRangeFilterEntry>,
+    /// The bat detection catalog, which is not one of `models`.
+    ///
+    /// Its own field for the same reason as `available_range_filter`: bat
+    /// classifiers are selected with `--bat <region>`, not `-m`. `None` when the
+    /// registry predates bat support.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_bat: Option<AvailableBatEntry>,
 }
 
 /// The shared range filter asset, as offered by `birda models list-available`.
@@ -558,6 +565,51 @@ pub struct AvailableRangeFilterEntry {
     /// would read as the whole download and understate it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_bytes: Option<u64>,
+}
+
+/// A single bat classifier region offered by `birda models list-available`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableBatRegionEntry {
+    /// The id to pass to `birda models install`, e.g. `bat-eu`.
+    pub id: String,
+    /// Region slug, e.g. `eu`, matching the `--bat` value.
+    pub region: String,
+    /// Display name.
+    pub name: String,
+    /// Number of bat species the head classifies.
+    pub species_count: usize,
+    /// Download size of the region head's model and labels, in bytes.
+    ///
+    /// The shared backbone is not counted here; see
+    /// [`AvailableBatEntry::backbone_size_bytes`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+}
+
+/// The bat detection catalog offered by `birda models list-available`.
+///
+/// Kept in its own field rather than folded into `models` for the same reason
+/// as [`AvailableRangeFilterEntry`]: bat classifiers are not selectable with
+/// `-m` (they are chosen with `--bat <region>`), so a consumer building a model
+/// picker from `models` must not offer them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableBatEntry {
+    /// Upstream `BattyBirdNET-Analyzer` version.
+    pub version: String,
+    /// License type (SPDX identifier).
+    pub license: String,
+    /// Whether commercial use is allowed.
+    pub commercial_use: bool,
+    /// Whether derivatives must be shared under the same license.
+    pub share_alike: bool,
+    /// One-time download size of the shared embeddings backbone, in bytes.
+    ///
+    /// Installed once and reused by every region, so it is reported apart from
+    /// the per-region sizes rather than added into each.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backbone_size_bytes: Option<u64>,
+    /// Installable regions.
+    pub regions: Vec<AvailableBatRegionEntry>,
 }
 
 /// A single available model from the registry.
@@ -598,6 +650,13 @@ pub struct ModelCheckPayload {
     /// download is visible; birda never deletes these automatically.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub leftover_downloads: Vec<PathBuf>,
+    /// Install ids of the bat classifiers present on disk, e.g. `bat-eu`.
+    ///
+    /// Bat classifiers are not `config.models` entries, so they never appear in
+    /// `models`. Reported here, like `geomodel`, so `models check` reflects a bat
+    /// install. Empty when none are installed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub installed_bat: Vec<String>,
 }
 
 /// Status of the shared `BirdNET` Geomodel range filter.
@@ -1043,6 +1102,7 @@ mod tests {
                 commercial_use: false,
             }],
             available_range_filter: None,
+            available_bat: None,
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
@@ -1088,6 +1148,7 @@ mod tests {
                 obsolete_files: Vec::new(),
             },
             leftover_downloads: vec![PathBuf::from("/models/birdnet-v30.onnx.4242.part")],
+            installed_bat: Vec::new(),
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let actual: serde_json::Value = serde_json::from_str(&json).expect("deserialize");
@@ -1132,6 +1193,7 @@ mod tests {
                 obsolete_files: Vec::new(),
             },
             leftover_downloads: Vec::new(),
+            installed_bat: Vec::new(),
         };
         let json = serde_json::to_string(&payload).expect("serialize");
         let value: serde_json::Value = serde_json::from_str(&json).expect("deserialize");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,16 +16,17 @@ pub use audacity::AudacityWriter;
 pub use csv::CsvWriter;
 pub use json::JsonResultWriter;
 pub use json_envelope::{
-    AvailableModelEntry, AvailableModelsPayload, AvailableRangeFilterEntry, BatchProgress,
-    BsgMetadata, CancelReason, CancelledPayload, ClipExtractionEntry, ClipExtractionFailure,
-    ClipExtractionPayload, ConfigPathPayload, ConfigPayload, DetectionInfo, DetectionsPayload,
-    DownloadProgress, ErrorPayload, ErrorSeverity, EventType, ExecutionProviderInfo,
-    FileCompletedPayload, FileErrorInfo, FileProgress, FileStartedPayload, FileStatus,
-    GeomodelInfo, JsonEnvelope, ManifestVariant, ModelCheckEntry, ModelCheckPayload, ModelDetails,
-    ModelEntry, ModelInfoPayload, ModelInstalledPayload, ModelListPayload, ModelManifest,
-    ModelManifestPayload, ModelRemovedPayload, PipelineCompletedPayload, PipelineStartedPayload,
-    PipelineStatus, ProgressPayload, ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType,
-    SPEC_VERSION, SpeciesEntry, SpeciesListPayload, VersionPayload,
+    AvailableBatEntry, AvailableBatRegionEntry, AvailableModelEntry, AvailableModelsPayload,
+    AvailableRangeFilterEntry, BatchProgress, BsgMetadata, CancelReason, CancelledPayload,
+    ClipExtractionEntry, ClipExtractionFailure, ClipExtractionPayload, ConfigPathPayload,
+    ConfigPayload, DetectionInfo, DetectionsPayload, DownloadProgress, ErrorPayload, ErrorSeverity,
+    EventType, ExecutionProviderInfo, FileCompletedPayload, FileErrorInfo, FileProgress,
+    FileStartedPayload, FileStatus, GeomodelInfo, JsonEnvelope, ManifestVariant, ModelCheckEntry,
+    ModelCheckPayload, ModelDetails, ModelEntry, ModelInfoPayload, ModelInstalledPayload,
+    ModelListPayload, ModelManifest, ModelManifestPayload, ModelRemovedPayload,
+    PipelineCompletedPayload, PipelineStartedPayload, PipelineStatus, ProgressPayload,
+    ProviderInfo, ProvidersPayload, RangeFilterInfo, ResultType, SPEC_VERSION, SpeciesEntry,
+    SpeciesListPayload, VersionPayload,
 };
 pub use kaleidoscope::KaleidoscopeWriter;
 pub use parquet::{ParquetWriter, combine_parquet_files};

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -475,7 +475,6 @@ impl InstalledBat {
     }
 }
 
-/// Expected on-disk paths for the shared bat backbone. Performs no I/O.
 /// Paths to the shared bat embeddings backbone files. Performs no I/O.
 ///
 /// A named pair rather than a bare `(PathBuf, PathBuf)`, matching the
@@ -489,9 +488,31 @@ pub struct BatBackbonePaths {
     pub labels: PathBuf,
 }
 
+/// Reject a registry filename that is not a single, plain path component.
+///
+/// `FileInfo.filename` is deserialized from a user-writable `registry.json`, and
+/// [`bat_paths`]/[`bat_backbone_paths`] join it under `<models_dir>/bat`. A
+/// filename with an absolute root, a `..`, or nested components could otherwise
+/// steer a download destination outside that directory, where
+/// [`download_verified`] would create or replace a file. The registry is a local
+/// user-cache trust boundary, so this guards local file integrity, not a
+/// cross-user privilege bypass.
+fn validate_bat_filename(name: &str) -> Result<()> {
+    use std::path::Component;
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(Error::ConfigValidation {
+            message: format!("invalid bat model filename in registry: {name:?}"),
+        }),
+    }
+}
+
 /// Expected on-disk paths for the shared bat backbone. Performs no I/O.
 pub fn bat_backbone_paths(backbone: &BatBackbone) -> Result<BatBackbonePaths> {
     let dir = bat_models_dir()?;
+    validate_bat_filename(&backbone.model.filename)?;
+    validate_bat_filename(&backbone.labels.filename)?;
     Ok(BatBackbonePaths {
         model: dir.join(&backbone.model.filename),
         labels: dir.join(&backbone.labels.filename),
@@ -509,6 +530,8 @@ pub fn bat_backbone_paths(backbone: &BatBackbone) -> Result<BatBackbonePaths> {
 /// [`BatConfig::resolve`]: crate::config::BatConfig::resolve
 pub fn bat_paths(catalog: &BatCatalog, region: &BatRegionEntry) -> Result<InstalledBat> {
     let dir = bat_models_dir()?;
+    validate_bat_filename(&region.model.filename)?;
+    validate_bat_filename(&region.labels.filename)?;
     let backbone = bat_backbone_paths(&catalog.backbone)?;
     Ok(InstalledBat {
         region_model: dir.join(&region.model.filename),
@@ -1321,6 +1344,27 @@ mod tests {
                 missing.display()
             );
             std::fs::write(missing, b"x").unwrap();
+        }
+    }
+
+    #[test]
+    fn test_validate_bat_filename_accepts_plain_and_rejects_traversal() {
+        assert!(validate_bat_filename("BattyBirdNET-EU-256kHz_fp32.onnx").is_ok());
+        assert!(validate_bat_filename("birdnet-v24-embeddings.onnx").is_ok());
+        // A tampered registry must not steer a download outside the bat dir.
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../evil.onnx",
+            "/etc/passwd",
+            "sub/dir.onnx",
+            "a/../b.onnx",
+        ] {
+            assert!(
+                validate_bat_filename(bad).is_err(),
+                "{bad:?} must be rejected as a bat filename"
+            );
         }
     }
 

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -1,6 +1,8 @@
 //! Model download and installation logic.
 
-use super::types::{ModelEntry, ModelVariant, RangeFilterAsset};
+use super::types::{
+    BatBackbone, BatCatalog, BatRegionEntry, FileInfo, ModelEntry, ModelVariant, RangeFilterAsset,
+};
 use crate::error::{Error, Result};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -423,6 +425,166 @@ fn verify_or_remove(paths: &InstalledRangeFilter, asset: &RangeFilterAsset) -> R
         return Err(e);
     }
     Ok(())
+}
+
+/// Prefix on a `models install` id that selects a bat regional classifier,
+/// e.g. `bat-bavaria` or `bat-usa-east-high`.
+pub const BAT_INSTALL_PREFIX: &str = "bat-";
+
+/// Parse a `models install` id of the form `bat-<region>` into a [`BatRegion`].
+///
+/// Returns `None` for ids without the `bat-` prefix and for a prefix followed by
+/// an unknown region, so the caller can fall through to normal model resolution
+/// or report the unknown region.
+///
+/// [`BatRegion`]: crate::config::BatRegion
+#[must_use]
+pub fn parse_bat_install_id(id: &str) -> Option<crate::config::BatRegion> {
+    use clap::ValueEnum;
+    let slug = id.strip_prefix(BAT_INSTALL_PREFIX)?;
+    crate::config::BatRegion::from_str(slug, false).ok()
+}
+
+/// The directory holding installed bat models: `<models_dir>/bat/`.
+pub fn bat_models_dir() -> Result<PathBuf> {
+    Ok(models_dir()?.join("bat"))
+}
+
+/// Paths to an installed bat region and its shared backbone, all under
+/// `<models_dir>/bat/`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledBat {
+    /// Regional classifier head ONNX file.
+    pub region_model: PathBuf,
+    /// Regional classifier labels file.
+    pub region_labels: PathBuf,
+    /// Shared embeddings backbone ONNX file.
+    pub backbone_model: PathBuf,
+    /// Backbone (v2.4) labels file.
+    pub backbone_labels: PathBuf,
+}
+
+impl InstalledBat {
+    /// Whether all four files are present on disk.
+    #[must_use]
+    pub fn is_installed(&self) -> bool {
+        self.region_model.is_file()
+            && self.region_labels.is_file()
+            && self.backbone_model.is_file()
+            && self.backbone_labels.is_file()
+    }
+}
+
+/// Expected on-disk paths for the shared bat backbone. Performs no I/O.
+/// Paths to the shared bat embeddings backbone files. Performs no I/O.
+///
+/// A named pair rather than a bare `(PathBuf, PathBuf)`, matching the
+/// [`InstalledRangeFilter`] sibling, so callers cannot silently transpose the
+/// model and labels (both are `PathBuf`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatBackbonePaths {
+    /// Backbone ONNX file.
+    pub model: PathBuf,
+    /// Backbone (v2.4) labels file.
+    pub labels: PathBuf,
+}
+
+/// Expected on-disk paths for the shared bat backbone. Performs no I/O.
+pub fn bat_backbone_paths(backbone: &BatBackbone) -> Result<BatBackbonePaths> {
+    let dir = bat_models_dir()?;
+    Ok(BatBackbonePaths {
+        model: dir.join(&backbone.model.filename),
+        labels: dir.join(&backbone.labels.filename),
+    })
+}
+
+/// Expected on-disk paths for a bat region and the shared backbone. No I/O.
+///
+/// The region filenames come from the registry and are chosen to match
+/// [`BatRegion::model_filename`]/[`BatRegion::labels_filename`], so the files
+/// this installs are the exact ones [`BatConfig::resolve`] later looks for.
+///
+/// [`BatRegion::model_filename`]: crate::config::BatRegion::model_filename
+/// [`BatRegion::labels_filename`]: crate::config::BatRegion::labels_filename
+/// [`BatConfig::resolve`]: crate::config::BatConfig::resolve
+pub fn bat_paths(catalog: &BatCatalog, region: &BatRegionEntry) -> Result<InstalledBat> {
+    let dir = bat_models_dir()?;
+    let backbone = bat_backbone_paths(&catalog.backbone)?;
+    Ok(InstalledBat {
+        region_model: dir.join(&region.model.filename),
+        region_labels: dir.join(&region.labels.filename),
+        backbone_model: backbone.model,
+        backbone_labels: backbone.labels,
+    })
+}
+
+/// Verify a downloaded file against its registry checksum, if one is declared.
+///
+/// A file whose entry carries no checksum is accepted as-is, matching
+/// [`InstalledRangeFilter::verify`].
+fn verify_bat_file(path: &Path, info: &FileInfo) -> Result<()> {
+    if let Some(sum) = info.sha256.as_deref() {
+        crate::update::checksum::verify_sha256(path, sum)?;
+    }
+    Ok(())
+}
+
+/// Download `file` to `dest` unless a valid copy is already there.
+///
+/// Skips the download when `dest` exists and its checksum matches, so a repeat
+/// install, or a partial install where only some files are missing, re-fetches
+/// only what is absent or corrupt rather than everything (a missing tiny labels
+/// file no longer forces a fresh ~56 MB backbone download). A read error on an
+/// existing file is surfaced rather than treated as corruption, since
+/// re-downloading will not fix a failing disk; only a genuine checksum mismatch
+/// forces a fresh download. [`download_verified`] verifies the part file before
+/// the atomic rename, so a corrupt download never overwrites a good file.
+async fn download_if_needed(client: &Client, file: &FileInfo, dest: &Path) -> Result<()> {
+    if dest.is_file() {
+        match verify_bat_file(dest, file) {
+            Ok(()) => return Ok(()),
+            Err(e) if !crate::update::checksum::is_checksum_mismatch(&e) => return Err(e),
+            Err(_) => {}
+        }
+    }
+    download_verified(client, &file.url, dest, file.sha256.as_deref()).await
+}
+
+/// Download and verify the shared bat embeddings backbone.
+///
+/// Idempotent per file: a valid model or labels file already on disk is left
+/// untouched (see [`download_if_needed`]), so a partial install re-fetches only
+/// the missing part.
+pub async fn install_bat_backbone(backbone: &BatBackbone) -> Result<BatBackbonePaths> {
+    let paths = bat_backbone_paths(backbone)?;
+    let dir = bat_models_dir()?;
+    std::fs::create_dir_all(&dir).map_err(Error::Io)?;
+    let client = http_client()?;
+
+    download_if_needed(&client, &backbone.model, &paths.model).await?;
+    download_if_needed(&client, &backbone.labels, &paths.labels).await?;
+
+    Ok(paths)
+}
+
+/// Install a bat regional classifier and its shared embeddings backbone.
+///
+/// The backbone is installed first (and idempotently, so a second region reuses
+/// the one ~56 MB download). Every file, backbone and head alike, goes through
+/// [`download_if_needed`], which skips a file already present and valid and
+/// re-fetches only what is missing or corrupt, so a repeat or partial install is
+/// cheap and self-healing.
+pub async fn install_bat(catalog: &BatCatalog, region: &BatRegionEntry) -> Result<InstalledBat> {
+    // Also creates the bat models directory that the region files land in.
+    install_bat_backbone(&catalog.backbone).await?;
+
+    let paths = bat_paths(catalog, region)?;
+    let client = http_client()?;
+
+    download_if_needed(&client, &region.model, &paths.region_model).await?;
+    download_if_needed(&client, &region.labels, &paths.region_labels).await?;
+
+    Ok(paths)
 }
 
 /// Report files in the models directory that birda no longer uses.
@@ -1019,6 +1181,168 @@ mod tests {
             paths.labels.parent(),
             "both files live in the models directory"
         );
+    }
+
+    fn test_bat_catalog() -> BatCatalog {
+        let nc = LicenseInfo {
+            r#type: "CC-BY-NC-SA-4.0".into(),
+            url: "https://creativecommons.org/licenses/by-nc-sa/4.0/".into(),
+            commercial_use: false,
+            attribution_required: true,
+            share_alike: true,
+        };
+        let file = |name: &str| FileInfo {
+            url: format!("https://example.com/{name}"),
+            filename: name.into(),
+            sha256: Some(RIGHT_SHA256.into()),
+            size_bytes: Some(1),
+        };
+        BatCatalog {
+            backbone: BatBackbone {
+                id: "birdnet-v24-embeddings".into(),
+                name: "BirdNET v2.4 (embeddings backbone)".into(),
+                version: "2.4".into(),
+                vendor: "Cornell Lab".into(),
+                license: nc.clone(),
+                model: file("birdnet-v24-embeddings.onnx"),
+                labels: file("birdnet-v24-embeddings-labels.txt"),
+            },
+            version: "1.0".into(),
+            license: nc,
+            regions: vec![BatRegionEntry {
+                region: "eu".into(),
+                name: "BattyBirdNET EU".into(),
+                species_count: 30,
+                model: file("BattyBirdNET-EU-256kHz_fp32.onnx"),
+                labels: file("BattyBirdNET-EU-256kHz_Labels.txt"),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_parse_bat_install_id() {
+        use crate::config::BatRegion;
+        assert_eq!(parse_bat_install_id("bat-eu"), Some(BatRegion::Eu));
+        assert_eq!(
+            parse_bat_install_id("bat-usa-east-high"),
+            Some(BatRegion::UsaEastHigh),
+            "a multi-hyphen region slug must parse whole, not stop at the first dash"
+        );
+        assert_eq!(parse_bat_install_id("bat-nope"), None);
+        assert_eq!(parse_bat_install_id("bat-"), None);
+        assert_eq!(parse_bat_install_id("perch-v2"), None);
+        assert_eq!(parse_bat_install_id(GEOMODEL_INSTALL_ID), None);
+    }
+
+    #[test]
+    fn test_bat_paths_use_registry_filenames_under_bat_dir() {
+        let catalog = test_bat_catalog();
+        let entry = &catalog.regions[0];
+        let paths = bat_paths(&catalog, entry).unwrap();
+
+        // Region filenames must match what BatConfig::resolve looks for.
+        assert!(
+            paths
+                .region_model
+                .ends_with("BattyBirdNET-EU-256kHz_fp32.onnx")
+        );
+        assert!(
+            paths
+                .region_labels
+                .ends_with("BattyBirdNET-EU-256kHz_Labels.txt")
+        );
+        assert!(
+            paths
+                .backbone_model
+                .ends_with("birdnet-v24-embeddings.onnx")
+        );
+        assert!(
+            paths
+                .backbone_labels
+                .ends_with("birdnet-v24-embeddings-labels.txt")
+        );
+
+        // All four files live in <models_dir>/bat/.
+        for p in [
+            &paths.region_model,
+            &paths.region_labels,
+            &paths.backbone_model,
+            &paths.backbone_labels,
+        ] {
+            assert_eq!(
+                p.parent().and_then(|d| d.file_name()),
+                Some(std::ffi::OsStr::new("bat")),
+                "{} must be under the bat directory",
+                p.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_bat_region_model_filenames_match_batregion_naming() {
+        // The registry filenames the installer writes must be exactly what
+        // BatConfig::resolve later reads, or an install would look successful yet
+        // never be found. Assert the two derivations agree for the fixture region.
+        let catalog = test_bat_catalog();
+        let entry = &catalog.regions[0];
+        let region = crate::config::BatRegion::Eu;
+        assert_eq!(entry.model.filename, region.model_filename());
+        assert_eq!(entry.labels.filename, region.labels_filename());
+    }
+
+    #[test]
+    fn test_installed_bat_is_installed_requires_all_four_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = |name: &str| dir.path().join(name);
+        let installed = InstalledBat {
+            region_model: p("head.onnx"),
+            region_labels: p("head_labels.txt"),
+            backbone_model: p("backbone.onnx"),
+            backbone_labels: p("backbone_labels.txt"),
+        };
+        let all = [
+            installed.region_model.clone(),
+            installed.region_labels.clone(),
+            installed.backbone_model.clone(),
+            installed.backbone_labels.clone(),
+        ];
+        for f in &all {
+            std::fs::write(f, b"x").unwrap();
+        }
+        assert!(installed.is_installed(), "all four present");
+        // Each file individually absent must read as not installed, so a region
+        // is never reported ready with the shared backbone (or its own labels)
+        // missing.
+        for missing in &all {
+            std::fs::remove_file(missing).unwrap();
+            assert!(
+                !installed.is_installed(),
+                "{} missing must read as not installed",
+                missing.display()
+            );
+            std::fs::write(missing, b"x").unwrap();
+        }
+    }
+
+    #[test]
+    fn test_verify_bat_file_matches_mismatches_and_accepts_absent_checksum() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"right").unwrap();
+        let info = |sha: Option<&str>| FileInfo {
+            url: "https://example.com/f".into(),
+            filename: "f".into(),
+            sha256: sha.map(String::from),
+            size_bytes: None,
+        };
+
+        // Declared checksum matches the bytes.
+        assert!(verify_bat_file(&file, &info(Some(RIGHT_SHA256))).is_ok());
+        // Declared checksum does not match -> a checksum-mismatch error.
+        let err = verify_bat_file(&file, &info(Some(&"0".repeat(64)))).unwrap_err();
+        assert!(crate::update::checksum::is_checksum_mismatch(&err));
+        // No checksum declared -> accepted as-is.
+        assert!(verify_bat_file(&file, &info(None)).is_ok());
     }
 
     #[test]

--- a/src/registry/loader.rs
+++ b/src/registry/loader.rs
@@ -290,6 +290,7 @@ mod tests {
             schema_version: "1.0".into(),
             registry_version: version,
             range_filter: None,
+            bat: None,
             models: vec![],
         }
     }
@@ -659,6 +660,7 @@ mod tests {
             schema_version: "1.0".into(),
             registry_version: 0,
             range_filter: None,
+            bat: None,
             models: vec![
                 ModelEntry {
                     id: "test-1".into(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -12,9 +12,11 @@ pub mod types;
 // Re-export commonly used types and functions
 pub use cleanup::{orphaned_files, remove_orphans};
 pub use installer::{
-    GEOMODEL_INSTALL_ID, InstallProvenance, InstalledRangeFilter, download_file,
-    find_obsolete_files, find_stale_part_files, geomodel_paths, install_model,
-    install_range_filter, install_variant, models_dir, resolve_url,
+    BAT_INSTALL_PREFIX, BatBackbonePaths, GEOMODEL_INSTALL_ID, InstallProvenance, InstalledBat,
+    InstalledRangeFilter, bat_backbone_paths, bat_models_dir, bat_paths, download_file,
+    find_obsolete_files, find_stale_part_files, geomodel_paths, install_bat, install_bat_backbone,
+    install_model, install_range_filter, install_variant, models_dir, parse_bat_install_id,
+    resolve_url,
 };
 pub use license::{LicensedAsset, prompt_license_acceptance};
 pub use loader::{find_model, load_registry};
@@ -24,8 +26,8 @@ pub use loader::{find_model, load_registry};
 // how a variant is chosen, not part of the gallery's surface.
 pub use selection::{SystemProbe, select_variant};
 pub use types::{
-    Countries, FileInfo, LabelsInfo, LanguageVariant, LicenseInfo, ModelEntry, ModelFiles,
-    ModelVariant, RangeFilterAsset, Registry,
+    BatBackbone, BatCatalog, BatRegionEntry, Countries, FileInfo, LabelsInfo, LanguageVariant,
+    LicenseInfo, ModelEntry, ModelFiles, ModelVariant, RangeFilterAsset, Registry,
 };
 
 use crate::error::{Error, Result};
@@ -57,6 +59,7 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
             result_type: ResultType::AvailableModels,
             models,
             available_range_filter: registry.range_filter.as_ref().map(available_range_filter),
+            available_bat: registry.bat.as_ref().map(available_bat),
         };
         emit_json_result(&payload);
         return;
@@ -97,7 +100,58 @@ pub fn list_available(registry: &Registry, output_mode: crate::config::OutputMod
         println!();
     }
 
+    // Bat classifiers live in `registry.bat`, not `registry.models`, and are
+    // selected with `--bat <region>`. Listing their `bat-<region>` install ids
+    // here is what makes them discoverable at all.
+    if let Some(catalog) = registry.bat.as_ref() {
+        println!("Bat classifiers (install with the id shown, then run with --bat <region>):");
+        println!();
+        for region in &catalog.regions {
+            println!("  {}{}", BAT_INSTALL_PREFIX, region.region);
+            println!("    {} ({} bat species)", region.name, region.species_count);
+        }
+        println!(
+            "    License: {} (shared embeddings backbone installed automatically)",
+            license_line(&catalog.license)
+        );
+        println!();
+    }
+
     println!("Run 'birda models info <id>' for details.");
+}
+
+/// Project the bat catalog into its structured-output shape.
+fn available_bat(catalog: &BatCatalog) -> crate::output::AvailableBatEntry {
+    let backbone_size_bytes = combined_size(
+        catalog.backbone.model.size_bytes,
+        catalog.backbone.labels.size_bytes,
+    );
+    let regions = catalog
+        .regions
+        .iter()
+        .map(|r| crate::output::AvailableBatRegionEntry {
+            id: format!("{BAT_INSTALL_PREFIX}{}", r.region),
+            region: r.region.clone(),
+            name: r.name.clone(),
+            species_count: r.species_count,
+            size_bytes: combined_size(r.model.size_bytes, r.labels.size_bytes),
+        })
+        .collect();
+    crate::output::AvailableBatEntry {
+        version: catalog.version.clone(),
+        license: catalog.license.r#type.clone(),
+        commercial_use: catalog.license.commercial_use,
+        share_alike: catalog.license.share_alike,
+        backbone_size_bytes,
+        regions,
+    }
+}
+
+/// Sum two optional file sizes, yielding `None` unless both are present and
+/// their sum fits in `u64`. A partial total would understate the download, so a
+/// missing part collapses the whole to `None`, matching `total_download_size`.
+pub(crate) fn combined_size(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    a.and_then(|x| b.and_then(|y| x.checked_add(y)))
 }
 
 /// Render a variant's class count, or say the publisher did not state one.
@@ -160,9 +214,7 @@ fn available_range_filter(asset: &RangeFilterAsset) -> crate::output::AvailableR
 /// about is the total. Returns `None` unless both sizes are declared, rather
 /// than reporting a half-total that reads as the whole.
 fn total_download_size(asset: &RangeFilterAsset) -> Option<u64> {
-    let model = asset.model.size_bytes?;
-    let labels = asset.labels.size_bytes?;
-    model.checked_add(labels)
+    combined_size(asset.model.size_bytes, asset.labels.size_bytes)
 }
 
 /// Render the shared range filter asset for `birda models info geomodel`.
@@ -228,6 +280,73 @@ pub fn show_range_filter_info(asset: &RangeFilterAsset) {
     println!();
 
     println!("To install: birda models install {GEOMODEL_INSTALL_ID}");
+}
+
+/// Render a bat region for `birda models info bat-<region>`.
+///
+/// Separate from [`show_info`] because a bat classifier is not a [`ModelEntry`]:
+/// it is a head selected with `--bat <region>`, not `-m`, and it runs on a
+/// shared embeddings backbone that installs alongside it.
+pub fn show_bat_info(catalog: &BatCatalog, entry: &BatRegionEntry) {
+    println!("Bat classifier: {}", entry.name);
+    println!("ID: {BAT_INSTALL_PREFIX}{}", entry.region);
+    println!("Version: {}", catalog.version);
+    println!();
+
+    println!("Description:");
+    println!(
+        "  Identifies {} bat species from ultrasonic recordings. Selected with",
+        entry.species_count
+    );
+    println!("  --bat {}; not selectable with -m.", entry.region);
+    println!();
+
+    println!("License:");
+    println!("  Type: {}", catalog.license.r#type);
+    println!("  URL: {}", catalog.license.url);
+    println!(
+        "  Commercial use: {}",
+        if catalog.license.commercial_use {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    println!(
+        "  Attribution required: {}",
+        if catalog.license.attribution_required {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
+    println!();
+
+    println!("Files:");
+    println!("  Classifier: {}", entry.model.url);
+    println!("  Labels: {}", entry.labels.url);
+    println!(
+        "  Shared backbone: {} ({})",
+        catalog.backbone.model.url,
+        crate::config::geomodel::human_size(combined_size(
+            catalog.backbone.model.size_bytes,
+            catalog.backbone.labels.size_bytes,
+        ))
+    );
+    println!(
+        "  Classifier download size: {}",
+        crate::config::geomodel::human_size(combined_size(
+            entry.model.size_bytes,
+            entry.labels.size_bytes,
+        ))
+    );
+    println!();
+
+    println!(
+        "To install: birda models install {BAT_INSTALL_PREFIX}{}",
+        entry.region
+    );
+    println!("Powered by BirdNET (https://birdnet.cornell.edu/)");
 }
 
 /// Show detailed information about a specific model.

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -18,6 +18,12 @@ pub struct Registry {
     /// Optional so a registry written by an older birda still deserializes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub range_filter: Option<RangeFilterAsset>,
+    /// Bat detection catalog: the shared embeddings backbone plus the regional
+    /// `BattyBirdNET` classifiers.
+    ///
+    /// Optional so a registry written by an older birda still deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bat: Option<BatCatalog>,
 }
 
 /// Shared range filter asset available to every classifier.
@@ -42,6 +48,87 @@ pub struct RangeFilterAsset {
     /// ONNX model file.
     pub model: FileInfo,
     /// Labels file, one `Scientific name_Common name` per line.
+    pub labels: FileInfo,
+}
+
+/// Bat detection catalog: a shared embeddings backbone plus the regional
+/// `BattyBirdNET` classifier heads.
+///
+/// Kept separate from [`Registry::models`] because bat classifiers are not
+/// standalone `-m` models: each one is a small head that runs on top of the
+/// backbone's embeddings, selected with `--bat <region>`. Hand-maintained in
+/// `registry.json` and preserved across `gen-registry` runs, exactly like
+/// [`RangeFilterAsset`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BatCatalog {
+    /// Shared `BirdNET` v2.4 embeddings backbone, installed once and reused by
+    /// every regional bat classifier.
+    pub backbone: BatBackbone,
+    /// Upstream `BattyBirdNET-Analyzer` version the heads were converted from.
+    pub version: String,
+    /// License shared by all regional classifier heads.
+    pub license: LicenseInfo,
+    /// Regional classifier heads.
+    pub regions: Vec<BatRegionEntry>,
+}
+
+impl BatCatalog {
+    /// The regional entry whose slug matches `region`, if any.
+    #[must_use]
+    pub fn region(&self, region: &str) -> Option<&BatRegionEntry> {
+        self.regions.iter().find(|r| r.region == region)
+    }
+
+    /// Comma-separated list of the region slugs, for error messages.
+    #[must_use]
+    pub fn available_regions(&self) -> String {
+        self.regions
+            .iter()
+            .map(|r| r.region.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// The shared `BirdNET` v2.4 embeddings backbone for bat detection.
+///
+/// This is a v2.4 model exported with its embedding layer exposed as a second
+/// output. Bat mode discards its species predictions and feeds the embeddings
+/// to a regional head, but the classifier still loads the v2.4 labels, so the
+/// backbone ships them as a companion file.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BatBackbone {
+    /// Stable identifier, e.g. `birdnet-v24-embeddings`.
+    pub id: String,
+    /// Display name. Always includes "`BirdNET`" for attribution.
+    pub name: String,
+    /// Upstream model version, e.g. "2.4".
+    pub version: String,
+    /// Organization/author.
+    pub vendor: String,
+    /// License information.
+    pub license: LicenseInfo,
+    /// ONNX model file (two outputs: predictions and embeddings).
+    pub model: FileInfo,
+    /// v2.4 labels file, required to construct the classifier.
+    pub labels: FileInfo,
+}
+
+/// A single regional `BattyBirdNET` classifier head.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BatRegionEntry {
+    /// Region slug matching the `--bat` value, e.g. `bavaria`, `usa-east-high`.
+    pub region: String,
+    /// Human-readable region name shown in listings.
+    pub name: String,
+    /// Number of bat species the head classifies.
+    pub species_count: usize,
+    /// ONNX classifier head file. Its filename matches
+    /// `BatRegion::model_filename()` so the installed file is found by
+    /// `BatConfig::resolve`.
+    pub model: FileInfo,
+    /// Labels file, one bat species per line. Its filename matches
+    /// `BatRegion::labels_filename()`.
     pub labels: FileInfo,
 }
 

--- a/tests/bat_models.rs
+++ b/tests/bat_models.rs
@@ -1,0 +1,272 @@
+//! Integration tests for bat model install and `--bat` resolution (#397).
+//!
+//! Two kinds of test here. The first parses the bundled `registry.json`
+//! directly and asserts the shipped bat catalog matches `BatRegion`'s
+//! filename derivation for every region: an install writes the registry
+//! filenames, and `BatConfig::resolve` later reads `BatRegion::model_filename`,
+//! so if the two ever diverge an install would look successful yet never be
+//! found. The rest drive the real binary, because the install-id dispatch and
+//! the `--bat` auto-resolution live in the CLI layer where a unit test would
+//! not reach them.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use birda::constants::CONFIG_DIR_ENV;
+use serde_json::Value;
+
+/// The exact registry the binary ships with, parsed without touching any
+/// user/config directory so the test is hermetic.
+const REGISTRY_JSON: &str = include_str!("../registry.json");
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[test]
+fn bundled_registry_bat_catalog_matches_batregion_naming() {
+    let registry: birda::registry::Registry =
+        serde_json::from_str(REGISTRY_JSON).expect("bundled registry.json parses");
+    let catalog = registry.bat.expect("bundled registry has a bat catalog");
+
+    assert_eq!(
+        catalog.backbone.model.filename, "birdnet-v24-embeddings.onnx",
+        "backbone local filename is the stable name --bat resolves"
+    );
+    assert!(catalog.backbone.model.sha256.is_some());
+    assert!(catalog.backbone.labels.sha256.is_some());
+    assert_eq!(
+        catalog.regions.len(),
+        11,
+        "all 11 BattyBirdNET regions ship"
+    );
+
+    for entry in &catalog.regions {
+        let region = birda::registry::parse_bat_install_id(&format!("bat-{}", entry.region))
+            .unwrap_or_else(|| panic!("region slug '{}' must parse to a BatRegion", entry.region));
+
+        // The install↔resolve invariant: filenames the installer writes must be
+        // exactly the ones BatConfig::resolve reads.
+        assert_eq!(
+            entry.model.filename,
+            region.model_filename(),
+            "model filename mismatch for region '{}'",
+            entry.region
+        );
+        assert_eq!(
+            entry.labels.filename,
+            region.labels_filename(),
+            "labels filename mismatch for region '{}'",
+            entry.region
+        );
+
+        assert!(
+            entry.model.sha256.is_some() && entry.labels.sha256.is_some(),
+            "region '{}' must carry checksums",
+            entry.region
+        );
+        assert!(
+            entry.model.size_bytes.is_some() && entry.labels.size_bytes.is_some(),
+            "region '{}' must carry sizes",
+            entry.region
+        );
+        assert!(
+            entry.species_count > 0,
+            "region '{}' has species",
+            entry.region
+        );
+    }
+
+    assert!(
+        !catalog.license.commercial_use,
+        "bat models are CC-BY-NC-SA (non-commercial)"
+    );
+}
+
+/// Run birda against an isolated HOME so the suite never touches the
+/// developer's real config or models directory.
+fn run(args: &[&str]) -> std::process::Output {
+    let home = tempfile::tempdir().expect("create temp home");
+    run_in(home.path(), args)
+}
+
+/// Run birda against a caller-supplied HOME, so a test can seed files under the
+/// models directory and then observe how a command reacts.
+fn run_in(home: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = cargo_bin_cmd!("birda");
+    cmd.env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("XDG_DATA_HOME", home.join("data"))
+        .env(CONFIG_DIR_ENV, home)
+        .env_remove("BIRDA_OUTPUT_MODE")
+        .timeout(COMMAND_TIMEOUT);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("birda should run")
+}
+
+fn stdout_of(args: &[&str]) -> String {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "`birda {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn list_available_lists_bat_regions() {
+    let out = stdout_of(&["models", "list-available"]);
+    assert!(out.contains("Bat classifiers"), "has a bat section:\n{out}");
+    assert!(out.contains("bat-eu"), "lists the EU install id:\n{out}");
+    assert!(
+        out.contains("bat-usa-east-high"),
+        "lists multi-hyphen ids:\n{out}"
+    );
+}
+
+#[test]
+fn list_available_json_exposes_bat_catalog() {
+    let out = stdout_of(&["models", "list-available", "--output-mode", "json"]);
+    let value: Value = serde_json::from_str(&out).expect("valid JSON");
+    // Structured results are wrapped in a `{event, payload, ...}` envelope.
+    let bat = &value["payload"]["available_bat"];
+    assert!(bat.is_object(), "available_bat present: {value}");
+    let regions = bat["regions"].as_array().expect("regions array");
+    assert_eq!(regions.len(), 11);
+    assert!(
+        bat["backbone_size_bytes"].as_u64().is_some(),
+        "backbone size reported once"
+    );
+    // Non-commercial license flows through, so a consumer can warn on it.
+    assert_eq!(bat["commercial_use"], serde_json::json!(false));
+
+    // Pin one region's projected fields against independently-known values, so a
+    // field-mapping bug (name/region swapped, species from the wrong source)
+    // cannot pass. EU: 30 species, id bat-eu.
+    let eu = regions
+        .iter()
+        .find(|r| r["id"] == "bat-eu")
+        .expect("bat-eu present");
+    assert_eq!(eu["region"], "eu");
+    assert_eq!(eu["name"], "BattyBirdNET EU");
+    assert_eq!(eu["species_count"], serde_json::json!(30));
+    assert!(eu["size_bytes"].as_u64().is_some_and(|n| n > 0));
+}
+
+#[test]
+fn info_bat_region_json_reports_bat_model_type() {
+    let out = stdout_of(&["models", "info", "bat-eu", "--output-mode", "json"]);
+    let value: Value = serde_json::from_str(&out).expect("valid JSON");
+    let model = &value["payload"]["model"];
+    assert_eq!(model["id"], "bat-eu");
+    assert_eq!(model["model_type"], "bat");
+}
+
+#[test]
+fn bat_analyze_custom_model_path_requires_labels_path() {
+    // A custom backbone via --model-path must bring its own labels; pairing it
+    // with the registry v2.4 labels would risk a label-count mismatch at load.
+    let output = run(&["--bat", "eu", "--model-path", "/tmp/custom.onnx", "rec.wav"]);
+    assert!(!output.status.success(), "must reject a lone --model-path");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--labels-path is required with --model-path"),
+        "actionable labels-required error:\n{stderr}"
+    );
+}
+
+#[test]
+fn models_check_lists_an_installed_bat_region() {
+    let home = tempfile::tempdir().expect("temp home");
+    // Seed the four files a bat region needs, with the exact registry filenames,
+    // so installed_bat_region_ids sees bat-eu as installed. Content is irrelevant
+    // (models check reports presence, not checksums).
+    let bat_dir = home.path().join("models").join("bat");
+    std::fs::create_dir_all(&bat_dir).expect("create bat dir");
+    for name in [
+        "birdnet-v24-embeddings.onnx",
+        "birdnet-v24-embeddings-labels.txt",
+        "BattyBirdNET-EU-256kHz_fp32.onnx",
+        "BattyBirdNET-EU-256kHz_Labels.txt",
+    ] {
+        std::fs::write(bat_dir.join(name), b"x").expect("seed file");
+    }
+
+    let output = run_in(home.path(), &["models", "check"]);
+    assert!(
+        output.status.success(),
+        "models check failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Bat classifiers: bat-eu installed"),
+        "check must list the installed region:\n{stdout}"
+    );
+}
+
+#[test]
+fn models_remove_deletes_an_installed_bat_region() {
+    let home = tempfile::tempdir().expect("temp home");
+    let bat_dir = home.path().join("models").join("bat");
+    std::fs::create_dir_all(&bat_dir).expect("create bat dir");
+    let files = [
+        "birdnet-v24-embeddings.onnx",
+        "birdnet-v24-embeddings-labels.txt",
+        "BattyBirdNET-EU-256kHz_fp32.onnx",
+        "BattyBirdNET-EU-256kHz_Labels.txt",
+    ];
+    for name in files {
+        std::fs::write(bat_dir.join(name), b"x").expect("seed file");
+    }
+
+    let output = run_in(home.path(), &["models", "remove", "bat-eu", "--yes"]);
+    assert!(
+        output.status.success(),
+        "remove failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // EU was the only region, so its head and the now-unneeded shared backbone
+    // are both gone.
+    for name in files {
+        assert!(
+            !bat_dir.join(name).exists(),
+            "{name} should have been removed"
+        );
+    }
+}
+
+#[test]
+fn info_reports_a_bat_region() {
+    let out = stdout_of(&["models", "info", "bat-eu"]);
+    assert!(out.contains("BattyBirdNET EU"), "names the region:\n{out}");
+    assert!(out.contains("--bat eu"), "shows how to run it:\n{out}");
+}
+
+#[test]
+fn install_rejects_an_unknown_bat_region_with_the_valid_list() {
+    let output = run(&["models", "install", "bat-atlantis", "--yes"]);
+    assert!(!output.status.success(), "unknown region must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("bat region 'atlantis'") && stderr.contains("bavaria"),
+        "names the bad region and lists valid ones:\n{stderr}"
+    );
+}
+
+#[test]
+fn bat_analyze_without_backbone_fails_fast_with_install_hint() {
+    // No install has run, so the backbone is absent. Resolution must fail before
+    // any file work with an actionable message, not the cryptic per-segment
+    // error from deep in the pipeline.
+    let output = run(&["--bat", "eu", "/nonexistent/recording.wav"]);
+    assert!(!output.status.success(), "must fail without a backbone");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("embeddings backbone") && stderr.contains("models install bat-"),
+        "actionable backbone-not-installed error:\n{stderr}"
+    );
+}

--- a/tests/bat_models.rs
+++ b/tests/bat_models.rs
@@ -98,6 +98,12 @@ fn run_in(home: &std::path::Path, args: &[&str]) -> std::process::Output {
         .env("XDG_DATA_HOME", home.join("data"))
         .env(CONFIG_DIR_ENV, home)
         .env_remove("BIRDA_OUTPUT_MODE")
+        // Point the runtime at a missing library so the analyze fail-fast tests
+        // are environment-independent: bat validation must surface its own error
+        // BEFORE the runtime is touched, on a machine with ORT installed as well
+        // as without. None of these tests build a classifier, so a missing
+        // runtime never breaks one that should pass; it only guards the ordering.
+        .env("ORT_DYLIB_PATH", "/definitely/missing/onnxruntime")
         .timeout(COMMAND_TIMEOUT);
     for arg in args {
         cmd.arg(arg);
@@ -175,6 +181,43 @@ fn bat_analyze_custom_model_path_requires_labels_path() {
     assert!(
         stderr.contains("--labels-path is required with --model-path"),
         "actionable labels-required error:\n{stderr}"
+    );
+}
+
+#[test]
+fn bat_analyze_custom_labels_path_requires_model_path() {
+    // The mirror of the previous test: overriding only the labels would pair
+    // custom labels with the registry backbone and risk a label-count mismatch.
+    let output = run(&["--bat", "eu", "--labels-path", "/tmp/custom.txt", "rec.wav"]);
+    assert!(!output.status.success(), "must reject a lone --labels-path");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--model-path is required with --labels-path"),
+        "actionable model-path-required error:\n{stderr}"
+    );
+}
+
+#[test]
+fn bat_analyze_uninstalled_region_fails_fast_even_without_runtime() {
+    // Backbone present but the requested region head absent: the region-not-installed
+    // error must surface before the runtime is needed, so it is actionable even on
+    // a machine without libonnxruntime.so (the CI --no-default-features job).
+    let home = tempfile::tempdir().expect("temp home");
+    let bat_dir = home.path().join("models").join("bat");
+    std::fs::create_dir_all(&bat_dir).expect("create bat dir");
+    for name in [
+        "birdnet-v24-embeddings.onnx",
+        "birdnet-v24-embeddings-labels.txt",
+    ] {
+        std::fs::write(bat_dir.join(name), b"x").expect("seed backbone");
+    }
+
+    let output = run_in(home.path(), &["--bat", "uk", "recording.wav"]);
+    assert!(!output.status.success(), "uninstalled region must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("bat region 'uk' is not installed"),
+        "actionable region-not-installed error:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Bat detection was implemented but effectively unusable: it needed a hand-built BirdNET v2.4 embeddings backbone (the README pointed at an `expose_embeddings.py` script that does not exist), the backbone had to be registered manually so `-m birdnet-v24-embeddings` would resolve, and a wrong backbone failed deep in inference with a cryptic "bat mode requires embeddings from backbone, but got 0 of N segments". This makes the whole flow automatic.

`birda models install bat-<region>` now downloads the regional classifier and, on the first bat install, the shared v2.4 embeddings backbone it runs on, both checksum-verified. `birda --bat <region> file.wav` then resolves that backbone automatically, so bat detection works with no manual download, no ONNX conversion, and no `-m`.

Details:

- Registry gains a hand-maintained `bat` catalog block (the shared backbone plus 11 BattyBirdNET regions with real SHA256s and sizes), preserved across `gen-registry` runs exactly like the geomodel `range_filter` block; `registry_version` bumped to 8 so cached installs pick it up. The backbone uses the DFT-truncated fp32 export so it loads on OpenVINO as well as CPU and CUDA.
- Installer adds `install_bat` / `install_bat_backbone`, reusing the existing atomic checksum-verified download path. Every file is downloaded through a per-file idempotency helper, so a repeat or partial install re-fetches only what is missing or corrupt (a missing tiny labels file never forces a fresh ~56 MB backbone download), and the backbone installs once and is reused across regions.
- Analyze: `--bat` with no `-m` resolves the installed backbone, and fails fast with an actionable message when the backbone is missing or exposes no embeddings output, instead of the old per-segment failure. A custom backbone via `--model-path` must also pass `--labels-path`, since the label count is model-specific.
- CLI: `models install bat-<region>`, `models remove bat-<region>`, and bat entries in `models list-available`, `models info`, and `models check` (human and JSON).
- README: replaces the dead `expose_embeddings.py` instructions with the install-and-run flow, and notes the CC-BY-NC-SA (non-commercial) license and required BirdNET attribution.

## Related Issues

Fixes #397

## Test Plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (default, cuda, gen-registry, no-default-features) all green
- [x] New `tests/bat_models.rs` locks the install-to-resolve filename invariant for all 11 regions and drives the CLI (list-available/info/check/install/remove, fail-fast)
- [ ] Live install and 256 kHz analysis on a real bat recording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added regional bat detection models for Bavaria, Europe, Scotland, South Wales, Sweden, the UK, and the USA.
  - Bat models can be installed, inspected, checked, and removed by region.
  - Automatically installs and reuses the shared BirdNET v2.4 embeddings model.
  - Added checksum verification, recovery for incomplete installations, and clear setup errors.
  - Model listings and JSON output now include bat regions, licensing, download sizes, and installed status.
- **Documentation**
  - Updated usage instructions, installation steps, licensing details, and regional model requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->